### PR TITLE
Make SUPER+T actually float a window

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,15 +135,15 @@ whose minimum size exceeds its tile (Safari will not go narrower than ~574px) is
 then left alone rather than fought with forever. The same mechanism snaps a window back when you
 drag it out of its tile.
 
-**Floating windows.** `togglefloating` lifts a window out of the tree and gives it back the
-geometry it had before toe first tiled it — Hyprland's `m_vLastFloatingSize` and
-`m_vLastFloatingPosition` — and after that, wherever you last dragged it. toe writes a floating
-frame only when it actually changes and never re-asserts it, so dragging a floating window is
-never fought the way a tile is. If the display it was last on has been unplugged, the window is
-centred on the display that remains rather than clamped against an edge. It is raised when you
-float it and again whenever it is focused, but the Accessibility API offers no persistent
-always-on-top: activate a tiled window afterwards and it can cover the floating one. Floating
-windows stay reachable with `SUPER`+arrows.
+**Floating windows.** `togglefloating` lifts a window out of the tree and centres it on the
+monitor, at the size it remembers — what the window was before toe first tiled it, and after
+that the last size it floated at. Centring happens when you float it, not on every frame, so
+dragging a floating window afterwards sticks: toe writes a floating frame only when it actually
+changes and never re-asserts it, so a floating window is never fought the way a tile is. If the
+display it was last on has been unplugged, it is centred on the display that remains rather than
+clamped against an edge. It is raised when you float it and again whenever it is focused, but the
+Accessibility API offers no persistent always-on-top: activate a tiled window afterwards and it
+can cover the floating one. Floating windows stay reachable with `SUPER`+arrows.
 
 **Windows toe leaves alone**: dialogs, sheets, palettes, minimized and natively-fullscreen
 windows, and anything that refuses a position or size. Add your own exceptions with `[[float]]`

--- a/README.md
+++ b/README.md
@@ -135,15 +135,18 @@ whose minimum size exceeds its tile (Safari will not go narrower than ~574px) is
 then left alone rather than fought with forever. The same mechanism snaps a window back when you
 drag it out of its tile.
 
-**Floating windows.** `togglefloating` lifts a window out of the tree and centres it on the
-monitor, at the size it remembers — what the window was before toe first tiled it, and after
-that the last size it floated at. Centring happens when you float it, not on every frame, so
-dragging a floating window afterwards sticks: toe writes a floating frame only when it actually
-changes and never re-asserts it, so a floating window is never fought the way a tile is. If the
-display it was last on has been unplugged, it is centred on the display that remains rather than
-clamped against an edge. It is raised when you float it and again whenever it is focused, but the
-Accessibility API offers no persistent always-on-top: activate a tiled window afterwards and it
-can cover the floating one. Floating windows stay reachable with `SUPER`+arrows.
+**Floating windows.** `togglefloating` lifts a window out of the tree and centres it, at a
+consistent fraction of the display — 70% wide by 80% tall by default — so every floating window
+is the same shape whichever window it came from. No floating window is ever wider than 1.6 times
+its own height, which is what stops 70% of a 32:9 ultrawide from being a letterbox; on a laptop
+that cap never comes into play. All three are `[floating]` keys in the config. Sizing happens
+when you float the window, not on every frame, so dragging it afterwards sticks: toe writes a
+floating frame only when it actually changes and never re-asserts it, so a floating window is
+never fought the way a tile is. If the display it was last on has been unplugged, it is centred
+on the display that remains rather than clamped against an edge. It is raised when you float it
+and again whenever it is focused, but the Accessibility API offers no persistent always-on-top:
+activate a tiled window afterwards and it can cover the floating one. Floating windows stay
+reachable with `SUPER`+arrows.
 
 **Windows toe leaves alone**: dialogs, sheets, palettes, minimized and natively-fullscreen
 windows, and anything that refuses a position or size. Add your own exceptions with `[[float]]`

--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ whose minimum size exceeds its tile (Safari will not go narrower than ~574px) is
 then left alone rather than fought with forever. The same mechanism snaps a window back when you
 drag it out of its tile.
 
+**Floating windows.** `togglefloating` lifts a window out of the tree and gives it back the
+geometry it had before toe first tiled it — Hyprland's `m_vLastFloatingSize` and
+`m_vLastFloatingPosition` — and after that, wherever you last dragged it. toe writes a floating
+frame only when it actually changes and never re-asserts it, so dragging a floating window is
+never fought the way a tile is. It is raised when you float it and again whenever it is focused,
+but the Accessibility API offers no persistent always-on-top: activate a tiled window afterwards
+and it can cover the floating one. Floating windows stay reachable with `SUPER`+arrows.
+
 **Windows toe leaves alone**: dialogs, sheets, palettes, minimized and natively-fullscreen
 windows, and anything that refuses a position or size. Add your own exceptions with `[[float]]`
 rules.

--- a/README.md
+++ b/README.md
@@ -139,9 +139,11 @@ drag it out of its tile.
 geometry it had before toe first tiled it — Hyprland's `m_vLastFloatingSize` and
 `m_vLastFloatingPosition` — and after that, wherever you last dragged it. toe writes a floating
 frame only when it actually changes and never re-asserts it, so dragging a floating window is
-never fought the way a tile is. It is raised when you float it and again whenever it is focused,
-but the Accessibility API offers no persistent always-on-top: activate a tiled window afterwards
-and it can cover the floating one. Floating windows stay reachable with `SUPER`+arrows.
+never fought the way a tile is. If the display it was last on has been unplugged, the window is
+centred on the display that remains rather than clamped against an edge. It is raised when you
+float it and again whenever it is focused, but the Accessibility API offers no persistent
+always-on-top: activate a tiled window afterwards and it can cover the floating one. Floating
+windows stay reachable with `SUPER`+arrows.
 
 **Windows toe leaves alone**: dialogs, sheets, palettes, minimized and natively-fullscreen
 windows, and anything that refuses a position or size. Add your own exceptions with `[[float]]`

--- a/Sources/ToeCore/Config/Config.swift
+++ b/Sources/ToeCore/Config/Config.swift
@@ -21,6 +21,18 @@ public struct BarConfig: Equatable {
     public init() {}
 }
 
