### PR TITLE
Round the focus border to follow the window's corners

### DIFF
--- a/Sources/ToeCore/BorderGeometry.swift
+++ b/Sources/ToeCore/BorderGeometry.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// The corner-radius arithmetic behind the focus border. Lives in ToeCore, away from AppKit,
+/// so the selftest can reach it — the pixels themselves can only be eyeballed.
+public enum BorderGeometry {
+
+    /// The radius of the *window's own* corner. A negative `configured` follows the system.
+    ///
+    /// Clamped to half the shorter side: Core Animation would clamp it silently anyway, and a
+    /// radius larger than that is meaningless. Clamping against the window box rather than the
+    /// outset one is still enough for `outerRadius`, since `(min + 2w) / 2 >= min / 2 + w`.
+    public static func effectiveRadius(configured: Double, system: Double, box: Box) -> Double {
+        let base = configured < 0 ? system : configured
+        return max(0, min(base, min(box.w, box.h) / 2))
+    }
+
+    /// The radius the band is drawn with. The band sits `width` points outside the window, and
+    /// the outward offset of a curve of radius `inner` has radius `inner + width` — which is
+    /// what lands the band's inner edge exactly on the window's own corner.
+    public static func outerRadius(inner: Double, width: Double) -> Double {
+        max(0, inner) + max(0, width)
+    }
+}

--- a/Sources/ToeCore/Config/Config.swift
+++ b/Sources/ToeCore/Config/Config.swift
@@ -7,7 +7,9 @@ public struct BorderConfig: Equatable {
     public var activeStart: String = "#33ccffee"
     public var activeEnd: String = "#00ff99ee"
     public var angle: Double = 45
-    public var radius: Double = 0
+    /// Negative follows the system window corner radius, 0 is square, positive is an
+    /// explicit value in points.
+    public var radius: Double = -1
     public init() {}
 }
 

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -41,7 +41,8 @@ width        = 2
 active_start = "#33ccffee"
 active_end   = "#00ff99ee"
 angle        = 45
