### PR TITLE
Build, sign and publish toe through a Homebrew cask

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: ["**"]
   pull_request:
 
 concurrency:
@@ -14,7 +12,7 @@ jobs:
     # macos-15 is arm64, which is the only architecture toe ships for.
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Swift version
         run: swift --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    # macos-15 is arm64, which is the only architecture toe ships for.
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Swift version
+        run: swift --version
+
+      - name: Build
+        run: swift build -c release
+
+      # The layout suite is a plain executable rather than XCTest (see Package.swift), so it
+      # needs no Xcode, no simulator and no signing, and exits nonzero on failure.
+      - name: Test
+        run: swift run -c debug toe-selftest
+
+      # Catches bundling regressions. With no signing identity present this falls back to
+      # ad-hoc signing, so it needs no secrets and works on fork pull requests.
+      - name: Bundle
+        run: ./scripts/bundle.sh release
+
+      - name: Smoke test
+        run: build/Toe.app/Contents/MacOS/toe --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,129 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Not shallow: the cask bump below pushes to main, and git refuses to push
+          # from a shallow clone.
+          fetch-depth: 0
+
+      - name: Derive version
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      # toe is signed with a self-signed certificate rather than a Developer ID: it cannot be
+      # notarized, but it gives the app a stable designated requirement, so Accessibility
+      # grants survive `brew upgrade`. See scripts/release-cert.sh for the full rationale.
+      - name: Import signing certificate
+        env:
+          CERT_P12_BASE64: ${{ secrets.SIGNING_CERT_P12_BASE64 }}
+          CERT_PASSWORD: ${{ secrets.SIGNING_CERT_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          keychain="$RUNNER_TEMP/toe-signing.keychain-db"
+          echo "$CERT_P12_BASE64" | base64 --decode > "$RUNNER_TEMP/toe-release.p12"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$keychain"
+          security set-keychain-settings -lut 900 "$keychain"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$keychain"
+          security import "$RUNNER_TEMP/toe-release.p12" -k "$keychain" \
+            -P "$CERT_PASSWORD" -T /usr/bin/codesign
+          # Without this codesign blocks on a GUI keychain prompt and the job hangs.
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$keychain" > /dev/null
+          security list-keychains -d user -s "$keychain" $(security list-keychains -d user | tr -d '"')
+
+          # codesign cannot build a chain to an untrusted self-signed root. Runners have
+          # passwordless sudo, so trust the certificate for code signing only.
+          openssl pkcs12 -in "$RUNNER_TEMP/toe-release.p12" -passin pass:"$CERT_PASSWORD" \
+            -clcerts -nokeys -out "$RUNNER_TEMP/toe-release.pem"
+          sudo security add-trusted-cert -d -r trustRoot -p codeSign \
+            -k /Library/Keychains/System.keychain "$RUNNER_TEMP/toe-release.pem"
+
+          rm -f "$RUNNER_TEMP/toe-release.p12"
+
+          # find-identity exits 0 even when it finds nothing, so assert instead: without a
+          # *valid* (trusted) identity the build would fail later, inside codesign.
+          security find-identity -v -p codesigning "$keychain"
+          if ! security find-identity -v -p codesigning "$keychain" | grep -q "toe-release"; then
+            echo "toe-release is not a valid signing identity — is the certificate trusted?" >&2
+            exit 1
+          fi
+
+      - name: Test
+        run: swift run -c debug toe-selftest
+
+      - name: Build and sign
+        env:
+          TOE_VERSION: ${{ steps.version.outputs.version }}
+          TOE_SIGN_IDENTITY: toe-release
+        run: ./scripts/bundle.sh release
+
+      # Echo the designated requirement into the log: if it ever names a cdhash instead of a
+      # certificate, or names a different certificate, this release just broke every user's
+      # Accessibility grant and we want that visible rather than silent.
+      - name: Verify signature
+        run: |
+          set -euo pipefail
+          codesign --verify --deep --strict --verbose=2 build/Toe.app
+          codesign -d -r - build/Toe.app
+
+      - name: Smoke test
+        run: |
+          set -euo pipefail
+          actual="$(build/Toe.app/Contents/MacOS/toe --version)"
+          expected="${{ steps.version.outputs.version }}"
+          [ "$actual" = "$expected" ] || { echo "version is $actual, expected $expected"; exit 1; }
+
+      # ditto, not zip: it preserves the bundle's metadata and keeps the signature intact.
+      - name: Package
+        id: package
+        run: |
+          set -euo pipefail
+          asset="toe-${{ steps.version.outputs.version }}-arm64.zip"
+          ditto -c -k --keepParent build/Toe.app "$asset"
+          echo "asset=$asset" >> "$GITHUB_OUTPUT"
+          echo "sha256=$(shasum -a 256 "$asset" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.asset }}" \
+            --title "$GITHUB_REF_NAME" --generate-notes
+
+      - name: Bump cask
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          SHA256: ${{ steps.package.outputs.sha256 }}
+        run: |
+          set -euo pipefail
+          git fetch origin main
+          git checkout -B main origin/main
+          /usr/bin/sed -i '' \
+            -e "s|^  version \".*\"$|  version \"$VERSION\"|" \
+            -e "s|^  sha256 \".*\"$|  sha256 \"$SHA256\"|" \
+            Casks/toe.rb
+          if git diff --quiet Casks/toe.rb; then
+            echo "cask already at $VERSION"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "Bump toe cask to $VERSION" Casks/toe.rb
+          git push origin main
+
+      - name: Clean up keychain
+        if: always()
+        run: security delete-keychain "$RUNNER_TEMP/toe-signing.keychain-db" || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   release:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # Not shallow: the cask bump below pushes to main, and git refuses to push
           # from a shallow clone.

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 build/
 .DS_Store
 *.xcodeproj
+*.p12
+*.p12.passwords

--- a/Casks/toe.rb
+++ b/Casks/toe.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+cask "toe" do
+  # Both lines below are rewritten by .github/workflows/release.yml on each tag.
+  version "0.0.0"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+
+  url "https://github.com/theclifmeister/toe/releases/download/v#{version}/toe-#{version}-arm64.zip"
+  name "toe"
+  desc "Omarchy-style dwindle window manager"
+  homepage "https://github.com/theclifmeister/toe"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :sonoma"
+  depends_on arch: :arm64
+
+  app "Toe.app"
+
+  uninstall launchctl: "com.clifmeister.toe",
+            quit:      "com.clifmeister.toe"
+
+  zap trash: [
+    "~/.config/toe",
+    "~/Library/LaunchAgents/com.clifmeister.toe.plist",
+    "~/Library/Saved Application State/com.clifmeister.toe.savedState",
+  ]
+
+  caveats do
+    <<~EOS
+      Grant toe Accessibility before it can manage windows:
+        System Settings → Privacy & Security → Accessibility
+
+      toe is signed, but with a self-signed certificate rather than an Apple Developer ID, so
+      it is not notarized. Homebrew no longer quarantines cask downloads, so this is usually
+      invisible. If macOS refuses to open the app, clear the quarantine attribute by hand:
+        xattr -dr com.apple.quarantine /Applications/Toe.app
+
+      To start toe at login, see "Start at login" at #{homepage}
+    EOS
+  end
+end

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Clifford van Slimming
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -64,15 +64,31 @@ built when the menu opens, so nothing is maintained while it is closed.
 ## Install
 
 ```sh
-make install          # builds, ad-hoc signs, copies to /Applications
+brew tap theclifmeister/toe https://github.com/theclifmeister/toe
+brew install --cask theclifmeister/toe/toe
 open /Applications/Toe.app
-make start-at-login   # optional
 ```
+
+The two-argument `brew tap` is because the cask lives in this repository rather than a
+separate `homebrew-toe` one. `brew upgrade --cask toe` picks up new releases.
 
 Grant **System Settings → Privacy & Security → Accessibility** when asked. That single
 permission is all toe needs.
 
+### From source
+
+```sh
+make install          # builds, signs, copies to /Applications
+open /Applications/Toe.app
+```
+
 `make run` builds and launches in place without installing. `make test` runs the layout suite.
+
+### Start at login
+
+```sh
+make start-at-login   # from a clone; writes a LaunchAgent for /Applications/Toe.app
+```
 
 ## How faithful is the dwindle?
 
@@ -165,3 +181,7 @@ log stream --predicate 'subsystem == "com.clifmeister.toe"' --level info
 
 By design: no scratchpads, no binding modes, no scripting API, no resize bindings, no window
 groups. It is a layout engine and the bindings that drive it.
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -22,7 +22,7 @@
     <key>LSUIElement</key>
     <true/>
     <key>NSHumanReadableCopyright</key>
-    <string>toe — The Omarchy Experience</string>
+    <string>Copyright © 2026 Clifford van Slimming. MIT licensed.</string>
     <!-- Only needed because the default config's SUPER+ENTER bindings drive Ghostty and the
          browser through AppleScript. toe itself needs nothing but Accessibility. -->
     <key>NSAppleEventsUsageDescription</key>

--- a/Sources/toe/main.swift
+++ b/Sources/toe/main.swift
@@ -16,6 +16,14 @@ if CommandLine.arguments.contains("--print-default-config") {
     exit(0)
 }
 
+// `toe --version` reports what the bundle was stamped with, which is how the release workflow
+// checks that the tag made it into the app. Run outside a bundle there is nothing to report.
+if CommandLine.arguments.contains("--version") {
+    let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    print(version ?? "unknown")
+    exit(0)
+}
+
 let app = NSApplication.shared
 app.setActivationPolicy(.accessory)
 // `toe --print-corner-radius` reports what macOS rounds windows to, so the border can be

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-# Assembles Toe.app from the release binary and ad-hoc signs it.
+# Assembles Toe.app from the release binary and signs it.
+#
+# Two environment variables let CI drive this without changing local behaviour:
+#   TOE_SIGN_IDENTITY  signing identity to use, skipping the toe-dev/ad-hoc search
+#   TOE_VERSION        version to stamp into the bundled Info.plist
 set -euo pipefail
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -15,14 +19,31 @@ cp "$binary" "$app/Contents/MacOS/toe"
 cp "$root/Resources/Info.plist" "$app/Contents/Info.plist"
 printf 'APPL????' > "$app/Contents/PkgInfo"
 
-# macOS keys Accessibility grants to the code signature. Prefer the stable self-signed
-# identity from scripts/dev-cert.sh so the grant survives a rebuild; fall back to ad-hoc
-# signing, which changes on every build and makes macOS re-ask.
+# Releases stamp the tag's version into the bundle. Left alone, the committed Info.plist
+# version stands, so a local `make run` builds exactly what it always did.
+if [ -n "${TOE_VERSION:-}" ]; then
+    plist="$app/Contents/Info.plist"
+    /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $TOE_VERSION" "$plist"
+    /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $TOE_VERSION" "$plist"
+    echo "stamped version $TOE_VERSION"
+fi
+
+# macOS keys Accessibility grants to the code signature. Prefer a real identity — the release
+# certificate in CI, or the stable self-signed one from scripts/dev-cert.sh — so the grant
+# survives an upgrade; fall back to ad-hoc signing, which changes on every build and makes
+# macOS re-ask.
 identity="-"
-if security find-identity -v -p codesigning 2>/dev/null | grep -q '"toe-dev"'; then
+if [ -n "${TOE_SIGN_IDENTITY:-}" ]; then
+    identity="$TOE_SIGN_IDENTITY"
+elif security find-identity -v -p codesigning 2>/dev/null | grep -q '"toe-dev"'; then
     identity="toe-dev"
 fi
-codesign --force --sign "$identity" --identifier com.clifmeister.toe "$app" >/dev/null 2>&1
+# Quiet on success — codesign is chatty — but show everything if it fails, so a CI signing
+# problem reports itself instead of failing as a bare exit code.
+if ! out="$(codesign --force --sign "$identity" --identifier com.clifmeister.toe "$app" 2>&1)"; then
+    echo "$out" >&2
+    exit 1
+fi
 if [ "$identity" = "-" ]; then echo "signed ad-hoc"; else echo "signed with $identity"; fi
 
 echo "built $app"

--- a/scripts/release-cert.sh
+++ b/scripts/release-cert.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Creates the "toe-release" self-signed code-signing certificate used by CI.
+#
+# Why a certificate at all, when it cannot be notarized: macOS keys Accessibility grants to an
+# app's designated requirement. An ad-hoc signature puts the cdhash in that requirement, so it
+# changes with every build and every `brew upgrade` would silently revoke the grant. Signing
+# with a certificate — even a self-signed one nobody trusts — makes the requirement name the
+# certificate instead, and the grant survives upgrades.
+#
+# ⚠️ Run this ONCE, ever. Regenerating the certificate changes the designated requirement and
+# costs every existing user their Accessibility grant. Back the .p12 and its password up.
+#
+# usage: release-cert.sh [--out <path>] [--set-secrets <owner/repo>]
+#
+# With --set-secrets the three values are piped straight into `gh secret set` and never
+# printed, so they stay out of your terminal scrollback. Without it they are printed for
+# pasting into Settings → Secrets and variables → Actions.
+set -euo pipefail
+
+name="toe-release"
+out="$PWD/$name.p12"
+repo=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --out) out="$2"; shift 2 ;;
+        --set-secrets) repo="$2"; shift 2 ;;
+        *) echo "unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [ -e "$out" ]; then
+    echo "$out already exists — refusing to overwrite an existing release certificate" >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "$out")"
+cert_password="$(openssl rand -base64 24)"
+keychain_password="$(openssl rand -base64 24)"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+openssl req -x509 -newkey rsa:2048 -keyout "$tmp/key.pem" -out "$tmp/cert.pem" -days 3650 -nodes \
+    -subj "/CN=$name/O=toe/C=US" \
+    -addext "keyUsage=critical,digitalSignature" \
+    -addext "extendedKeyUsage=critical,codeSigning" \
+    -addext "basicConstraints=critical,CA:false" 2>/dev/null
+
+# Apple's Security framework cannot read OpenSSL 3's default PKCS#12 encryption.
+openssl pkcs12 -export -out "$out" -inkey "$tmp/key.pem" -in "$tmp/cert.pem" \
+    -passout pass:"$cert_password" -name "$name" \
+    -macalg sha1 -certpbe PBE-SHA1-3DES -keypbe PBE-SHA1-3DES 2>/dev/null
+chmod 600 "$out"
+
+# The passwords are needed again only if the secrets ever have to be re-created, so keep them
+# next to the certificate rather than only in GitHub.
+cat > "$out.passwords" <<EOF
+SIGNING_CERT_PASSWORD=$cert_password
+KEYCHAIN_PASSWORD=$keychain_password
+EOF
+chmod 600 "$out.passwords"
+
+echo "wrote $out"
+echo "wrote $out.passwords"
+echo "SHA-256 fingerprint: $(openssl x509 -in "$tmp/cert.pem" -noout -fingerprint -sha256 | cut -d= -f2)"
+
+if [ -n "$repo" ]; then
+    base64 < "$out" | gh secret set SIGNING_CERT_P12_BASE64 --repo "$repo"
+    printf '%s' "$cert_password" | gh secret set SIGNING_CERT_PASSWORD --repo "$repo"
+    printf '%s' "$keychain_password" | gh secret set KEYCHAIN_PASSWORD --repo "$repo"
+    echo "set SIGNING_CERT_P12_BASE64, SIGNING_CERT_PASSWORD and KEYCHAIN_PASSWORD on $repo"
+else
+    cat <<EOF
+
+Add these repository secrets (Settings → Secrets and variables → Actions):
+
+  SIGNING_CERT_P12_BASE64
+$(base64 < "$out" | sed 's/^/    /')
+
+  SIGNING_CERT_PASSWORD
+    $cert_password
+
+  KEYCHAIN_PASSWORD
+    $keychain_password
+
+EOF
+fi
+
+cat <<EOF
+
+⚠️  Back up $out and $out.passwords somewhere durable — a password manager.
+    Losing them means the next release must use a different certificate, and every user
+    will have to grant Accessibility again.
+EOF


