### PR TITLE
Keep Omarchy's five persistent workspaces on the bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,18 @@ at `~/.config/toe/toe.toml`.
 ## The menu bar
 
 The status item is the workspace strip, styled the way Omarchy's waybar styles it: the
-workspace you are on is a filled rounded square rather than a number, every other occupied
-workspace is its own digit, and workspace 10 shows as `0`. An empty workspace appears only
-while you are on it, dimmed. With several displays, a workspace showing on one you are not
-focused on gets the same square, outlined.
+workspace you are on is a filled rounded square rather than a number, every other workspace
+is its own digit, and workspace 10 shows as `0`. Workspaces 1-5 always have a slot — that is
+waybar's `persistent-workspaces` — dimmed while they are empty; past those, a workspace shows
+up only once it has windows on it. With several displays, a workspace showing on one you are
+not focused on gets the same square, outlined.
 
 ```
-▪ 3 7
+▪ 2 3 4 5 7
 ```
+
+`[bar] persistent_workspaces` sets how many keep a slot: `0` shows only the ones in use, `10`
+always shows all ten.
 
 Clicking a workspace switches to it, as Omarchy's `on-click: activate` does. Right-click —
 or left-click the padding at either end — to open the menu, which breaks each workspace down

--- a/Sources/ToeCore/Config/Config.swift
+++ b/Sources/ToeCore/Config/Config.swift
@@ -13,6 +13,14 @@ public struct BorderConfig: Equatable {
     public init() {}
 }
 