-radius       = 0
+# -1 follows the system window corner radius, 0 is square, or set an explicit value.
+radius       = -1
 
 [binds]
 # ── Focus — SUPER + arrows ────────────────────────────────────────────────────

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -280,6 +280,7 @@ h.test("the shipped default config parses cleanly") { t in
     t.equal(c.dwindle.preserveSplit, true, "preserve_split")
     t.equal(c.dwindle.forceSplit, 2, "force_split")
     t.equal(c.border.activeStart, "#33ccffee", "Omarchy active border gradient start")
+    t.equal(c.border.radius, -1, "radius follows the system window corner radius")
     t.equal(c.floatRules.count, 5, "float rules")
 
     func binding(_ spec: String) -> Binding? { c.bindings.first { $0.source == spec } }
@@ -307,6 +308,27 @@ h.test("the shipped default config parses cleanly") { t in
     } else {
         t.expect(false, "SUPER+ENTER should be an exec binding")
     }
+}
+
+h.test("a negative radius survives the TOML parser") { t in
+    let c = try Config.parse("[border]\nradius = -1\n")
+    t.equal(c.border.radius, -1, "radius = -1")
+    t.equal(c.warnings, [], "no warnings")
+}
+
+h.test("border corner radius") { t in
+    let big = box(0, 0, 800, 600)
+    t.equal(BorderGeometry.effectiveRadius(configured: 12, system: 26, box: big), 12,
+            "an explicit radius wins over the system value")
+    t.equal(BorderGeometry.effectiveRadius(configured: -1, system: 26, box: big), 26,
+            "a negative radius follows the system")
+    t.equal(BorderGeometry.effectiveRadius(configured: 0, system: 26, box: big), 0,
+            "0 still means square")
+    t.equal(BorderGeometry.effectiveRadius(configured: -1, system: 26, box: box(0, 0, 20, 20)), 10,
+            "clamped to half the shorter side on a tiny window")
+    t.equal(BorderGeometry.outerRadius(inner: 26, width: 2), 28,
+            "the band's outer radius clears the window's by the band width")
+    t.equal(BorderGeometry.outerRadius(inner: 0, width: 2), 2, "square window, offset band")
 }
 
 h.test("binding specs parse in both spellings") { t in

--- a/Sources/toe/UI/BorderOverlay.swift
+++ b/Sources/toe/UI/BorderOverlay.swift
@@ -8,7 +8,10 @@ final class BorderOverlay {
 
     private let panel: NSPanel
     private let gradient = CAGradientLayer()
-    private let shape = CAShapeLayer()
+    /// The gradient's mask. A plain CALayer, not a CAShapeLayer: only CALayer draws macOS's
+    /// continuous-curvature corners, and a mask masks by whatever alpha it renders — so a layer
+    /// with no background and a white border is exactly the band we want.
+    private let band = CALayer()
     private var config = BorderConfig()
 
     init() {
@@ -27,10 +30,14 @@ final class BorderOverlay {
         let view = NSView(frame: .zero)
         view.wantsLayer = true
         view.layer?.addSublayer(gradient)
-        gradient.mask = shape
-        shape.fillColor = nil
-        shape.strokeColor = NSColor.white.cgColor
+        gradient.mask = band
+        band.backgroundColor = nil                  // the middle stays transparent
+        band.borderColor = NSColor.white.cgColor    // mask alpha only; the colour is the gradient's
+        band.cornerCurve = .continuous              // macOS's squircle, not a circular arc
         panel.contentView = view
+
+        // Resolves the system corner radius here, on the main thread, and records it once.
+        Log.info("system window corner radius: \(SystemCornerRadius.points) pt (\(SystemCornerRadius.source))")
     }
 
     func apply(_ newConfig: BorderConfig) {
@@ -41,8 +48,9 @@ final class BorderOverlay {
         let dx = cos(radians) / 2, dy = sin(radians) / 2
         gradient.startPoint = CGPoint(x: 0.5 - dx, y: 0.5 - dy)
         gradient.endPoint = CGPoint(x: 0.5 + dx, y: 0.5 + dy)
-        shape.lineWidth = newConfig.width
         if !newConfig.enabled { hide() }
+        // The band's width and radius move together and depend on the window, so both are set
+        // in show() rather than here.
     }
 
     /// `box` is the window's own frame in AX coordinates; the border is drawn just outside it.
@@ -54,17 +62,27 @@ final class BorderOverlay {
         let rect = Coordinates.toCocoa(outer)
         guard rect.width > 0, rect.height > 0 else { hide(); return }
 
+        let windowRadius = BorderGeometry.effectiveRadius(configured: config.radius,
+                                                          system: Double(SystemCornerRadius.points),
+                                                          box: box)
+
         CATransaction.begin()
         CATransaction.setDisableActions(true)
         panel.setFrame(rect, display: false)
         let bounds = CGRect(origin: .zero, size: rect.size)
         panel.contentView?.frame = bounds
         gradient.frame = bounds
-        shape.frame = bounds
-        // Stroke straddles the path, so inset by half the line width to keep it inside.
-        shape.path = CGPath(roundedRect: bounds.insetBy(dx: w / 2, dy: w / 2),
-                            cornerWidth: config.radius, cornerHeight: config.radius,
-                            transform: nil)
+        // CALayer.borderWidth draws inside the bounds, unlike a CAShapeLayer stroke, so the band
+        // fills the whole outset with no half-line-width inset. Clearing the window's radius by
+        // the band width is what lands the band's inner edge on the window's own corner.
+        band.frame = bounds
+        band.borderWidth = w
+        band.cornerRadius = BorderGeometry.outerRadius(inner: windowRadius, width: w)
+        // A mask rasterises at its own contentsScale, which defaults to 1 — without this the
+        // border is soft on Retina. Re-read every time: the panel can change display.
+        let scale = panel.backingScaleFactor
+        if gradient.contentsScale != scale { gradient.contentsScale = scale }
+        if band.contentsScale != scale { band.contentsScale = scale }
         CATransaction.commit()
 
         panel.orderFront(nil)

--- a/Sources/toe/UI/SystemCornerRadius.swift
+++ b/Sources/toe/UI/SystemCornerRadius.swift
@@ -1,0 +1,79 @@
+import AppKit
+import ObjectiveC
+
+/// The corner radius macOS rounds a window to. No public API reports it, and on macOS 26 no
+/// private one does either, so this is part measurement, part lookup.
+///
+/// On macOS 26 the window server rounds every window itself, and AppKit's own accessors have
+/// not followed: `NSWindow._cornerRadius`, `_effectiveCornerRadius`, `NSThemeFrame._cornerRadius`
+/// and `_getCachedWindowCornerRadius` all still answer 16, while windows actually render at 24.
+/// Fitting a rendered CALayer silhouette against a screenshot of a real window puts the value at
+/// 24.0 pt (rms 0.24 px; 16 pt is off by 2.99 px), so 26 and later use the measured constant.
+///
+/// Earlier releases drew the rounding in AppKit, where the private accessor did match, so those
+/// keep asking. That path is guarded at every step and falls back rather than crashing.
+enum SystemCornerRadius {
+
+    /// macOS 26 and later. Measured, not reported — see the note above.
+    static let tahoe: CGFloat = 24
+
+    /// macOS 11...15, if the private accessor is gone.
+    static let legacy: CGFloat = 10
+
+    /// Resolved once, lazily. First access must be on the main thread — `BorderOverlay.init()`
+    /// forces it there.
+    static let points: CGFloat = resolve()
+
+    /// Where the value came from, for the log line.
+    private(set) static var source = "unknown"
+
+    private static func resolve() -> CGFloat {
+        if ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 26 {
+            source = "measured constant for macOS 26+"
+            return tahoe
+        }
+        if let probed = probe() {
+            source = "NSThemeFrame"
+            return probed
+        }
+        source = "fallback"
+        return legacy
+    }
+
+    /// Reads the radius off a throwaway window that is created and closed without ever being
+    /// shown. PRIVATE API, and undocumented: every step is guarded, and a miss returns nil.
+    private static func probe() -> CGFloat? {
+        // A borderless window gets a different frame view with no rounding, so the style mask
+        // has to be a normal titled one. `defer: false` forces the backing store — and with it
+        // the theme frame — to exist right away.
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 200, height: 200),
+                              styleMask: [.titled, .closable, .miniaturizable, .resizable],
+                              backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        defer { window.close() }
+
+        // The content view is created on demand; its superview is the NSThemeFrame.
+        guard let frame = window.contentView?.superview, let cls = object_getClass(frame) else {
+            return nil
+        }
+
+        for name in ["roundedCornerRadius", "_cornerRadius"] {
+            let selector = NSSelectorFromString(name)
+            // `responds(to:)` alone is not enough: it also answers yes for a forwarded selector
+            // that has no method to look up.
+            guard frame.responds(to: selector),
+                  let method = class_getInstanceMethod(cls, selector)
+            else { continue }
+
+            // Not `perform(_:)` — that reads the return value as an object pointer, but a
+            // CGFloat comes back in a floating-point register, so the result would be garbage.
+            typealias Getter = @convention(c) (AnyObject, Selector) -> CGFloat
+            let getter = unsafeBitCast(method_getImplementation(method), to: Getter.self)
+            let value = getter(frame, selector)
+
+            // Anything outside this band is a selector collision, not a radius.
+            if value.isFinite, value > 0, value <= 60 { return value }
+        }
+        return nil
+    }
+}

--- a/Sources/toe/main.swift
+++ b/Sources/toe/main.swift
@@ -18,6 +18,13 @@ if CommandLine.arguments.contains("--print-default-config") {
 
 let app = NSApplication.shared
 app.setActivationPolicy(.accessory)
+// `toe --print-corner-radius` reports what macOS rounds windows to, so the border can be
+// checked without granting Accessibility or launching the agent. Needs NSApp to exist.
+if CommandLine.arguments.contains("--print-corner-radius") {
+    print(SystemCornerRadius.points)
+    exit(0)
+}
+
 let delegate = AppDelegate()
 app.delegate = delegate
 app.run()

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -34,7 +34,8 @@ width        = 2
 active_start = "#33ccffee"
 active_end   = "#00ff99ee"
 angle        = 45
-radius       = 0
+# -1 follows the system window corner radius, 0 is square, or set an explicit value.
+radius       = -1
 
 [binds]
 # ── Focus — SUPER + arrows ────────────────────────────────────────────────────


### PR DESCRIPTION
The focus overlay stroked a sharp-cornered rectangle around windows whose corners are rounded, so it overshot at all four corners.

## What was wrong

Three separate defects in `BorderOverlay`:

1. **Sharp corners.** `border.radius` shipped as `0`, so the path was a plain rectangle.
2. **No concentric compensation.** The band sits `width` points outside the window, and the outward offset of a curve of radius `r` has radius `r + width` — the raw value was applied after an `insetBy(w/2)` with no correction.
3. **Wrong curve family.** `CGPath(roundedRect:)` draws circular arcs; macOS corners are continuous-curvature, and a circular arc of the same radius meets the straight edge with a visible curvature break.

Plus a latent one: neither the gradient nor its mask ever got `contentsScale`, so both rasterised at 1× on Retina. `NSView` sets it on its backing layer but does not propagate to manually added sublayers.

## Approach

Replace the `CAShapeLayer` stroke with a plain `CALayer` mask. Only `CALayer` draws continuous corners, and a mask masks by the alpha it *renders* — so a layer with no background and a white border is exactly the band, and it drops into `gradient.mask` with no structural change. This routes the border through the same rasteriser AppKit uses to draw the real window.

`border.radius` now takes `-1` to follow the system, `0` for square, or an explicit value in points.

## The macOS 26 radius

`SystemCornerRadius` uses a measured constant of **24.0 pt** on macOS 26+. The window server rounds windows itself there and AppKit's accessors have not followed: `NSWindow._cornerRadius`, `_effectiveCornerRadius`, `NSThemeFrame._cornerRadius` and `_getCachedWindowCornerRadius` all still answer 16, while windows render at 24.

Fitting rendered `CALayer` silhouettes against a screenshot of a real window:

| radius | rms error vs the real window |
|---|---|
| 16 | 2.99 px |
| 22 | 0.48 px |
| **24** | **0.24 px** |
| 26 | 0.42 px |

Earlier releases drew the rounding in AppKit, where the private accessor did match, so those keep probing it — guarded by `responds(to:)`, `class_getInstanceMethod` and a range check, falling back rather than crashing. The log line names which source was used.

## Verification

- `make test` — 112 assertions, covering the radius arithmetic and that `radius = -1` survives the hand-rolled TOML parser.
- Rendered the band headlessly and measured its thickness: 2.000 pt on the flat edge, 2.121 pt on the corner diagonal (one diagonal pixel step at 4× sampling) — concentric.
- Confirmed `cornerCurve = .continuous` is honoured on a *mask* layer by diffing continuous vs circular renders (7128 differing bytes), rather than assuming it.
- End-to-end against a real window: the band's inner edge misses by rms 5.05 px at radius 16, dropping to 1.44 px at 24 (residual is a ~1 px bias from tracking the window's highlight ring; the registration-corrected fit was 0.24 px).

## Notes

- `radius` measured against one Safari window. An app that rounds differently would show it first; `radius = <n>` overrides.
- The pre-26 probe path could not be exercised on this machine.
- Existing `~/.config/toe/toe.toml` files contain `radius = 0` and are not rewritten — that line needs changing to `-1` to pick up the new default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTeYPBu1zjQFpMyVCnENhF