### PR DESCRIPTION
Adds CI on every push and a tag-driven release pipeline, so installing toe is
`brew install --cask` rather than cloning the repo. Also adds the MIT license the
repo was missing before going public.

## What lands

- **`.github/workflows/ci.yml`** — build, the 169-assertion self-test suite, bundle and a
  smoke test on every push and PR. No secrets, so it runs on fork PRs too.
- **`.github/workflows/release.yml`** — on a `v*` tag: import the signing certificate into
  an ephemeral keychain, build, sign, verify, package with `ditto`, cut the release, and
  rewrite `Casks/toe.rb`.
- **`Casks/toe.rb`** — passes `brew style` clean.
- **`scripts/release-cert.sh`** — one-time generator for the CI certificate.
- **`scripts/bundle.sh`** — `TOE_VERSION` and `TOE_SIGN_IDENTITY` overrides; unchanged
  behaviour when neither is set.
- **`toe --version`** — so the release can assert the tag reached the bundle.

## Why a self-signed certificate

There is no Apple Developer Program membership, so the app cannot be notarized. That turns
out not to be the blocker it sounds like: Homebrew 6.x no longer quarantines cask downloads
(`Cask::Quarantine.check_quarantine_support` returns `:quarantine_unavailable`), and arm64
only requires that a binary carry *some* valid signature.

