### PR TITLE
Activate without the deprecated ignoringOtherApps option

### DIFF
--- a/Sources/toe/AX/WindowMover.swift
+++ b/Sources/toe/AX/WindowMover.swift
@@ -42,8 +42,7 @@ enum WindowMover {
         window.element.set(kAXMainAttribute, kCFBooleanTrue)
         window.element.set(kAXFocusedAttribute, kCFBooleanTrue)
         AXUIElementPerformAction(window.element, kAXRaiseAction as CFString)
-        NSRunningApplication(processIdentifier: window.pid)?
-            .activate(options: [.activateIgnoringOtherApps])
+        NSRunningApplication(processIdentifier: window.pid)?.activate()
     }
 
     static func close(_ window: ManagedWindow) {


### PR DESCRIPTION
`activateIgnoringOtherApps` has been deprecated since macOS 14 and has no effect there, so on toe's macOS 14 deployment target the option bought us nothing but a release-build warning:

```
Sources/toe/AX/WindowMover.swift:46:34: warning: 'activateIgnoringOtherApps' was deprecated in macOS 14.0
```

`WindowMover.focus` now calls the bare `activate()`, which does the same job. `swift build -c release` is warning-free again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dPjXVbQ77tW3z47uVrWPY