### PR TITLE
Style the workspace strip the way Omarchy's waybar does

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,23 +33,27 @@ at `~/.config/toe/toe.toml`.
 
 ## The menu bar
 
-The status item is the workspace strip, in the style of waybar: occupied workspaces only, with
-the focused one picked out in bold. Workspaces showing on another display are bold but dimmed,
-and an empty workspace appears only while you are on it.
+The status item is the workspace strip, styled the way Omarchy's waybar styles it: the
+workspace you are on is a filled rounded square rather than a number, every other occupied
+workspace is its own digit, and workspace 10 shows as `0`. An empty workspace appears only
+while you are on it, dimmed. With several displays, a workspace showing on one you are not
+focused on gets the same square, outlined.
 
 ```
-1 3 7
+▪ 3 7
 ```
 
-Opening it breaks each workspace down into the applications living there:
+Clicking a workspace switches to it, as Omarchy's `on-click: activate` does. Right-click —
+or left-click the padding at either end — to open the menu, which breaks each workspace down
+into the applications living there:
 
 ```
-Workspace 1  ✓
-    Ghostty  ×2
-    Safari  ×2
-Workspace 4
-    Google Chrome
-────────────────
+▪ Workspace 1
+      Ghostty  ×2
+      Safari  ×2
+  Workspace 4
+      Google Chrome
+────────────────────
 Config loaded
 ```
 

--- a/Sources/ToeCore/WorkspaceStrip.swift
+++ b/Sources/ToeCore/WorkspaceStrip.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// The menu bar's workspace strip, in Omarchy's waybar styling.
+///
+/// Omarchy's `hyprland/workspaces` module maps the focused workspace to a filled rounded
+/// square (`nf-md-square_rounded`) and every other one to its own digit, with workspace 10
+/// labelled `0` and empty workspaces at half opacity. This is the part of that with no
+/// AppKit in it: which workspaces earn a slot, what each one is labelled, and how a click
+/// lands on one. `StatusItem` draws the result.
+public enum WorkspaceStrip {
+
+    /// What the strip needs to know about one workspace.
+    public struct State: Equatable {
+        public let index: Int
+        /// Showing on the monitor that currently has focus.
+        public let isFocused: Bool
+        /// Showing on some monitor — with several displays, more than one is visible.
+        public let isVisible: Bool
+        public let isEmpty: Bool
+
+        public init(index: Int, isFocused: Bool, isVisible: Bool, isEmpty: Bool) {
+            self.index = index
+            self.isFocused = isFocused
+            self.isVisible = isVisible
+            self.isEmpty = isEmpty
+        }
+    }
+
+    /// How a workspace is drawn. Omarchy separates only the focused one from the rest;
+    /// `visible` is toe's addition, because Hyprland's bar leaves the second display
+    /// unstyled and toe would rather not lose the signal.
+    public enum Marker: Equatable {
+        /// A filled rounded square, replacing the digit.
+        case focused
+        /// The same square, outlined.
+        case visible
+        /// The workspace's own digit.
+        case digit
+    }
+
+    public struct Item: Equatable {
+        public let index: Int
+        /// What Omarchy labels the workspace: its digit, and `0` for workspace 10.
+        public let label: String
+        public let marker: Marker
+        /// Omarchy's `#workspaces button.empty { opacity: 0.5 }`.
+        public let dim: Bool
+    }
+
+    /// A workspace earns a slot by having windows on it, or by being on screen right now —
+    /// so the strip stays as short as what you are actually using.
+    public static func items(for states: [State]) -> [Item] {
+        states.filter { !$0.isEmpty || $0.isVisible }.map { state in
+            Item(index: state.index,
+                 label: state.index == 10 ? "0" : "\(state.index)",
+                 marker: state.isFocused ? .focused : (state.isVisible ? .visible : .digit),
+                 dim: state.isEmpty)
+        }
+    }
+
+    /// Which item a click at `x` landed on, as a position in `widths`.
+    ///
+    /// The strip is centred in `buttonWidth`, its items `gap` apart. Zones reach to the
+    /// midpoint between neighbours so the gaps are not dead, but a click beyond either end
+    /// of the strip returns nil — that is the padding, and it opens the menu instead.
+    public static func hit(x: Double, widths: [Double], gap: Double, buttonWidth: Double) -> Int? {
+        guard !widths.isEmpty else { return nil }
+
+        let total = widths.reduce(0, +) + gap * Double(widths.count - 1)
+        let origin = (buttonWidth - total) / 2
+
+        var starts: [Double] = []
+        var cursor = origin
+        for width in widths {
+            starts.append(cursor)
+            cursor += width + gap
+        }
+        let ends = zip(starts, widths).map(+)
+
+        guard x >= starts[0], x <= ends[ends.count - 1] else { return nil }
+
+        for i in widths.indices {
+            let left = i == 0 ? starts[0] : (ends[i - 1] + starts[i]) / 2
+            let right = i == widths.count - 1 ? ends[i] : (ends[i] + starts[i + 1]) / 2
+            if x >= left, x <= right { return i }
+        }
+        return nil
+    }
+}

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -413,4 +413,57 @@ h.test("a workspace knows which monitor is showing it") { t in
     t.equal(wm.visibleWorkspaceIndices.count, 2, "one visible workspace per monitor")
 }
 