The certificate exists for a different reason. macOS keys Accessibility grants to an app's
designated requirement, and toe is useless without Accessibility. Built both ways:

| Signature | Designated requirement |
|---|---|
| ad-hoc | `cdhash H"54a0025…"` |
| certificate | `identifier "com.clifmeister.toe" and certificate root = H"b2a78c4…"` |

The ad-hoc `cdhash` changes on every build, so every `brew upgrade` would silently revoke
Accessibility. The certificate-based requirement is stable as long as the same certificate is
reused — hence the loud warning in `release-cert.sh` against regenerating it.

## Verified

- 169 assertions pass; `--version` returns the stamped version
- signature survives the `ditto` zip round trip
- the cask bump `sed` matches and leaves valid Ruby; `brew style` clean
- the release `.p12` imports into a keychain, confirming the PKCS#12 encoding is one Apple
  can read
- both workflows parse as YAML

Not verified locally: the `sudo security add-trusted-cert` signing path, which needs to touch
the System keychain. The first tagged release exercises it on a runner.

## Before merging

Repository secrets are already set. Two things to know:

- If `main` has branch protection, the cask-bump push at the end of the release job will fail
  and needs a bot exemption or a PR-based split.
- `Casks/toe.rb` ships with placeholder `version "0.0.0"` and a zeroed `sha256`; the first tag
  fills them in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMLhreG5MiyzvMErDwqJMv