+/// How big a window is when it leaves the tiling tree.
+public struct FloatingSize: Equatable {
+    /// Fraction of the monitor's usable width and height.
+    public var width: Double = 0.70
+    public var height: Double = 0.80
+    /// Widest the window may be relative to its own height. On an ultrawide, 70% of the
+    /// width is a letterbox; capping the ratio keeps a floating window a shape you would
+    /// have picked by hand, on any display.
+    public var maxAspectRatio: Double = 1.6
+    public init() {}
+}
+
 /// A window that should float instead of joining the dwindle tree.
 public struct FloatRule: Equatable {
     /// Bundle identifier. `*` matches any run of characters.
@@ -63,6 +75,7 @@ public struct Config: Equatable {
     public var dwindle: DwindleOptions = DwindleOptions()
     public var border: BorderConfig = BorderConfig()
     public var bar: BarConfig = BarConfig()
+    public var floating: FloatingSize = FloatingSize()
     public var bindings: [Binding] = []
     public var floatRules: [FloatRule] = Config.defaultFloatRules
     /// Non-fatal problems (a binding that would not parse, an unknown key). Surfaced in the
@@ -130,6 +143,24 @@ public struct Config: Equatable {
                     config.bar.persistentWorkspaces = v
                 } else {
                     config.warnings.append("bar.persistent_workspaces: must be 0 ... \(WorkspaceManager.workspaceCount), using \(config.bar.persistentWorkspaces)")
+                }
+            }
+        }
+
+        if let f = root["floating"]?.tableValue {
+            if let v = f["width"]?.doubleValue {
+                if v > 0, v <= 1 { config.floating.width = v } else {
+                    config.warnings.append("floating.width: must be over 0 and at most 1, using \(config.floating.width)")
+                }
+            }
+            if let v = f["height"]?.doubleValue {
+                if v > 0, v <= 1 { config.floating.height = v } else {
+                    config.warnings.append("floating.height: must be over 0 and at most 1, using \(config.floating.height)")
+                }
+            }
+            if let v = f["max_aspect_ratio"]?.doubleValue {
+                if v > 0 { config.floating.maxAspectRatio = v } else {
+                    config.warnings.append("floating.max_aspect_ratio: must be over 0, using \(config.floating.maxAspectRatio)")
                 }
             }
         }

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -44,6 +44,15 @@ angle        = 45
 # -1 follows the system window corner radius, 0 is square, or set an explicit value.
 radius       = -1
 
+[floating]
+# The size a window gets when SUPER+T lifts it out of the tree — it is always centred, at
+# this fraction of the display, so every floating window is the same shape.
+width  = 0.70
+height = 0.80
+# ...except that no floating window is ever wider than this many times its own height. On a
+# 32:9 ultrawide a plain 70% would be a letterbox; on a laptop this never comes into play.
+max_aspect_ratio = 1.6
+
 [bar]
 # waybar's persistent-workspaces: Omarchy keeps slots 1-5 on the bar even when they are
 # empty, dimmed. 0 shows only the workspaces in use; 10 always shows all ten.

--- a/Sources/ToeCore/Geometry.swift
+++ b/Sources/ToeCore/Geometry.swift
@@ -49,11 +49,13 @@ public struct Box: Equatable, Hashable, Sendable {
         return dx * dx + dy * dy
     }
 