+h.test("the strip shows occupied and visible workspaces") { t in
+    let items = WorkspaceStrip.items(for: [
+        WorkspaceStrip.State(index: 1, isFocused: true, isVisible: true, isEmpty: false),
+        WorkspaceStrip.State(index: 3, isFocused: false, isVisible: false, isEmpty: true),
+        WorkspaceStrip.State(index: 7, isFocused: false, isVisible: false, isEmpty: false),
+    ])
+    t.equal(items.map(\.index), [1, 7], "an empty off-screen workspace gets no slot")
+    t.equal(items.map(\.dim), [false, false], "occupied workspaces are full contrast")
+
+    // The one you are on is always there, even with nothing on it — dimmed, the way waybar's
+    // `#workspaces button.empty { opacity: 0.5 }` dims it.
+    let onEmpty = WorkspaceStrip.items(for: [
+        WorkspaceStrip.State(index: 5, isFocused: true, isVisible: true, isEmpty: true)])
+    t.equal(onEmpty.map(\.index), [5], "the focused workspace keeps its slot when empty")
+    t.equal(onEmpty.map(\.dim), [true], "and is dimmed")
+    t.equal(WorkspaceStrip.items(for: []).isEmpty, true, "nothing in, nothing out")
+}
+
+h.test("workspace ten is labelled zero") { t in
+    let items = WorkspaceStrip.items(for: (1...10).map {
+        WorkspaceStrip.State(index: $0, isFocused: false, isVisible: false, isEmpty: false) })
+    t.equal(items.map(\.label), ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"],
+            "workspace 10 shows as 0, as Omarchy's format-icons do")
+}
+
+h.test("markers follow focus and visibility") { t in
+    let items = WorkspaceStrip.items(for: [
+        WorkspaceStrip.State(index: 1, isFocused: true, isVisible: true, isEmpty: false),
+        WorkspaceStrip.State(index: 2, isFocused: false, isVisible: true, isEmpty: false),
+        WorkspaceStrip.State(index: 4, isFocused: false, isVisible: false, isEmpty: false),
+    ])
+    t.equal(items.map(\.marker), [.focused, .visible, .digit],
+            "a filled square where you are, outlined on another display, a digit off-screen")
+}
+
+h.test("clicking the strip picks the workspace under the pointer") { t in
+    // Three 8pt items, 7pt apart, centred in a 60pt button: they start at 11, 26 and 41.
+    func hit(_ x: Double) -> Int? {
+        WorkspaceStrip.hit(x: x, widths: [8, 8, 8], gap: 7, buttonWidth: 60)
+    }
+    t.equal(hit(15), .some(0), "on the first item")
+    t.equal(hit(30), .some(1), "on the middle item")
+    t.equal(hit(45), .some(2), "on the last item")
+
+    // The gaps are not dead: they belong to whichever neighbour is nearer.
+    t.equal(hit(21), .some(0), "just past the first item")
+    t.equal(hit(24), .some(1), "just before the second")
+
+    t.equal(hit(5), nil, "the padding before the strip opens the menu instead")
+    t.equal(hit(55), nil, "and so does the padding after it")
+    t.equal(WorkspaceStrip.hit(x: 30, widths: [], gap: 7, buttonWidth: 60), nil, "no items, no hit")
+}
+
 exit(h.report())

