### PR TITLE
Match Hyprland's dwindle in the paths around the focused-window split

### DIFF
--- a/Sources/ToeCore/Geometry.swift
+++ b/Sources/ToeCore/Geometry.swift
@@ -42,6 +42,13 @@ public struct Box: Equatable, Hashable, Sendable {
         p.x >= x && p.x < maxX && p.y >= y && p.y < maxY
     }
 
+    /// Hyprland's `vecToRectDistanceSquared` — zero when the point is inside the box.
+    public func distanceSquared(to p: Point) -> Double {
+        let dx = max(0.0, minX - p.x, p.x - maxX)
+        let dy = max(0.0, minY - p.y, p.y - maxY)
+        return dx * dx + dy * dy
+    }
+
     /// Shrink by per-edge insets. Used to apply gaps.
     public func inset(top: Double, left: Double, bottom: Double, right: Double) -> Box {
         Box(x: x + left, y: y + top, w: w - left - right, h: h - top - bottom).noNegativeSize()

--- a/Sources/ToeCore/Layout/DwindleLayout.swift
+++ b/Sources/ToeCore/Layout/DwindleLayout.swift
@@ -23,6 +23,9 @@ public final class DwindleLayout {
 
     public private(set) var root: DwindleNode?
     private var nodes: [WindowID: DwindleNode] = [:]
+    /// Creation order, so the insertion fail-safe can pick the oldest window the way
+    /// Hyprland's `getFirstNodeOnWorkspace` scans `m_dwindleNodesData` in list order.
+    private var order: [WindowID] = []
 
     public init(area: Box, options: DwindleOptions = DwindleOptions()) {
         self.area = area
@@ -41,6 +44,12 @@ public final class DwindleLayout {
     /// The leaf whose box contains `point`.
     public func node(at point: Point) -> DwindleNode? {
         root?.leaves().first { $0.box.contains(point) }
+    }
+
+    /// Port of `getClosestNodeOnWorkspace`: the leaf nearest `point`, used when the pointer
+    /// is on the monitor but outside the tiling area (Hyprland's reserved strip).
+    public func closestNode(to point: Point) -> DwindleNode? {
+        root?.leaves().min { $0.box.distanceSquared(to: point) < $1.box.distanceSquared(to: point) }
     }
 
     // MARK: - Insertion
@@ -64,15 +73,21 @@ public final class DwindleLayout {
 
         let node = DwindleNode(window: id)
         nodes[id] = node
+        order.append(id)
 
-        // Resolve what we are splitting. Fall back to any leaf, as Hyprland's fail-safe does.
+        // Resolve what we are splitting, in Hyprland's order: the focused window, else the
+        // leaf under the pointer, else — when the pointer is off the tiling area, its
+        // `isPointOnReservedArea` case — the closest leaf, else the fail-safe oldest leaf.
         var openingOn: DwindleNode?
         if let anchor, let anchorNode = nodes[anchor], anchorNode !== node {
             openingOn = anchorNode
         } else if let focalPoint, let hit = self.node(at: focalPoint), hit !== node {
             openingOn = hit
+        } else if let focalPoint, !area.contains(focalPoint),
+                  let near = closestNode(to: focalPoint), near !== node {
+            openingOn = near
         } else {
-            openingOn = root?.leaves().first { $0 !== node }
+            openingOn = order.first { $0 != id }.flatMap { nodes[$0] }
         }
 
         // First window on the workspace: it takes the whole usable area.
@@ -92,8 +107,9 @@ public final class DwindleLayout {
 
         // Child ordering.
         if options.forceSplit == 0 || !isFirstMap {
-            // Hyprland consults the pointer here. macOS has no cursor-follows-focus, so a
-            // focal point is only present for `movewindow`; otherwise behave as force_split = 2.
+            // Hyprland consults the pointer here, and so do we: the focal point is the
+            // cursor on a fresh map, or the edge probe `movewindow` computes. With no point
+            // at all — a headless insert — behave as force_split = 2.
             let firstHalf: Bool
             if let fp = focalPoint {
                 firstHalf = sideBySide
@@ -138,6 +154,7 @@ public final class DwindleLayout {
     /// Port of `onWindowRemovedTiling`: the sibling absorbs the parent's box and slot.
     public func remove(_ id: WindowID) {
         guard let node = nodes.removeValue(forKey: id) else { return }
+        order.removeAll { $0 == id }
 
         guard let parent = node.parent else {
             // Last window on the workspace.
@@ -183,7 +200,39 @@ public final class DwindleLayout {
         nb.window = a
         nodes[a] = nb
         nodes[b] = na
+        swapOrder(a, b)
         recalculate()
+    }
+
+    /// `switchWindows` across two trees. Hyprland swaps the node payloads and then the
+    /// windows' monitor/workspace pointers — it never re-inserts, so both shapes survive.
+    public static func swap(_ a: WindowID, in la: DwindleLayout, with b: WindowID, in lb: DwindleLayout) {
+        guard a != b else { return }
+        if la === lb {
+            la.swap(a, b)
+            return
+        }
+        guard let na = la.nodes[a], let nb = lb.nodes[b] else { return }
+
+        na.window = b
+        nb.window = a
+
+        la.nodes[a] = nil
+        la.nodes[b] = na
+        lb.nodes[b] = nil
+        lb.nodes[a] = nb
+
+        // The nodes keep their creation order; only the window each one carries moves.
+        if let ia = la.order.firstIndex(of: a) { la.order[ia] = b }
+        if let ib = lb.order.firstIndex(of: b) { lb.order[ib] = a }
+
+        la.recalculate()
+        lb.recalculate()
+    }
+
+    private func swapOrder(_ a: WindowID, _ b: WindowID) {
+        guard let ia = order.firstIndex(of: a), let ib = order.firstIndex(of: b) else { return }
+        order.swapAt(ia, ib)
     }
 
     /// Port of `moveWindowTo` — the `movewindow` dispatcher. Removes the window and

--- a/Sources/ToeCore/Layout/WorkspaceManager.swift
+++ b/Sources/ToeCore/Layout/WorkspaceManager.swift
@@ -54,6 +54,10 @@ public final class WorkspaceManager {
     /// Frames of floating windows, supplied by the app layer so directional search has an
     /// origin box for them.
     public var floatingFrames: [WindowID: Box] = [:]
+    /// The pointer, in AX coordinates, supplied by the app layer so ToeCore stays free of
+    /// AppKit. Hyprland splits the window under the cursor when there is no focused tiled
+    /// window to split — see `onWindowCreatedTiling`'s `use_active_for_splits` branch.
+    public var cursorLocation: (() -> Point?)?
 
     public var options: DwindleOptions {
         didSet { workspaces.values.forEach { $0.layout.options = options; $0.layout.recalculate() } }
@@ -141,6 +145,23 @@ public final class WorkspaceManager {
 
     // MARK: - Window lifecycle
 
+    /// Hyprland looks at exactly one window — `m_lastWindow` — and falls to the pointer when
+    /// it is floating, unmapped or on another workspace. `focusHistory.first` is that window.
+    private func anchor(on ws: Workspace, excluding id: WindowID? = nil) -> WindowID? {
+        guard let last = focusHistory.first, last != id, ws.layout.contains(last) else { return nil }
+        return last
+    }
+
+    /// The pointer, but only while it is on the workspace's own monitor — Hyprland's
+    /// `vectorToWindowUnified` / `isPointOnReservedArea` are both scoped to that monitor.
+    private func focalPoint(on ws: Workspace) -> Point? {
+        guard let point = cursorLocation?(),
+              let monitor = monitor(id: ws.monitorID),
+              monitor.frame.contains(point)
+        else { return nil }
+        return point
+    }
+
     /// Add a window to the active workspace of the focused monitor, splitting the focused
     /// window (Hyprland's `use_active_for_splits`, which Omarchy leaves at its default).
     public func addWindow(_ id: WindowID, floating: Bool = false, toWorkspace index: Int? = nil) {
@@ -151,8 +172,7 @@ public final class WorkspaceManager {
         if floating {
             ws.floating.insert(id)
         } else {
-            let anchor = focusHistory.first { ws.layout.contains($0) }
-            ws.layout.insert(id, anchor: anchor)
+            ws.layout.insert(id, anchor: anchor(on: ws, excluding: id), focalPoint: focalPoint(on: ws))
         }
         noteFocus(id)
     }
@@ -171,8 +191,7 @@ public final class WorkspaceManager {
         let ws = workspace(index)
         if ws.floating.contains(id) {
             ws.floating.remove(id)
-            let anchor = focusHistory.first { $0 != id && ws.layout.contains($0) }
-            ws.layout.insert(id, anchor: anchor)
+            ws.layout.insert(id, anchor: anchor(on: ws, excluding: id), focalPoint: focalPoint(on: ws))
         } else {
             ws.layout.remove(id)
             ws.floating.insert(id)
@@ -230,16 +249,10 @@ public final class WorkspaceManager {
               let targetIndex = workspaceIndex(of: target)
         else { return false }
 
-        if sourceIndex == targetIndex {
-            workspaces[sourceIndex]?.layout.swap(source, target)
-        } else {
-            // Across monitors: exchange which workspace each window belongs to.
-            guard let a = workspaces[sourceIndex], let b = workspaces[targetIndex] else { return false }
-            a.layout.remove(source)
-            b.layout.remove(target)
-            a.layout.insert(target, anchor: nil)
-            b.layout.insert(source, anchor: nil)
-        }
+        guard let a = workspaces[sourceIndex], let b = workspaces[targetIndex] else { return false }
+        // Across monitors too, only the payloads move: `switchWindows` swaps the windows'
+        // monitor/workspace pointers rather than re-inserting, so both trees keep their shape.
+        DwindleLayout.swap(source, in: a.layout, with: target, in: b.layout)
         return true
     }
 
@@ -313,8 +326,8 @@ public final class WorkspaceManager {
         if wasFloating {
             target.floating.insert(id)
         } else {
-            let anchor = focusHistory.first { $0 != id && target.layout.contains($0) }
-            target.layout.insert(id, anchor: anchor)
+            target.layout.insert(id, anchor: anchor(on: target, excluding: id),
+                                 focalPoint: focalPoint(on: target))
         }
 
         if follow {

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -56,6 +56,51 @@ h.test("new window splits the focused window, not the last one") { t in
     t.equalBox(l.idealBox(of: 3), box(756, 491, 756, 491), "w3 untouched")
 }
 
+// MARK: - Insertion fallbacks
+
+// With no focused tiled window to split, Hyprland falls to the leaf under the pointer, then
+// to the closest leaf when the pointer sits on a reserved strip, then to the oldest window.
+
+h.test("with no focused window, the leaf under the pointer splits") { t in
+    let l = omarchyLayout()
+    l.insert(1, anchor: nil)
+    l.insert(2, anchor: 1)
+    l.insert(3, anchor: 2)
+    // Pointer inside w2's tile. The fail-safe would have picked w1, the oldest.
+    l.insert(4, anchor: nil, focalPoint: Point(x: 1000, y: 100))
+    t.equalBox(l.idealBox(of: 2), box(756, 0, 378, 491), "w2 shrinks to its left half")
+    t.equalBox(l.idealBox(of: 4), box(1134, 0, 378, 491), "w4 takes w2's right half")
+    t.equalBox(l.idealBox(of: 1), box(0, 0, 756, 982), "w1 untouched")
+    t.equalBox(l.idealBox(of: 3), box(756, 491, 756, 491), "w3 untouched")
+}
+
+h.test("a pointer off the tiling area falls to the closest leaf") { t in
+    let l = omarchyLayout()
+    l.insert(1, anchor: nil)
+    l.insert(2, anchor: 1)
+    l.insert(3, anchor: 2)
+    // Below the tiling area — the Dock strip, Hyprland's isPointOnReservedArea case.
+    // The fail-safe would have picked w1; the closest leaf is w3.
+    l.insert(4, anchor: nil, focalPoint: Point(x: 1200, y: 1000))
+    t.equalBox(l.idealBox(of: 3), box(756, 491, 378, 491), "w3, the nearest leaf, shrinks to its left half")
+    t.equalBox(l.idealBox(of: 4), box(1134, 491, 378, 491), "w4 takes w3's right half")
+    t.equalBox(l.idealBox(of: 1), box(0, 0, 756, 982), "w1 untouched")
+    t.equalBox(l.idealBox(of: 2), box(756, 0, 756, 491), "w2 untouched")
+}
+
+h.test("the fail-safe leaf is the oldest window, not the leftmost") { t in
+    let l = omarchyLayout()
+    l.insert(1, anchor: nil)
+    l.insert(2, anchor: 1)
+    l.swapSplit(1)   // w2 is now the leftmost leaf, w1 is still the oldest
+    t.equalBox(l.idealBox(of: 2), box(0, 0, 756, 982), "w2 moved to the left half")
+
+    l.insert(3, anchor: nil)
+    t.equalBox(l.idealBox(of: 1), box(756, 0, 756, 491), "w1 split, the way getFirstNodeOnWorkspace picks it")
+    t.equalBox(l.idealBox(of: 3), box(756, 491, 756, 491), "w3 took w1's bottom half")
+    t.equalBox(l.idealBox(of: 2), box(0, 0, 756, 982), "w2 untouched")
+}
+
 // MARK: - preserve_split
 
 h.test("preserve_split freezes orientation across a resize") { t in
@@ -131,6 +176,34 @@ h.test("swapwindow exchanges windows without reshaping the tree") { t in
     t.equalBox(l.idealBox(of: 3), box(0, 0, 756, 982), "w3 now occupies the left half")
     t.equalBox(l.idealBox(of: 1), box(756, 491, 756, 491), "w1 now occupies the bottom-right quarter")
     t.equalBox(l.idealBox(of: 2), box(756, 0, 756, 491), "w2 untouched")
+}
+
+h.test("swapwindow across monitors reshapes neither tree") { t in
+    let a = omarchyLayout()
+    a.insert(1, anchor: nil)
+    a.insert(2, anchor: 1)
+    a.insert(3, anchor: 2)
+
+    let b = omarchyLayout(area: box(1512, 0, 1920, 1080))
+    b.insert(10, anchor: nil)
+    b.insert(11, anchor: 10)
+
+    let beforeA = a.idealBoxes().map(\.box).sorted { ($0.x, $0.y) < ($1.x, $1.y) }
+    let beforeB = b.idealBoxes().map(\.box).sorted { ($0.x, $0.y) < ($1.x, $1.y) }
+
+    DwindleLayout.swap(3, in: a, with: 11, in: b)
+
+    t.equal(a.idealBoxes().map(\.box).sorted { ($0.x, $0.y) < ($1.x, $1.y) }, beforeA, "tree A keeps its boxes")
+    t.equal(b.idealBoxes().map(\.box).sorted { ($0.x, $0.y) < ($1.x, $1.y) }, beforeB, "tree B keeps its boxes")
+
+    t.equalBox(a.idealBox(of: 11), box(756, 491, 756, 491), "w11 took w3's exact slot on A")
+    t.equalBox(b.idealBox(of: 3), box(2472, 0, 960, 1080), "w3 took w11's exact slot on B")
+    t.equalBox(a.idealBox(of: 1), box(0, 0, 756, 982), "w1 untouched")
+    t.equalBox(a.idealBox(of: 2), box(756, 0, 756, 491), "w2 untouched")
+    t.equalBox(b.idealBox(of: 10), box(1512, 0, 960, 1080), "w10 untouched")
+
+    t.expect(!a.contains(3) && b.contains(3), "w3 moved to tree B")
+    t.expect(!b.contains(11) && a.contains(11), "w11 moved to tree A")
 }
 
 // MARK: - Gaps
@@ -240,6 +313,47 @@ h.test("movetoworkspace follows the window") { t in
     wm.moveFocusedWindow(toWorkspace: 1, follow: false)
     t.equal(wm.focusedWorkspaceIndex, 3, "silent move does not follow")
     t.equal(wm.workspaceIndex(of: 2), 1, "w2 moved anyway")
+}
+
+h.test("a floating focus falls back to the window under the pointer") { t in
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
+    wm.addWindow(1); wm.addWindow(2); wm.addWindow(3)   // the usual staircase
+
+    wm.addWindow(4, floating: true)                     // focus is now on a floating window
+    wm.cursorLocation = { Point(x: 1000, y: 100) }      // pointer sits over w2's tile
+    wm.addWindow(5)
+
+    let l = wm.workspaces[wm.focusedWorkspaceIndex]!.layout
+    t.equalBox(l.idealBox(of: 2), box(756, 0, 378, 491), "w2, under the pointer, shrinks to its left half")
+    t.equalBox(l.idealBox(of: 5), box(1134, 0, 378, 491), "w5 takes w2's right half")
+    t.equalBox(l.idealBox(of: 1), box(0, 0, 756, 982), "w1 untouched")
+    t.equalBox(l.idealBox(of: 3), box(756, 491, 756, 491), "w3 untouched")
+}
+
+h.test("swapwindow across monitors trades slots, keeping both layouts") { t in
+    let left = box(0, 0, 1512, 982)
+    let right = box(1512, 0, 1920, 1080)
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: left, usable: left),
+                    Monitor(id: 2, frame: right, usable: right)])
+
+    let leftWS = wm.activeWorkspace[1]!
+    let rightWS = wm.activeWorkspace[2]!
+    wm.switchTo(workspace: leftWS)
+    wm.addWindow(1); wm.addWindow(2)
+    wm.switchTo(workspace: rightWS)
+    wm.addWindow(10); wm.addWindow(11)
+
+    wm.noteFocus(2)
+    t.equal(wm.swapWindow(.right), true, "w2's right neighbour is w10, on the other monitor")
+
+    t.equal(wm.workspaceIndex(of: 2), rightWS, "w2 now lives on the right monitor's workspace")
+    t.equal(wm.workspaceIndex(of: 10), leftWS, "w10 now lives on the left monitor's workspace")
+    t.equalBox(wm.workspaces[leftWS]?.layout.idealBox(of: 10), box(756, 0, 756, 982), "w10 took w2's exact slot")
+    t.equalBox(wm.workspaces[rightWS]?.layout.idealBox(of: 2), box(1512, 0, 960, 1080), "w2 took w10's exact slot")
+    t.equalBox(wm.workspaces[leftWS]?.layout.idealBox(of: 1), box(0, 0, 756, 982), "w1 untouched")
+    t.equalBox(wm.workspaces[rightWS]?.layout.idealBox(of: 11), box(2472, 0, 960, 1080), "w11 untouched")
 }
 
 h.test("a workspace follows its monitor") { t in

--- a/Sources/toe/AX/AXElement.swift
+++ b/Sources/toe/AX/AXElement.swift
@@ -110,6 +110,10 @@ enum Coordinates {
     static func toAX(_ rect: NSRect) -> Box {
         Box(x: rect.minX, y: primaryFrame.maxY - rect.maxY, w: rect.width, h: rect.height)
     }
+
+    static func toAX(_ point: NSPoint) -> Point {
+        Point(x: point.x, y: primaryFrame.maxY - point.y)
+    }
 }
 
 extension NSScreen {

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -28,6 +28,7 @@ final class Coordinator: WindowTrackerDelegate {
     // MARK: - Start-up
 
     func start() {
+        workspaces.cursorLocation = { Coordinates.toAX(NSEvent.mouseLocation) }
         status.workspaceProvider = { [weak self] in self?.workspaceSummaries() ?? [] }
         status.onSelectWorkspace = { [weak self] index in
             self?.dispatch(.workspace(.index(index)))


### PR DESCRIPTION
This started as a check on one question: when toe places a new window relative to the **focused** window, is that what Omarchy actually does?

**It is.** Verified against sources rather than memory:

- Omarchy's `default/hypr/looknfeel.conf` sets exactly two dwindle options — `preserve_split = true` and `force_split = 2` — leaving `use_active_for_splits` at Hyprland's default of `true`.
- In Hyprland v0.50.1's `CHyprDwindleLayout::onWindowCreatedTiling`, that makes `OPENINGON` equal `g_pCompositor->m_lastWindow` — the focused window — with the new window becoming `children[1]` (the right/bottom half) and the orientation taken from the focused window's own aspect ratio, then frozen by `preserve_split`.

`DwindleLayout.insert` already reproduced that line for line, so **the core insertion is unchanged**. What the check did turn up was three divergences in the paths *around* it.

## 1. Cross-monitor `swapwindow` rebuilt both trees

`WorkspaceManager.swapWindow` handled a swap across monitors by removing both windows and re-inserting them with `anchor: nil`, so each was grafted onto a fail-safe leaf instead of taking the other's slot — the shape of *both* trees changed. Hyprland's `switchWindows` swaps the node payloads and then the windows' monitor/workspace pointers, and never re-inserts:

```cpp
PNODE2->pWindow = pWindow;
PNODE->pWindow  = pWindow2;
if (PNODE->workspaceID != PNODE2->workspaceID) {
    std::swap(pWindow2->m_monitor,   pWindow->m_monitor);
    std::swap(pWindow2->m_workspace, pWindow->m_workspace);
}
```

Added `DwindleLayout.swap(_:in:with:in:)` as the cross-tree form of the existing same-workspace `swap`. This is the one change you can see on screen.

## 2. No pointer fallback

With `use_active_for_splits` on, Hyprland looks at exactly **one** window and falls back when it does not qualify:

```cpp
if (lastWindow && !lastWindow->m_isFloating && lastWindow != pWindow &&
    lastWindow->m_workspace == pWindow->m_workspace && lastWindow->m_isMapped)
    OPENINGON = getNodeFromWindow(lastWindow);
else
    OPENINGON = getNodeFromWindow(vectorToWindowUnified(MOUSECOORDS, ...));
if (!OPENINGON && isPointOnReservedArea(MOUSECOORDS, PMONITOR))
    OPENINGON = getClosestNodeOnWorkspace(workspaceID, MOUSECOORDS);
```

toe instead walked the whole focus history for the first tiled window and never read the pointer — most visible when focus sits on a floating window, where Hyprland splits whatever is under the mouse.

`WorkspaceManager` gains a `cursorLocation` closure so `ToeCore` stays free of AppKit, fed from `NSEvent.mouseLocation` through a new `Coordinates.toAX(NSPoint)`. `closestNode(to:)` ports `getClosestNodeOnWorkspace`, gated on the pointer being on the workspace's monitor but outside the tiling area.

Omarchy's `force_split = 2` never consults the focal point for child ordering, so **the shipped default is unaffected**; `force_split = 0` simply became correct.

## 3. The insertion fail-safe picked the leftmost leaf

`getFirstNodeOnWorkspace` scans `m_dwindleNodesData` in node-creation order, so Hyprland's last resort is the *oldest* window. toe used `root.leaves().first`, the leftmost leaf in DFS order. `DwindleLayout` now tracks creation order and keeps it consistent through both swap paths.

## Testing

`make test` — **145 assertions pass**, up from 113. Six cases added:

| Test | Level |
|---|---|
| leaf under the pointer splits when there is no focused window | `DwindleLayout` |
| pointer off the tiling area falls to the closest leaf | `DwindleLayout` |
| fail-safe leaf is the oldest window, not the leftmost | `DwindleLayout` |
| cross-monitor swap reshapes neither tree | `DwindleLayout` |
| floating focus falls back to the window under the pointer | `WorkspaceManager` |
| `swapwindow` across monitors trades slots, keeping both layouts | `WorkspaceManager` |

Each was confirmed to **fail** when reverted to the previous behaviour — the cross-monitor case failing with exactly the wrong-slot symptom. The existing staircase, `preserve_split`, removal and same-workspace swap cases stay green, which is the guard that §2's anchor change leaves the ordinary focused-window path alone.

## Worth a look before merge

- The two-monitor swap is only covered headlessly. Worth confirming on real hardware: build a distinct shape on each display and `SUPER+SHIFT+arrow` across the boundary.
- The pointer fallback means that with focus on a floating window, where your mouse rests decides which tile splits. Faithful to Hyprland, but a behaviour change from the README's "no cursor-follows-focus on macOS" framing. The README makes no claim either way, so it is untouched — happy to document it if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hg7Ny44QBN3q7hLiHWfGB6