-    /// Whether any part of the two boxes overlap. Used to tell a floating window that has
-    /// merely been dragged near an edge from one whose remembered frame belongs to a display
-    /// that is no longer attached.
-    public func intersects(_ other: Box) -> Bool {
-        minX < other.maxX && maxX > other.minX && minY < other.maxY && maxY > other.minY
+    /// The overlapping region of two boxes, empty when they do not overlap. How much of a
+    /// floating window is actually on its monitor is measured with this.
+    public func intersection(_ other: Box) -> Box {
+        Box(x: max(minX, other.minX),
+            y: max(minY, other.minY),
+            w: min(maxX, other.maxX) - max(minX, other.minX),
+            h: min(maxY, other.maxY) - max(minY, other.minY)).noNegativeSize()
     }
 
     /// Shrink by per-edge insets. Used to apply gaps.

--- a/Sources/ToeCore/Geometry.swift
+++ b/Sources/ToeCore/Geometry.swift
@@ -49,6 +49,13 @@ public struct Box: Equatable, Hashable, Sendable {
         return dx * dx + dy * dy
     }
 
+    /// Whether any part of the two boxes overlap. Used to tell a floating window that has
+    /// merely been dragged near an edge from one whose remembered frame belongs to a display
+    /// that is no longer attached.
+    public func intersects(_ other: Box) -> Bool {
+        minX < other.maxX && maxX > other.minX && minY < other.maxY && maxY > other.minY
+    }
+
     /// Shrink by per-edge insets. Used to apply gaps.
     public func inset(top: Double, left: Double, bottom: Double, right: Double) -> Box {
         Box(x: x + left, y: y + top, w: w - left - right, h: h - top - bottom).noNegativeSize()

--- a/Sources/ToeCore/Layout/WorkspaceManager.swift
+++ b/Sources/ToeCore/Layout/WorkspaceManager.swift
@@ -372,23 +372,25 @@ public final class WorkspaceManager {
     /// window vanish.
     private func floatingBox(for id: WindowID, on monitor: Monitor) -> Box {
         let usable = monitor.usable
-        guard let remembered = floatingFrames[id] else {
-            let w = usable.w / 2.0, h = usable.h / 2.0
-            return Box(x: usable.minX + (usable.w - w) / 2.0,
-                       y: usable.minY + (usable.h - h) / 2.0,
-                       w: w, h: h).rounded()
+        let remembered = floatingFrames[id]
+
+        if let remembered {
+            let onScreen = remembered.intersection(usable)
+            if onScreen.w >= min(Self.minimumOnScreen, remembered.w),
+               onScreen.h >= min(Self.minimumOnScreen, remembered.h) {
+                return remembered
+            }
         }
 
-        let onScreen = remembered.intersection(usable)
-        if onScreen.w >= min(Self.minimumOnScreen, remembered.w),
-           onScreen.h >= min(Self.minimumOnScreen, remembered.h) {
-            return remembered
-        }
-
-        let w = min(remembered.w, usable.w)
-        let h = min(remembered.h, usable.h)
-        return Box(x: clampf(remembered.x, usable.minX, max(usable.minX, usable.maxX - w)),
-                   y: clampf(remembered.y, usable.minY, max(usable.minY, usable.maxY - h)),
+        // Nowhere useful to put it back: a frame remembered on a display that has since been
+        // unplugged, a window left parked in the stash corner, or one that has never floated.
+        // Centre it on the monitor, keeping the size it remembers if it has one. Centring
+        // rather than clamping matters when a display goes away — an edge-clamped window
+        // lands wherever the old geometry happened to point, which is rarely where you left it.
+        let w = min(remembered?.w ?? usable.w / 2.0, usable.w)
+        let h = min(remembered?.h ?? usable.h / 2.0, usable.h)
+        return Box(x: usable.minX + (usable.w - w) / 2.0,
+                   y: usable.minY + (usable.h - h) / 2.0,
                    w: w, h: h).rounded()
     }
 

--- a/Sources/ToeCore/Layout/WorkspaceManager.swift
+++ b/Sources/ToeCore/Layout/WorkspaceManager.swift
@@ -355,12 +355,21 @@ public final class WorkspaceManager {
 
     // MARK: - Rendering
 
+    /// How much of a floating window has to be on its monitor for its remembered frame to be
+    /// taken at face value. Matches the 60pt floor the tracker uses to decide a window is a
+    /// real window at all.
+    private static let minimumOnScreen = 60.0
+
     /// Where a floating window belongs. Hyprland restores `m_vLastFloatingSize` and
     /// `m_vLastFloatingPosition`; `floatingFrames` is that, kept current by the app layer as
-    /// the window is dragged. A frame that no longer touches the monitor at all — remembered
-    /// from a display that has since been unplugged — is pulled back in rather than leaving
-    /// the window stranded off-screen. Anything that still overlaps is left exactly alone, so
-    /// dragging a window half off an edge is not undone on the next render.
+    /// the window is dragged.
+    ///
+    /// A frame is taken as-is only while a usable amount of the window is still on the
+    /// monitor, so dragging one half off an edge is never undone on the next render. Anything
+    /// less is pulled back. Hyprland never has to think about this; toe does, because hiding a
+    /// workspace parks its windows with a single pixel inside the monitor's corner — a frame
+    /// captured from a parked window overlaps by 1×1pt, and handing that back would make the
+    /// window vanish.
     private func floatingBox(for id: WindowID, on monitor: Monitor) -> Box {
         let usable = monitor.usable
         guard let remembered = floatingFrames[id] else {
@@ -369,7 +378,12 @@ public final class WorkspaceManager {
                        y: usable.minY + (usable.h - h) / 2.0,
                        w: w, h: h).rounded()
         }
-        if remembered.intersects(usable) { return remembered }
+
+        let onScreen = remembered.intersection(usable)
+        if onScreen.w >= min(Self.minimumOnScreen, remembered.w),
+           onScreen.h >= min(Self.minimumOnScreen, remembered.h) {
+            return remembered
+        }
 
         let w = min(remembered.w, usable.w)
         let h = min(remembered.h, usable.h)

--- a/Sources/ToeCore/Layout/WorkspaceManager.swift
+++ b/Sources/ToeCore/Layout/WorkspaceManager.swift
@@ -64,6 +64,8 @@ public final class WorkspaceManager {
         didSet { workspaces.values.forEach { $0.layout.options = options; $0.layout.recalculate() } }
     }
     public var gaps: Gaps
+    /// How big a window is when it leaves the tree. See `centredFloatingBox`.
+    public var floatingSize = FloatingSize()
 
     public init(options: DwindleOptions = DwindleOptions(), gaps: Gaps = Gaps()) {
         self.options = options
@@ -201,7 +203,7 @@ public final class WorkspaceManager {
             // window — deriving it every render would drag the window back to the middle of
             // the screen the moment you tried to move it.
             if let m = monitor(id: ws.monitorID) {
-                floatingFrames[id] = centredFloatingBox(for: id, on: m)
+                floatingFrames[id] = centredFloatingBox(on: m)
             }
         }
     }
@@ -379,7 +381,7 @@ public final class WorkspaceManager {
     /// window vanish.
     private func floatingBox(for id: WindowID, on monitor: Monitor) -> Box {
         guard let remembered = floatingFrames[id] else {
-            return centredFloatingBox(for: id, on: monitor)
+            return centredFloatingBox(on: monitor)
         }
 
         let onScreen = remembered.intersection(monitor.usable)
@@ -392,15 +394,16 @@ public final class WorkspaceManager {
         // unplugged, or a window left parked in the stash corner. Centring rather than
         // clamping matters here — an edge-clamped window lands wherever the old geometry
         // happened to point, which on a display that is gone is arbitrary.
-        return centredFloatingBox(for: id, on: monitor)
+        return centredFloatingBox(on: monitor)
     }
 
-    /// Centred on the monitor at the size the window remembers — what it was before toe first
-    /// tiled it, or the last size it floated at — or half the screen with nothing to go on.
-    private func centredFloatingBox(for id: WindowID, on monitor: Monitor) -> Box {
+    /// Centred on the monitor at a consistent fraction of it, so a floating window is the
+    /// same shape whichever window it came from. The aspect cap is what keeps that honest on
+    /// a wide display, where a plain width fraction would produce a letterbox.
+    private func centredFloatingBox(on monitor: Monitor) -> Box {
         let usable = monitor.usable
-        let w = min(floatingFrames[id]?.w ?? usable.w / 2.0, usable.w)
-        let h = min(floatingFrames[id]?.h ?? usable.h / 2.0, usable.h)
+        let h = min(usable.h * floatingSize.height, usable.h)
+        let w = min(usable.w * floatingSize.width, usable.w, h * floatingSize.maxAspectRatio)
         return Box(x: usable.minX + (usable.w - w) / 2.0,
                    y: usable.minY + (usable.h - h) / 2.0,
                    w: w, h: h).rounded()

--- a/Sources/ToeCore/Layout/WorkspaceManager.swift
+++ b/Sources/ToeCore/Layout/WorkspaceManager.swift
@@ -4,9 +4,10 @@ import Foundation
 public struct RenderPlan: Equatable {
     /// Tiled windows on a visible workspace and the frame each should occupy (gaps applied).
     public var frames: [WindowID: Box] = [:]
-    /// Windows belonging to a visible workspace that we do not tile (floating). The app layer
-    /// restores their remembered frame.
-    public var restored: Set<WindowID> = []
+    /// Floating windows on a visible workspace and the frame each should occupy. Unlike
+    /// `frames`, the app layer writes these once when they change and never re-asserts them —
+    /// a floating window belongs to whoever is dragging it.
+    public var floating: [WindowID: Box] = [:]
     /// Windows on a hidden workspace. The app layer parks these off-screen.
     public var stashed: Set<WindowID> = []
     /// The window that should hold focus, if it changed.
@@ -220,14 +221,17 @@ public final class WorkspaceManager {
               let ws = workspaces[index],
               let origin = ws.layout.idealBox(of: source) ?? floatingFrames[source]
         else { return nil }
-        _ = ws
 
-        // Candidates: every tiled window on a *visible* workspace. Hyprland's
+        // Candidates: every window on a *visible* workspace, floating ones included — a
+        // floated window you cannot focus again is a window you have lost. Hyprland's
         // `window_direction_monitor_fallback` defaults to true, so focus crosses monitors.
         var candidates: [(id: WindowID, box: Box)] = []
         for wsIndex in visibleWorkspaceIndices {
             guard let w = workspaces[wsIndex] else { continue }
             candidates.append(contentsOf: w.layout.idealBoxes())
+            for id in w.floating {
+                if let box = floatingFrames[id] { candidates.append((id: id, box: box)) }
+            }
         }
 
         return DirectionalSearch.windowInDirection(
@@ -351,6 +355,29 @@ public final class WorkspaceManager {
 
     // MARK: - Rendering
 
+    /// Where a floating window belongs. Hyprland restores `m_vLastFloatingSize` and
+    /// `m_vLastFloatingPosition`; `floatingFrames` is that, kept current by the app layer as
+    /// the window is dragged. A frame that no longer touches the monitor at all — remembered
+    /// from a display that has since been unplugged — is pulled back in rather than leaving
+    /// the window stranded off-screen. Anything that still overlaps is left exactly alone, so
+    /// dragging a window half off an edge is not undone on the next render.
+    private func floatingBox(for id: WindowID, on monitor: Monitor) -> Box {
+        let usable = monitor.usable
+        guard let remembered = floatingFrames[id] else {
+            let w = usable.w / 2.0, h = usable.h / 2.0
+            return Box(x: usable.minX + (usable.w - w) / 2.0,
+                       y: usable.minY + (usable.h - h) / 2.0,
+                       w: w, h: h).rounded()
+        }
+        if remembered.intersects(usable) { return remembered }
+
+        let w = min(remembered.w, usable.w)
+        let h = min(remembered.h, usable.h)
+        return Box(x: clampf(remembered.x, usable.minX, max(usable.minX, usable.maxX - w)),
+                   y: clampf(remembered.y, usable.minY, max(usable.minY, usable.maxY - h)),
+                   w: w, h: h).rounded()
+    }
+
     public func render() -> RenderPlan {
         var plan = RenderPlan()
         let visibleIndices = visibleWorkspaceIndices
@@ -362,7 +389,9 @@ public final class WorkspaceManager {
                     ws.layout.recalculate()
                 }
                 for (id, box) in ws.layout.frames(gaps: gaps) { plan.frames[id] = box }
-                plan.restored.formUnion(ws.floating)
+                if let m = monitor(id: ws.monitorID) {
+                    for id in ws.floating { plan.floating[id] = floatingBox(for: id, on: m) }
+                }
             } else {
                 plan.stashed.formUnion(ws.windows)
             }

--- a/Sources/ToeCore/Layout/WorkspaceManager.swift
+++ b/Sources/ToeCore/Layout/WorkspaceManager.swift
@@ -196,6 +196,13 @@ public final class WorkspaceManager {
         } else {
             ws.layout.remove(id)
             ws.floating.insert(id)
+            // A window leaving the tree is centred, at the size it remembers. This is set here
+            // rather than derived in `floatingBox` so that it happens once, when you float the
+            // window — deriving it every render would drag the window back to the middle of
+            // the screen the moment you tried to move it.
+            if let m = monitor(id: ws.monitorID) {
+                floatingFrames[id] = centredFloatingBox(for: id, on: m)
+            }
         }
     }
 
@@ -371,24 +378,29 @@ public final class WorkspaceManager {
     /// captured from a parked window overlaps by 1×1pt, and handing that back would make the
     /// window vanish.
     private func floatingBox(for id: WindowID, on monitor: Monitor) -> Box {
-        let usable = monitor.usable
-        let remembered = floatingFrames[id]
+        guard let remembered = floatingFrames[id] else {
+            return centredFloatingBox(for: id, on: monitor)
+        }
 
-        if let remembered {
-            let onScreen = remembered.intersection(usable)
-            if onScreen.w >= min(Self.minimumOnScreen, remembered.w),
-               onScreen.h >= min(Self.minimumOnScreen, remembered.h) {
-                return remembered
-            }
+        let onScreen = remembered.intersection(monitor.usable)
+        if onScreen.w >= min(Self.minimumOnScreen, remembered.w),
+           onScreen.h >= min(Self.minimumOnScreen, remembered.h) {
+            return remembered
         }
 
         // Nowhere useful to put it back: a frame remembered on a display that has since been
-        // unplugged, a window left parked in the stash corner, or one that has never floated.
-        // Centre it on the monitor, keeping the size it remembers if it has one. Centring
-        // rather than clamping matters when a display goes away — an edge-clamped window
-        // lands wherever the old geometry happened to point, which is rarely where you left it.
-        let w = min(remembered?.w ?? usable.w / 2.0, usable.w)
-        let h = min(remembered?.h ?? usable.h / 2.0, usable.h)
+        // unplugged, or a window left parked in the stash corner. Centring rather than
+        // clamping matters here — an edge-clamped window lands wherever the old geometry
+        // happened to point, which on a display that is gone is arbitrary.
+        return centredFloatingBox(for: id, on: monitor)
+    }
+
+    /// Centred on the monitor at the size the window remembers — what it was before toe first
+    /// tiled it, or the last size it floated at — or half the screen with nothing to go on.
+    private func centredFloatingBox(for id: WindowID, on monitor: Monitor) -> Box {
+        let usable = monitor.usable
+        let w = min(floatingFrames[id]?.w ?? usable.w / 2.0, usable.w)
+        let h = min(floatingFrames[id]?.h ?? usable.h / 2.0, usable.h)
         return Box(x: usable.minX + (usable.w - w) / 2.0,
                    y: usable.minY + (usable.h - h) / 2.0,
                    w: w, h: h).rounded()

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -331,6 +331,71 @@ h.test("a floating focus falls back to the window under the pointer") { t in
     t.equalBox(l.idealBox(of: 3), box(756, 491, 756, 491), "w3 untouched")
 }
 
+// MARK: - Floating
+
+h.test("toggling a window out of the tree and back") { t in
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
+    wm.addWindow(1); wm.addWindow(2)
+    wm.floatingFrames[2] = box(200, 150, 640, 400)   // seeded at adopt time by the app layer
+
+    wm.noteFocus(2)
+    wm.toggleFloating(2)
+    t.equal(wm.isFloating(2), true, "w2 floats")
+    t.equal(wm.workspaces[1]?.layout.contains(2), false, "and has left the tree")
+    t.equalBox(wm.workspaces[1]?.layout.idealBox(of: 1), AREA, "w1 absorbs the whole area")
+    t.equalBox(wm.render().floating[2], box(200, 150, 640, 400), "its remembered frame is rendered")
+
+    wm.toggleFloating(2)
+    t.equal(wm.isFloating(2), false, "w2 is tiled again")
+    t.equalBox(wm.workspaces[1]?.layout.idealBox(of: 1), box(0, 0, 756, 982), "w1 back to the left half")
+    t.equalBox(wm.workspaces[1]?.layout.idealBox(of: 2), box(756, 0, 756, 982), "w2 back to the right half")
+    t.equal(wm.render().floating.isEmpty, true, "nothing floats any more")
+}
+
+h.test("a floating frame is left alone unless it is stranded") { t in
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
+    wm.addWindow(1, floating: true)
+
+    wm.floatingFrames[1] = box(-40, 900, 600, 400)
+    t.equalBox(wm.render().floating[1], box(-40, 900, 600, 400),
+               "dragged half off an edge: not undone on the next render")
+
+    wm.floatingFrames[1] = box(2000, 1400, 800, 600)   // remembered on a display since unplugged
+    t.equalBox(wm.render().floating[1], box(712, 382, 800, 600), "pulled back into the usable area")
+
+    wm.floatingFrames.removeValue(forKey: 1)
+    t.equalBox(wm.render().floating[1], box(378, 246, 756, 491), "nothing remembered: centred, half size")
+}
+
+h.test("movefocus reaches a floating window") { t in
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
+    wm.addWindow(1); wm.addWindow(2)                 // left half / right half
+    wm.addWindow(3, floating: true)
+    wm.floatingFrames[3] = box(756, 0, 400, 300)     // over w2, sharing w1's right edge
+    wm.noteFocus(1)
+
+    t.equal(wm.windowInDirection(.right), 3,
+            "w2 and the floating w3 both abut w1; the more recently focused w3 wins")
+    t.equal(wm.windowInDirection(.left, from: 3), 1, "and it hands focus back")
+}
+
+h.test("a floating window keeps its frame across a workspace round trip") { t in
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
+    wm.addWindow(1, floating: true)
+    wm.floatingFrames[1] = box(300, 200, 500, 400)
+
+    wm.switchTo(workspace: 2)
+    t.equal(wm.render().stashed, [1], "hidden workspace: w1 is stashed")
+    t.equal(wm.render().floating.isEmpty, true, "and not rendered as floating")
+
+    wm.switchTo(workspace: 1)
+    t.equalBox(wm.render().floating[1], box(300, 200, 500, 400), "comes back exactly where it was")
+}
+
 h.test("swapwindow across monitors trades slots, keeping both layouts") { t in
     let left = box(0, 0, 1512, 982)
     let right = box(1512, 0, 1920, 1080)
@@ -408,6 +473,14 @@ h.test("the shipped default config parses cleanly") { t in
     t.equal(binding("super-shift-0")?.command, .moveToWorkspace(10, follow: true), "SUPER+SHIFT+0")
     t.equal(binding("super-w")?.command, .killActive, "SUPER+W closes")
     t.equal(binding("super-tab")?.command, .workspace(.next), "SUPER+TAB")
+
+    // SUPER+T is not a shipped default — it is a local-config binding, so assert the parser
+    // rather than the default table.
+    let (mods, code, key) = try BindingParser.parse("super-t", superKey: .option)
+    t.equal(mods, Modifiers.option, "super-t: SUPER resolves to Option")
+    t.equal(code, 0x11, "super-t: T key code")
+    t.equal(key, "t", "super-t: key name")
+    t.equal(try CommandParser.parse("togglefloating"), .toggleFloating, "togglefloating dispatcher")
 
     let arrows = ["super-left", "super-right", "super-up", "super-down"]
     t.equal(arrows.allSatisfy { binding($0) != nil }, true, "all four focus arrows bound")

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -344,7 +344,12 @@ h.test("toggling a window out of the tree and back") { t in
     t.equal(wm.isFloating(2), true, "w2 floats")
     t.equal(wm.workspaces[1]?.layout.contains(2), false, "and has left the tree")
     t.equalBox(wm.workspaces[1]?.layout.idealBox(of: 1), AREA, "w1 absorbs the whole area")
-    t.equalBox(wm.render().floating[2], box(200, 150, 640, 400), "its remembered frame is rendered")
+    t.equalBox(wm.render().floating[2], box(436, 291, 640, 400),
+               "centred on the monitor, at the size it remembers")
+
+    wm.floatingFrames[2] = box(40, 40, 640, 400)   // dragged into the corner by hand
+    t.equalBox(wm.render().floating[2], box(40, 40, 640, 400),
+               "a drag is not pulled back to the centre on the next render")
 
     wm.toggleFloating(2)
     t.equal(wm.isFloating(2), false, "w2 is tiled again")

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -363,17 +363,35 @@ h.test("a floating frame is left alone unless it is stranded") { t in
                "dragged half off an edge: not undone on the next render")
 
     wm.floatingFrames[1] = box(2000, 1400, 800, 600)   // remembered on a display since unplugged
-    t.equalBox(wm.render().floating[1], box(712, 382, 800, 600), "pulled back into the usable area")
+    t.equalBox(wm.render().floating[1], box(356, 191, 800, 600), "centred, at the size it remembers")
 
     // Hiding a workspace parks a window one pixel inside the monitor's corner. Adopting a
     // window that was left parked — toe killed rather than quit — captures that as its
     // floating frame, and handing it straight back would make the window vanish.
     wm.floatingFrames[1] = box(1511, 981, 800, 600)
-    t.equalBox(wm.render().floating[1], box(712, 382, 800, 600),
+    t.equalBox(wm.render().floating[1], box(356, 191, 800, 600),
                "a 1pt sliver on screen is not enough to take a frame at face value")
 
     wm.floatingFrames.removeValue(forKey: 1)
-    t.equalBox(wm.render().floating[1], box(378, 246, 756, 491), "nothing remembered: centred, half size")
+    t.equalBox(wm.render().floating[1], box(378, 246, 756, 491), "nothing remembered: centred, half the screen")
+}
+
+h.test("a floating window is centred when its display is disconnected") { t in
+    let left = box(0, 0, 1512, 982)
+    let right = box(1512, 0, 1920, 1080)
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: left, usable: left),
+                    Monitor(id: 2, frame: right, usable: right)])
+
+    wm.addWindow(1, floating: true)                   // workspace 1, on the left display
+    wm.floatingFrames[1] = box(300, 200, 800, 600)
+    t.equalBox(wm.render().floating[1], box(300, 200, 800, 600), "left exactly where it was put")
+
+    // The left display is unplugged. Workspace 1 re-homes to what is left of the desk.
+    wm.setMonitors([Monitor(id: 2, frame: right, usable: right)])
+    wm.switchTo(workspace: 1)
+    t.equalBox(wm.render().floating[1], box(2072, 240, 800, 600),
+               "centred on the remaining display, keeping the size it remembers")
 }
 
 h.test("movefocus reaches a floating window") { t in

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -365,6 +365,13 @@ h.test("a floating frame is left alone unless it is stranded") { t in
     wm.floatingFrames[1] = box(2000, 1400, 800, 600)   // remembered on a display since unplugged
     t.equalBox(wm.render().floating[1], box(712, 382, 800, 600), "pulled back into the usable area")
 
+    // Hiding a workspace parks a window one pixel inside the monitor's corner. Adopting a
+    // window that was left parked — toe killed rather than quit — captures that as its
+    // floating frame, and handing it straight back would make the window vanish.
+    wm.floatingFrames[1] = box(1511, 981, 800, 600)
+    t.equalBox(wm.render().floating[1], box(712, 382, 800, 600),
+               "a 1pt sliver on screen is not enough to take a frame at face value")
+
     wm.floatingFrames.removeValue(forKey: 1)
     t.equalBox(wm.render().floating[1], box(378, 246, 756, 491), "nothing remembered: centred, half size")
 }

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -344,8 +344,8 @@ h.test("toggling a window out of the tree and back") { t in
     t.equal(wm.isFloating(2), true, "w2 floats")
     t.equal(wm.workspaces[1]?.layout.contains(2), false, "and has left the tree")
     t.equalBox(wm.workspaces[1]?.layout.idealBox(of: 1), AREA, "w1 absorbs the whole area")
-    t.equalBox(wm.render().floating[2], box(436, 291, 640, 400),
-               "centred on the monitor, at the size it remembers")
+    t.equalBox(wm.render().floating[2], box(227, 98, 1058, 786),
+               "centred, 70% wide by 80% tall — the same box whichever window it came from")
 
     wm.floatingFrames[2] = box(40, 40, 640, 400)   // dragged into the corner by hand
     t.equalBox(wm.render().floating[2], box(40, 40, 640, 400),
@@ -368,17 +368,17 @@ h.test("a floating frame is left alone unless it is stranded") { t in
                "dragged half off an edge: not undone on the next render")
 
     wm.floatingFrames[1] = box(2000, 1400, 800, 600)   // remembered on a display since unplugged
-    t.equalBox(wm.render().floating[1], box(356, 191, 800, 600), "centred, at the size it remembers")
+    t.equalBox(wm.render().floating[1], box(227, 98, 1058, 786), "centred at the standard floating size")
 
     // Hiding a workspace parks a window one pixel inside the monitor's corner. Adopting a
     // window that was left parked — toe killed rather than quit — captures that as its
     // floating frame, and handing it straight back would make the window vanish.
     wm.floatingFrames[1] = box(1511, 981, 800, 600)
-    t.equalBox(wm.render().floating[1], box(356, 191, 800, 600),
+    t.equalBox(wm.render().floating[1], box(227, 98, 1058, 786),
                "a 1pt sliver on screen is not enough to take a frame at face value")
 
     wm.floatingFrames.removeValue(forKey: 1)
-    t.equalBox(wm.render().floating[1], box(378, 246, 756, 491), "nothing remembered: centred, half the screen")
+    t.equalBox(wm.render().floating[1], box(227, 98, 1058, 786), "nothing remembered: the same centred box")
 }
 
 h.test("a floating window is centred when its display is disconnected") { t in
@@ -395,8 +395,27 @@ h.test("a floating window is centred when its display is disconnected") { t in
     // The left display is unplugged. Workspace 1 re-homes to what is left of the desk.
     wm.setMonitors([Monitor(id: 2, frame: right, usable: right)])
     wm.switchTo(workspace: 1)
-    t.equalBox(wm.render().floating[1], box(2072, 240, 800, 600),
-               "centred on the remaining display, keeping the size it remembers")
+    t.equalBox(wm.render().floating[1], box(1800, 108, 1344, 864),
+               "centred on the remaining display, sized to it")
+}
+
+h.test("a floating window is not a letterbox on an ultrawide") { t in
+    let wide = box(0, 0, 5120, 1410)
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: wide, usable: wide)])
+    wm.addWindow(1); wm.addWindow(2)
+    wm.noteFocus(2)
+    wm.toggleFloating(2)
+
+    // 80% of 1410 is 1128 tall. A plain 70% of 5120 would be 3584 wide — instead the window
+    // stops at 1.6 times its own height.
+    t.equalBox(wm.render().floating[2], box(1658, 141, 1805, 1128),
+               "width capped by max_aspect_ratio, still centred")
+
+    wm.floatingSize.maxAspectRatio = 100                 // effectively uncapped
+    wm.noteFocus(2)
+    wm.toggleFloating(2); wm.toggleFloating(2)           // re-float to re-centre
+    t.equalBox(wm.render().floating[2], box(768, 141, 3584, 1128), "uncapped, it is the full 70%")
 }
 
 h.test("movefocus reaches a floating window") { t in
@@ -492,6 +511,9 @@ h.test("the shipped default config parses cleanly") { t in
     t.equal(c.border.activeStart, "#33ccffee", "Omarchy active border gradient start")
     t.equal(c.border.radius, -1, "radius follows the system window corner radius")
     t.equal(c.floatRules.count, 5, "float rules")
+    t.equal(c.floating.width, 0.70, "floating width fraction")
+    t.equal(c.floating.height, 0.80, "floating height fraction")
+    t.equal(c.floating.maxAspectRatio, 1.6, "floating max aspect ratio")
 
     func binding(_ spec: String) -> Binding? { c.bindings.first { $0.source == spec } }
 

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -149,6 +149,7 @@ final class Coordinator: WindowTrackerDelegate {
 
         workspaces.options = newConfig.dwindle
         workspaces.gaps = newConfig.gaps
+        workspaces.floatingSize = newConfig.floating
         tracker.floatRules = newConfig.floatRules
         border.apply(newConfig.border)
         status.persistentWorkspaces = newConfig.bar.persistentWorkspaces

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -207,9 +207,10 @@ final class Coordinator: WindowTrackerDelegate {
     // MARK: - WindowTrackerDelegate
 
     func windowAppeared(_ window: ManagedWindow, shouldFloat: Bool) {
-        if shouldFloat {
-            workspaces.floatingFrames[window.id] = window.element.frame
-        }
+        // Adopt time is the only moment a window's own geometry is known — the first tile
+        // write clobbers it. This is Hyprland's `m_vLastFloatingSize` / `..Position`, and it
+        // is what a window returns to the first time you float it.
+        workspaces.floatingFrames[window.id] = window.element.frame
         workspaces.addWindow(window.id, floating: shouldFloat)
         apply(refocus: false)
         refreshStatus()
@@ -246,9 +247,7 @@ final class Coordinator: WindowTrackerDelegate {
         }
 
         guard let want = desired[id], let have = window.element.frame else { return }
-        let settled = abs(have.x - want.x) < 2 && abs(have.y - want.y) < 2
-            && abs(have.w - want.w) < 2 && abs(have.h - want.h) < 2
-        if settled {
+        if Self.settled(have, want) {
             corrections[id] = 0
             if id == workspaces.focusedWindow { updateBorder() }
             return
@@ -259,6 +258,12 @@ final class Coordinator: WindowTrackerDelegate {
         corrections[id] = attempts + 1
         WindowMover.setFrame(want, element: window.element, pid: window.pid)
         if id == workspaces.focusedWindow { updateBorder() }
+    }
+
+    /// Apps round and clamp the frames they are given; two frames within 2pt of each other are
+    /// the same frame as far as toe is concerned.
+    private static func settled(_ a: Box, _ b: Box) -> Bool {
+        abs(a.x - b.x) < 2 && abs(a.y - b.y) < 2 && abs(a.w - b.w) < 2 && abs(a.h - b.h) < 2
     }
 
     func screensChanged() {
@@ -278,16 +283,20 @@ final class Coordinator: WindowTrackerDelegate {
             window.frameBeforeStash = window.element.frame
             window.isStashed = true
             desired.removeValue(forKey: id)
-        corrections.removeValue(forKey: id)
+            corrections.removeValue(forKey: id)
             WindowMover.setPosition(stashPoint(for: window), element: window.element, pid: window.pid)
         }
 
-        for id in plan.restored {
-            guard let window = tracker.window(id), window.isStashed else { continue }
+        // Floating frames deliberately bypass `desired` / `corrections`: that machinery exists
+        // to re-assert a tile against an app that fights it, and pointing it at a floating
+        // window would fight the user's own drags instead. Writing only on a real difference
+        // makes this a no-op on every render but the one that changed something — floating a
+        // window, bringing its workspace back, or losing the display it was remembered on.
+        for (id, box) in plan.floating {
+            guard let window = tracker.window(id) else { continue }
             window.isStashed = false
-            if let frame = window.frameBeforeStash {
-                WindowMover.setFrame(frame, element: window.element, pid: window.pid)
-            }
+            if let have = window.element.frame, Self.settled(have, box) { continue }
+            WindowMover.setFrame(box, element: window.element, pid: window.pid)
         }
 
         for (id, box) in plan.frames {
@@ -376,13 +385,16 @@ final class Coordinator: WindowTrackerDelegate {
 
         case .toggleFloating:
             guard let id = workspaces.focusedWindow else { return }
-            if !workspaces.isFloating(id), let window = tracker.window(id) {
-                workspaces.floatingFrames[id] = window.frameBeforeStash ?? window.element.frame
-            }
             workspaces.toggleFloating(id)
             desired.removeValue(forKey: id)
-        corrections.removeValue(forKey: id)
+            corrections.removeValue(forKey: id)
             apply(refocus: false)
+            // A floating window belongs above the tiles. AX has no persistent always-on-top,
+            // so raise it now; focusing it later raises it again.
+            if workspaces.isFloating(id), let window = tracker.window(id) {
+                WindowMover.focus(window)
+                focusApplied = id
+            }
 
         case .toggleSplit:
             guard let id = workspaces.focusedWindow,

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -24,6 +24,7 @@ final class Coordinator: WindowTrackerDelegate {
     /// than fought with forever.
     private var corrections: [WindowID: Int] = [:]
     private var focusApplied: WindowID?
+    private var signalSources: [any DispatchSourceSignal] = []
 
     // MARK: - Start-up
 
@@ -50,6 +51,7 @@ final class Coordinator: WindowTrackerDelegate {
             NSApp.terminate(nil)
         }
 
+        installSignalHandlers()
         writeDefaultConfigIfMissing()
         loadConfig()
 
@@ -66,6 +68,23 @@ final class Coordinator: WindowTrackerDelegate {
             return
         }
         beginManaging()
+    }
+
+    /// `make run` restarts toe with `pkill`, and SIGTERM's default action would leave a hidden
+    /// workspace's windows parked in the stash corner. The next launch then adopts them there
+    /// and records that corner as the frame to float them back to — so a window you floated
+    /// would disappear. Unstash before going away, exactly as the Quit menu item does.
+    private func installSignalHandlers() {
+        for number in [SIGTERM, SIGINT] {
+            signal(number, SIG_IGN)
+            let source = DispatchSource.makeSignalSource(signal: number, queue: .main)
+            source.setEventHandler { [weak self] in
+                self?.unstashEverything()
+                exit(0)
+            }
+            source.resume()
+            signalSources.append(source)
+        }
     }
 
     /// toe is useless without Accessibility, but it should not die either — it keeps its menu

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -37,6 +37,15 @@ angle        = 45
 # -1 follows the system window corner radius, 0 is square, or set an explicit value.
 radius       = -1
 
+[floating]
+# The size a window gets when SUPER+T lifts it out of the tree — it is always centred, at
+# this fraction of the display, so every floating window is the same shape.
+width  = 0.70
+height = 0.80
+# ...except that no floating window is ever wider than this many times its own height. On a
+# 32:9 ultrawide a plain 70% would be a letterbox; on a laptop this never comes into play.
+max_aspect_ratio = 1.6
+
 [bar]
 # waybar's persistent-workspaces: Omarchy keeps slots 1-5 on the bar even when they are
 # empty, dimmed. 0 shows only the workspaces in use; 10 always shows all ten.


### PR DESCRIPTION
## Context

Asked what full support for `SUPER+T` — toggle tiling — would take. The dispatcher already existed (`togglefloating`), so it looked like a one-line config change. It wasn't: **the float half of the toggle was effectively unimplemented.**

`WorkspaceManager.render()` collected floating windows into `plan.restored`, and `Coordinator.apply()` skipped every entry that failed `window.isStashed`. A window you floated therefore got **no frame written at all** — it sat at its old tile geometry, overlapping the siblings that had just grown into its space, and `movefocus` could never select it again.

## Floating windows get a frame

- **`RenderPlan.restored` → `floating: [WindowID: Box]`**, resolved by `WorkspaceManager.floatingBox(for:on:)`. A remembered frame is taken at face value only while a usable amount of the window is still on the monitor, so dragging one half off an edge is never undone on the next render.
- **Those frames bypass `desired` / `corrections`**, and are written only on a real difference. That machinery exists to re-assert a tile against an app that fights it; aimed at a floating window it would fight the user's own drags instead. The 2pt tolerance moved into `Coordinator.settled(_:_:)`, shared with `windowFrameChangedExternally`.
- **`windowInDirection` includes floating windows** as candidates, so `SUPER`+arrows still reach them. The most-recently-focused tie-break composes unchanged.
- **Floating raises the window.** AX offers no persistent always-on-top, so it raises on float and again on focus — documented in the README's design notes.

## A window could vanish when you floated it

Hiding a workspace parks its windows with a single pixel inside the monitor's corner — deliberately, so AppKit's `constrainFrameRect` doesn't drag them back. `make run` restarts toe with `pkill`, and SIGTERM skipped `unstashEverything()`, which only ran from the Quit menu item. The next launch adopted those windows where it found them and recorded the corner as the frame to float them back to.

The guard against this used `Box.intersects`, which the stash position passes — it overlaps the usable area by exactly 1×1pt. Replaced with `Box.intersection` plus a 60pt floor on how much of the window has to be on screen, and **SIGTERM/SIGINT now unstash**, so the stale frames stop being created at all.

## Floating is centred, at a consistent size

Returning a window to the geometry it had before toe first tiled it meant floating looked arbitrary — one window filled the screen, the next was a sliver, depending only on how the app opened. A floating window is now **centred at 70% × 80% of the display**, so it is the same shape whichever window it came from.

A width fraction alone doesn't survive an ultrawide, where 70% of 32:9 is a letterbox, so no floating window is ever wider than **1.6× its own height** — 1805×1128 on a 5120-wide desk, and a cap that never binds on a laptop. All three are `[floating]` config keys.

The size is set in `toggleFloating`, when the window leaves the tree, rather than derived in `floatingBox` every render — deriving it per-frame would drag the window back to the middle the moment you tried to move it. There's a test pinning exactly that.

If the display a floating window was last on is unplugged, it is centred on the display that remains rather than clamped against an edge, where it would land wherever the old geometry happened to point.

## Tests

`make test` — **209 assertions**, 19 new:

- tile → float → tile round trip, and a drag that survives the next render
- centred at 70×80; the ultrawide aspect cap, and the full 70% once uncapped
- a stranded frame and a stash-corner sliver are both re-centred
- a floating window is centred on the remaining display when its own is disconnected
- `movefocus` reaches a floating window and it hands focus back
- a floating window keeps its frame across a workspace stash/un-stash round trip
- `super-t` parses to `.toggleFloating`, and the `[floating]` config defaults

## Not in this PR

`SUPER+T` itself is a local-config binding — the shipped defaults still bind `togglefloating` to `SUPER+SHIFT+V`, and the README bindings table is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXaoo2FCM1oXYLqUFrz9aL