--- a/Sources/toe/UI/StatusItem.swift
+++ b/Sources/toe/UI/StatusItem.swift
@@ -20,12 +20,18 @@ struct WorkspaceSummary {
     let apps: [AppSummary]
 
     var isEmpty: Bool { apps.isEmpty }
+
+    var stripState: WorkspaceStrip.State {
+        .init(index: index, isFocused: isFocused, isVisible: isVisible, isEmpty: isEmpty)
+    }
 }
 
 /// The menu bar item. toe is an `LSUIElement`, so this is its only visible surface.
 ///
-/// The title is the workspace strip — occupied workspaces, with the focused one picked out —
-/// and the menu breaks each workspace down into the applications living on it.
+/// The title is the workspace strip in Omarchy's waybar styling — the focused workspace is
+/// a filled rounded square, every other one its own digit — and the menu breaks each
+/// workspace down into the applications living on it. Clicking a workspace switches to it,
+/// as Omarchy's `on-click: activate` does; anywhere else opens the menu.
 final class StatusItem: NSObject, NSMenuDelegate {
 
     private let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -45,14 +51,25 @@ final class StatusItem: NSObject, NSMenuDelegate {
     private var accessibilityGranted = false
     private var showMonitorNames = false
 
-    private let regular = NSFont.monospacedDigitSystemFont(ofSize: 13, weight: .regular)
-    private let emphasised = NSFont.monospacedDigitSystemFont(ofSize: 13, weight: .bold)
+    /// What the strip currently draws, and how wide each item came out — together they turn
+    /// a click position back into a workspace.
+    private var stripItems: [WorkspaceStrip.Item] = []
+    private var stripWidths: [Double] = []
+
+    // Omarchy's bar is JetBrainsMono Nerd Font at 12px with `padding: 0 6px; margin: 0 1.5px`,
+    // i.e. a ~15px slot per workspace. These are its equivalents at menu bar size.
+    private let font = NSFont.monospacedDigitSystemFont(ofSize: 13, weight: .regular)
+    private let gap: CGFloat = 7
+    private let markerSide: CGFloat = 8
+    private let markerRadius: CGFloat = 2.5
 
     override init() {
         super.init()
         menu.delegate = self
-        item.menu = menu
         item.button?.title = "toe"
+        item.button?.target = self
+        item.button?.action = #selector(buttonClicked(_:))
+        item.button?.sendAction(on: [.leftMouseUp, .rightMouseUp])
     }
 
     /// Cheap: only the title strip is recomputed. The menu rebuilds itself when opened.
@@ -62,44 +79,125 @@ final class StatusItem: NSObject, NSMenuDelegate {
         self.accessibilityGranted = accessibilityGranted
         self.showMonitorNames = showMonitorNames
         item.button?.attributedTitle = title(for: workspaces)
-        item.button?.toolTip = accessibilityGranted
+
+        // The focused workspace is drawn as a square rather than a digit, so the title on
+        // its own no longer reads as anything — spell it out for VoiceOver.
+        let described = accessibilityGranted
             ? "toe — workspace \(workspaces.first { $0.isFocused }?.index ?? 1)"
             : "toe needs Accessibility permission"
+        item.button?.toolTip = described
+        item.button?.setAccessibilityLabel(described)
     }
 
     // MARK: - The workspace strip
 
     private func title(for workspaces: [WorkspaceSummary]) -> NSAttributedString {
+        stripItems = []
+        stripWidths = []
+
         guard accessibilityGranted else {
             return NSAttributedString(string: "toe !", attributes: [
-                .font: emphasised, .foregroundColor: NSColor.systemOrange,
+                .font: font, .foregroundColor: NSColor.systemOrange,
             ])
         }
 
-        // Empty workspaces are hidden, so the strip stays as short as what you are actually
-        // using — but the focused one is always there, even when it is empty.
-        let shown = workspaces.filter { !$0.isEmpty || $0.isVisible }
-        guard !shown.isEmpty else {
-            return NSAttributedString(string: "toe", attributes: [.font: regular])
+        let items = WorkspaceStrip.items(for: workspaces.map(\.stripState))
+        guard !items.isEmpty else {
+            return NSAttributedString(string: "toe", attributes: [.font: font])
         }
 
         let strip = NSMutableAttributedString()
-        for workspace in shown {
-            if strip.length > 0 {
-                strip.append(NSAttributedString(string: " ", attributes: [.font: regular]))
-            }
-            let attributes: [NSAttributedString.Key: Any]
-            if workspace.isFocused {
-                attributes = [.font: emphasised, .foregroundColor: NSColor.labelColor]
-            } else if workspace.isVisible {
-                // Showing on another display.
-                attributes = [.font: emphasised, .foregroundColor: NSColor.secondaryLabelColor]
-            } else {
-                attributes = [.font: regular, .foregroundColor: NSColor.tertiaryLabelColor]
-            }
-            strip.append(NSAttributedString(string: "\(workspace.index)", attributes: attributes))
+        for item in items {
+            if strip.length > 0 { strip.append(spacer) }
+            strip.append(piece(for: item))
+            stripItems.append(item)
+            stripWidths.append(Double(width(of: item)))
         }
         return strip
+    }
+
+    /// A fixed `gap` of empty space, kerned rather than padded so its width is exactly known.
+    private var spacer: NSAttributedString {
+        let space = NSAttributedString(string: " ", attributes: [.font: font]).size().width
+        return NSAttributedString(string: " ", attributes: [.font: font, .kern: gap - space])
+    }
+
+    private func piece(for item: WorkspaceStrip.Item) -> NSAttributedString {
+        switch item.marker {
+        case .digit:
+            return NSAttributedString(string: item.label, attributes: [
+                .font: font,
+                .foregroundColor: item.dim ? NSColor.secondaryLabelColor : NSColor.labelColor,
+            ])
+        case .focused, .visible:
+            let attachment = NSTextAttachment()
+            attachment.image = marker(filled: item.marker == .focused, dim: item.dim,
+                                      side: markerSide)
+            // Centre the square on the digits' cap height rather than the baseline.
+            attachment.bounds = NSRect(x: 0, y: (font.capHeight - markerSide) / 2,
+                                       width: markerSide, height: markerSide)
+            return NSAttributedString(attachment: attachment)
+        }
+    }
+
+    private func width(of item: WorkspaceStrip.Item) -> CGFloat {
+        item.marker == .digit
+            ? NSAttributedString(string: item.label, attributes: [.font: font]).size().width
+            : markerSide
+    }
+
+    /// `nf-md-square_rounded`, which is what Omarchy marks the active workspace with — drawn
+    /// rather than set, so it needs no Nerd Font installed. The drawing handler runs at draw
+    /// time, so the colour resolves against whichever appearance the menu bar is in.
+    private func marker(filled: Bool, dim: Bool, side: CGFloat,
+                        canvas: CGFloat? = nil) -> NSImage {
+        let box = canvas ?? side
+        let radius = markerRadius * (side / markerSide)
+        let image = NSImage(size: NSSize(width: box, height: box), flipped: false) { rect in
+            let colour = dim ? NSColor.secondaryLabelColor : NSColor.labelColor
+            let square = NSRect(x: (rect.width - side) / 2, y: (rect.height - side) / 2,
+                                width: side, height: side)
+            if filled {
+                colour.setFill()
+                NSBezierPath(roundedRect: square, xRadius: radius, yRadius: radius).fill()
+            } else {
+                colour.setStroke()
+                let path = NSBezierPath(roundedRect: square.insetBy(dx: 0.75, dy: 0.75),
+                                        xRadius: radius - 0.75, yRadius: radius - 0.75)
+                path.lineWidth = 1.5
+                path.stroke()
+            }
+            return true
+        }
+        // Redraw on every use, so a light/dark switch cannot leave a stale square behind.
+        image.cacheMode = .never
+        return image
+    }
+
+    // MARK: - Clicks
+
+    /// The menu is attached only while it is up, so the rest of the time this action runs and
+    /// the strip stays clickable.
+    @objc private func buttonClicked(_ sender: NSStatusBarButton) {
+        guard let event = NSApp.currentEvent,
+              event.type == .leftMouseUp,
+              !event.modifierFlags.contains(.control)
+        else { return popUpMenu() }
+
+        let x = sender.convert(event.locationInWindow, from: nil).x
+        if let hit = WorkspaceStrip.hit(x: Double(x), widths: stripWidths,
+                                        gap: Double(gap), buttonWidth: Double(sender.bounds.width)) {
+            onSelectWorkspace?(stripItems[hit].index)
+        } else {
+            // The padding at either end, or a strip with no workspaces in it.
+            popUpMenu()
+        }
+    }
+
+    private func popUpMenu() {
+        item.menu = menu                 // menuNeedsUpdate fires here
+        item.button?.performClick(nil)   // blocks until the menu closes
+        item.menu = nil
     }
 
     // MARK: - The menu
@@ -122,7 +220,11 @@ final class StatusItem: NSObject, NSMenuDelegate {
                                      action: #selector(selectWorkspace(_:)), keyEquivalent: "")
             heading.target = self
             heading.tag = workspace.index
-            heading.state = workspace.isFocused ? .on : (workspace.isVisible ? .mixed : .off)
+            // The same square the strip uses, so the two surfaces read as one thing.
+            if workspace.isVisible {
+                heading.image = marker(filled: workspace.isFocused, dim: workspace.isEmpty,
+                                       side: 9, canvas: 12)
+            }
             heading.attributedTitle = NSAttributedString(
                 string: headingTitle(workspace),
                 attributes: [.font: NSFont.menuFont(ofSize: 13).bold])


### PR DESCRIPTION
The menu bar strip was bare digits separated by spaces, with the only differentiation being font weight and three levels of grey. The README called it "in the style of waybar"; it was not.

## What Omarchy actually renders

From `basecamp/omarchy` → `config/waybar/config.jsonc`:

```jsonc
"hyprland/workspaces": {
  "on-click": "activate",
  "format": "{icon}",
  "format-icons": {
    "default": "",     // nf-cod-circle_filled
    "1": "1", … "9": "9", "10": "0",
    "active": "\U000f14fb"   // nf-md-square_rounded
  }
}
```

plus `#workspaces button.empty { opacity: 0.5 }` in `style.css`, and **no** `.active` colour rule in any theme — themes define only `@foreground` / `@background`.

Resolved against Waybar's own icon lookup order (urgent → active → special → **named** → visible → empty → persistent → default, `src/modules/hyprland/workspace.cpp:299`):

| | Omarchy | toe before |
|---|---|---|
| Active workspace | filled rounded square, **replacing** the digit | digit, bold |
| Occupied, inactive | digit, full foreground | digit, `tertiaryLabelColor` |
| Empty | digit at 50% opacity | hidden |
| Workspace 10 | `0` | `10` |
| Click | activates that workspace | opened the dropdown |

The defining trait — the active workspace being a shape rather than a number — was missing entirely.

## Changes

- **`Sources/ToeCore/WorkspaceStrip.swift`** (new) — the AppKit-free half: which workspaces earn a slot, each one's label, its marker, whether it is dimmed, and the click hit-test math. In ToeCore because the selftest harness cannot touch AppKit.
- **`Sources/toe/UI/StatusItem.swift`** — the strip is now a rounded square for the focused workspace and digits for the rest, 7pt apart (kerned, so the widths are exact for hit testing). The square is drawn with `NSBezierPath(roundedRect:)` inside an `NSImage` drawing handler, so it needs no Nerd Font installed and resolves its colour against whichever appearance the menu bar is in; `cacheMode = .never` keeps a light/dark switch from leaving a stale square behind.
- **Click to activate** — `item.menu` is no longer attached at rest, so the button's own action runs. Left-click on a workspace switches to it; right-click, control-click, or a left-click on the padding at either end opens the menu. Menu headings carry the same square and drop the now-redundant checkmark.
- `setAccessibilityLabel` on the button — the title is a glyph now, so VoiceOver had nothing to read.
- **`Sources/toe-selftest/main.swift`** — four cases: the slot filter, `0` for workspace 10, marker selection, and hit testing including gap midpoints and padding returning nil.
- **`README.md`** — the "The menu bar" section documented the old look.

## One deliberate deviation

Omarchy leaves the `visible` state unstyled — its config has no `"visible"` icon, so a workspace showing on another display falls through to its plain digit. Dropping toe's signal for it would regress multi-monitor use, so it gets the same square, outlined. Nothing renders that way on a single display, so the single-monitor strip is exactly Omarchy. To drop it, return `.digit` for `.visible` in `WorkspaceStrip.items(for:)`; nothing else changes.

## Verification

- `make test` — 128 assertions pass.
- `make run`, then driven through the Accessibility API: the status item measures 8pt-square-plus-insets on a single occupied workspace, and opening it rebuilds correctly — `Workspace 1, Ghostty ×4, Safari, —, Config loaded, —, Reload config, Open config…, —, Quit toe`.
- **Not verified from the terminal:** the left-click-to-switch path needs a real mouse event at the status item (an AX press deliberately falls through to the menu), and no screenshot was possible without Screen Recording permission. Worth a manual click with windows on a few workspaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tz7v7dP3gWCQ6d587n7fRm