+/// The menu bar's workspace strip.
+public struct BarConfig: Equatable {
+    /// waybar's `persistent-workspaces`: how many workspaces keep a slot whether or not
+    /// anything is on them. 0 shows only the ones in use.
+    public var persistentWorkspaces: Int = WorkspaceStrip.defaultPersistent
+    public init() {}
+}
+
 /// A window that should float instead of joining the dwindle tree.
 public struct FloatRule: Equatable {
     /// Bundle identifier. `*` matches any run of characters.
@@ -54,6 +62,7 @@ public struct Config: Equatable {
     public var gaps: Gaps = Gaps(inner: 5, outer: 10)
     public var dwindle: DwindleOptions = DwindleOptions()
     public var border: BorderConfig = BorderConfig()
+    public var bar: BarConfig = BarConfig()
     public var bindings: [Binding] = []
     public var floatRules: [FloatRule] = Config.defaultFloatRules
     /// Non-fatal problems (a binding that would not parse, an unknown key). Surfaced in the
@@ -112,6 +121,17 @@ public struct Config: Equatable {
             if let v = b["active_end"]?.stringValue { config.border.activeEnd = v }
             if let v = b["angle"]?.doubleValue { config.border.angle = v }
             if let v = b["radius"]?.doubleValue { config.border.radius = v }
+        }
+
+        if let b = root["bar"]?.tableValue {
+            if let v = b["persistent_workspaces"]?.intValue {
+                let allowed = 0...WorkspaceManager.workspaceCount
+                if allowed.contains(v) {
+                    config.bar.persistentWorkspaces = v
+                } else {
+                    config.warnings.append("bar.persistent_workspaces: must be 0 ... \(WorkspaceManager.workspaceCount), using \(config.bar.persistentWorkspaces)")
+                }
+            }
         }
 
         if let binds = root["binds"]?.tableValue {

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -44,6 +44,11 @@ angle        = 45
 # -1 follows the system window corner radius, 0 is square, or set an explicit value.
 radius       = -1
 
+[bar]
+# waybar's persistent-workspaces: Omarchy keeps slots 1-5 on the bar even when they are
+# empty, dimmed. 0 shows only the workspaces in use; 10 always shows all ten.
+persistent_workspaces = 5
+
 [binds]
 # ── Focus — SUPER + arrows ────────────────────────────────────────────────────
 "super-left"  = "movefocus l"

--- a/Sources/ToeCore/WorkspaceStrip.swift
+++ b/Sources/ToeCore/WorkspaceStrip.swift
@@ -9,6 +9,10 @@ import Foundation
 /// lands on one. `StatusItem` draws the result.
 public enum WorkspaceStrip {
 
+    /// Omarchy's waybar declares `persistent-workspaces` 1-5, so those five keep a slot on
+    /// the bar whether or not anything is on them.
+    public static let defaultPersistent = 5
+
     /// What the strip needs to know about one workspace.
     public struct State: Equatable {
         public let index: Int
@@ -47,10 +51,13 @@ public enum WorkspaceStrip {
         public let dim: Bool
     }
 
-    /// A workspace earns a slot by having windows on it, or by being on screen right now —
-    /// so the strip stays as short as what you are actually using.
-    public static func items(for states: [State]) -> [Item] {
-        states.filter { !$0.isEmpty || $0.isVisible }.map { state in
+    /// A workspace earns a slot by being one of the first `persistent` — Omarchy's
+    /// `persistent-workspaces` — or by having windows on it, or by being on screen right
+    /// now. So the first five are always there, and past those the strip stays as short as
+    /// what you are actually using.
+    public static func items(for states: [State],
+                             persistent: Int = defaultPersistent) -> [Item] {
+        states.filter { $0.index <= persistent || !$0.isEmpty || $0.isVisible }.map { state in
             Item(index: state.index,
                  label: state.index == 10 ? "0" : "\(state.index)",
                  marker: state.isFocused ? .focused : (state.isVisible ? .visible : .digit),

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -391,6 +391,7 @@ h.test("the shipped default config parses cleanly") { t in
     t.equal(c.warnings, [], "no warnings")
     t.equal(c.superKey, Modifiers.option, "SUPER is Option")
     t.equal(c.gaps, Gaps(inner: 5, outer: 10), "Omarchy gaps")
+    t.equal(c.bar.persistentWorkspaces, 5, "Omarchy's persistent-workspaces 1-5")
     t.equal(c.dwindle.preserveSplit, true, "preserve_split")
     t.equal(c.dwindle.forceSplit, 2, "force_split")
     t.equal(c.border.activeStart, "#33ccffee", "Omarchy active border gradient start")
@@ -422,6 +423,20 @@ h.test("the shipped default config parses cleanly") { t in
     } else {
         t.expect(false, "SUPER+ENTER should be an exec binding")
     }
+}
+
+h.test("persistent_workspaces is configurable and range-checked") { t in
+    let off = try Config.parse("[bar]\npersistent_workspaces = 0\n")
+    t.equal(off.bar.persistentWorkspaces, 0, "0 turns persistent slots off")
+    t.equal(off.warnings, [], "no warnings")
+
+    let all = try Config.parse("[bar]\npersistent_workspaces = 10\n")
+    t.equal(all.bar.persistentWorkspaces, 10, "10 keeps every workspace on the bar")
+
+    let bad = try Config.parse("[bar]\npersistent_workspaces = 99\n")
+    t.equal(bad.bar.persistentWorkspaces, 5, "an out-of-range value keeps the default")
+    t.equal(bad.warnings.contains { $0.contains("bar.persistent_workspaces") }, true,
+            "and says so in the menu bar")
 }
 
 h.test("a negative radius survives the TOML parser") { t in
@@ -550,21 +565,47 @@ h.test("a workspace knows which monitor is showing it") { t in
 }
 
 h.test("the strip shows occupied and visible workspaces") { t in
+    // persistent: 0 is the strip with nothing kept back — every slot has to be earned.
     let items = WorkspaceStrip.items(for: [
         WorkspaceStrip.State(index: 1, isFocused: true, isVisible: true, isEmpty: false),
         WorkspaceStrip.State(index: 3, isFocused: false, isVisible: false, isEmpty: true),
         WorkspaceStrip.State(index: 7, isFocused: false, isVisible: false, isEmpty: false),
-    ])
+    ], persistent: 0)
     t.equal(items.map(\.index), [1, 7], "an empty off-screen workspace gets no slot")
     t.equal(items.map(\.dim), [false, false], "occupied workspaces are full contrast")
 
     // The one you are on is always there, even with nothing on it — dimmed, the way waybar's
     // `#workspaces button.empty { opacity: 0.5 }` dims it.
     let onEmpty = WorkspaceStrip.items(for: [
-        WorkspaceStrip.State(index: 5, isFocused: true, isVisible: true, isEmpty: true)])
+        WorkspaceStrip.State(index: 5, isFocused: true, isVisible: true, isEmpty: true)],
+        persistent: 0)
     t.equal(onEmpty.map(\.index), [5], "the focused workspace keeps its slot when empty")
     t.equal(onEmpty.map(\.dim), [true], "and is dimmed")
-    t.equal(WorkspaceStrip.items(for: []).isEmpty, true, "nothing in, nothing out")
+    t.equal(WorkspaceStrip.items(for: [], persistent: 0).isEmpty, true, "nothing in, nothing out")
+}
+
+h.test("the strip keeps Omarchy's persistent workspaces") { t in
+    // Omarchy's waybar declares persistent-workspaces 1-5: they are on the bar whether or
+    // not anything is on them, dimmed while empty.
+    func states(occupied: Set<Int>, focused: Int) -> [WorkspaceStrip.State] {
+        (1...WorkspaceManager.workspaceCount).map {
+            WorkspaceStrip.State(index: $0, isFocused: $0 == focused, isVisible: $0 == focused,
+                                 isEmpty: !occupied.contains($0))
+        }
+    }
+
+    let fresh = WorkspaceStrip.items(for: states(occupied: [1], focused: 1))
+    t.equal(fresh.map(\.index), [1, 2, 3, 4, 5], "five slots with one workspace in use")
+    t.equal(fresh.map(\.marker), [.focused, .digit, .digit, .digit, .digit],
+            "a square where you are, digits for the rest")
+    t.equal(fresh.map(\.dim), [false, true, true, true, true], "the empty four are dimmed")
+
+    let beyond = WorkspaceStrip.items(for: states(occupied: [1, 8], focused: 1))
+    t.equal(beyond.map(\.index), [1, 2, 3, 4, 5, 8],
+            "a workspace past the persistent five appears once it has windows")
+
+    t.equal(WorkspaceStrip.items(for: states(occupied: [1], focused: 1), persistent: 10)
+                .map(\.index), Array(1...10), "persistent 10 shows all ten")
 }
 
 h.test("workspace ten is labelled zero") { t in

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -132,6 +132,7 @@ final class Coordinator: WindowTrackerDelegate {
         workspaces.gaps = newConfig.gaps
         tracker.floatRules = newConfig.floatRules
         border.apply(newConfig.border)
+        status.persistentWorkspaces = newConfig.bar.persistentWorkspaces
 
         refreshStatus()
         Log.info("config loaded: \(newConfig.bindings.count) binding(s), \(warnings.count) warning(s)")

--- a/Sources/toe/UI/StatusItem.swift
+++ b/Sources/toe/UI/StatusItem.swift
@@ -51,6 +51,9 @@ final class StatusItem: NSObject, NSMenuDelegate {
     private var accessibilityGranted = false
     private var showMonitorNames = false
 
+    /// waybar's `persistent-workspaces` — how many workspaces keep a slot when empty.
+    var persistentWorkspaces = WorkspaceStrip.defaultPersistent
+
     /// What the strip currently draws, and how wide each item came out — together they turn
     /// a click position back into a workspace.
     private var stripItems: [WorkspaceStrip.Item] = []
@@ -62,6 +65,18 @@ final class StatusItem: NSObject, NSMenuDelegate {
     private let gap: CGFloat = 7
     private let markerSide: CGFloat = 8
     private let markerRadius: CGFloat = 2.5
+
+    /// Omarchy dims empty workspaces with `opacity: 0.5`. The menu bar is translucent over
+    /// whatever wallpaper is behind it, and half opacity there is too faint to read, so toe
+    /// dims less far.
+    ///
+    /// Built from a dynamic provider rather than `secondaryLabelColor` so it resolves when it
+    /// is drawn, against the menu bar's own appearance — which is not always the app's, since
+    /// macOS darkens the menu bar to suit the desktop picture.
+    private static let dimLabelColor = NSColor(name: "toeDimLabel") { appearance in
+        let dark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+        return (dark ? NSColor.white : NSColor.black).withAlphaComponent(0.7)
+    }
 
     override init() {
         super.init()
@@ -101,7 +116,8 @@ final class StatusItem: NSObject, NSMenuDelegate {
             ])
         }
 
-        let items = WorkspaceStrip.items(for: workspaces.map(\.stripState))
+        let items = WorkspaceStrip.items(for: workspaces.map(\.stripState),
+                                         persistent: persistentWorkspaces)
         guard !items.isEmpty else {
             return NSAttributedString(string: "toe", attributes: [.font: font])
         }
@@ -127,7 +143,7 @@ final class StatusItem: NSObject, NSMenuDelegate {
         case .digit:
             return NSAttributedString(string: item.label, attributes: [
                 .font: font,
-                .foregroundColor: item.dim ? NSColor.secondaryLabelColor : NSColor.labelColor,
+                .foregroundColor: item.dim ? Self.dimLabelColor : NSColor.labelColor,
             ])
         case .focused, .visible:
             let attachment = NSTextAttachment()
@@ -154,7 +170,7 @@ final class StatusItem: NSObject, NSMenuDelegate {
         let box = canvas ?? side
         let radius = markerRadius * (side / markerSide)
         let image = NSImage(size: NSSize(width: box, height: box), flipped: false) { rect in
-            let colour = dim ? NSColor.secondaryLabelColor : NSColor.labelColor
+            let colour = dim ? Self.dimLabelColor : NSColor.labelColor
             let square = NSRect(x: (rect.width - side) / 2, y: (rect.height - side) / 2,
                                 width: side, height: side)
             if filled {

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -37,6 +37,11 @@ angle        = 45
 # -1 follows the system window corner radius, 0 is square, or set an explicit value.
 radius       = -1
 
+[bar]
+# waybar's persistent-workspaces: Omarchy keeps slots 1-5 on the bar even when they are
+# empty, dimmed. 0 shows only the workspaces in use; 10 always shows all ten.
+persistent_workspaces = 5
+
 [binds]
 # ── Focus — SUPER + arrows ────────────────────────────────────────────────────
 "super-left"  = "movefocus l"


### PR DESCRIPTION
The strip drew a slot only for a workspace with windows on it or one showing on a monitor, so a session with a single workspace in use showed a single square and nothing else.

## Verified against Omarchy

`config/waybar/config.jsonc` declares `persistent-workspaces` for 1 through 5:

```jsonc
"hyprland/workspaces": {
  "on-click": "activate",
  "format": "{icon}",
  "format-icons": { "default": "", "1": "1", …, "10": "0", "active": "󱓻" },
  "persistent-workspaces": { "1": [], "2": [], "3": [], "4": [], "5": [] }
}
```

Those five are on the bar whether or not anything is on them — dimmed while empty, by `#workspaces button.empty { opacity: 0.5 }` — and 6 through 10 appear only once they hold windows.

## The change

toe already had every part of that styling and was missing only the persistence rule, so `WorkspaceStrip.items` gains a `persistent` bound and the filter becomes `index <= persistent || !isEmpty || isVisible`. The `map` body is untouched: a persistent empty workspace already falls out as a dimmed digit, which is exactly what waybar draws.

```
before:  ▪
after:   ▪ 2 3 4 5
```

Exposed as `[bar] persistent_workspaces`, clamped to `0 ... 10` — `0` is the old behaviour, `10` always shows all ten. An out-of-range value warns in the menu and keeps the previous value rather than throwing, following `super_key`: a typo in the bar must not cost you the config. `Coordinator` sets it beside `border.apply`, so it hot-reloads with everything else.

The menu keeps its own `!isEmpty || isVisible` filter. Its job is listing the applications on a workspace, and four "empty" headings is noise.

## Dimming

Dimming also had to move off `secondaryLabelColor`. That is 50% alpha, the direct analogue of waybar's `opacity: 0.5`, but waybar draws on a solid bar while the menu bar is translucent over the desktop picture, and the digits came out unreadable. The replacement is 70% through an `NSColor(name:dynamicProvider:)`, which resolves when it is drawn rather than when it is built — macOS darkens the menu bar to suit the wallpaper independently of the app's appearance, so a colour resolved against the app can be drawn black on a dark bar. Same reason the marker image already used a drawing handler with `cacheMode = .never`.

## Testing

`make test`: 180 assertions, up from 168. The existing use-only test now passes `persistent: 0` and keeps asserting that rule. New coverage: a fresh session yields indices `[1,2,3,4,5]` with markers `[.focused, .digit × 4]` and dim `[false, true × 4]`; an occupied workspace 8 still appends; `persistent: 10` shows all ten; and `[bar] persistent_workspaces` parses at 0, 10, and out of range.

Confirmed in the running app: the strip reads a filled square followed by four dimmed digits, and clicking each digit switches to that workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129xjz4cReBBHb2kncTHjUY