### PR TITLE
Hide the focus border while a window is dragged

### DIFF
--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -12,6 +12,7 @@ final class Coordinator: WindowTrackerDelegate {
     private let tracker = WindowTracker()
     private let hotkeys = HotkeyManager()
     private let border = BorderOverlay()
+    private let drag = DragMonitor()
     private let status = StatusItem()
     private var watcher: ConfigWatcher?
 
@@ -58,6 +59,7 @@ final class Coordinator: WindowTrackerDelegate {
         watcher?.start()
 
         hotkeys.onTrigger = { [weak self] binding in self?.dispatch(binding.command) }
+        drag.onEnd = { [weak self] in self?.updateBorder() }
 
         guard waitForAccessibility() else {
             Log.error("no Accessibility permission — hotkeys are live but windows cannot be moved. "
@@ -239,6 +241,8 @@ final class Coordinator: WindowTrackerDelegate {
     /// snap-back when a window is dragged out of its tile.
     func windowFrameChangedExternally(_ id: WindowID) {
         guard let window = tracker.window(id), !window.isStashed else { return }
+        // A move the user is making by hand hides the border until they let go; see DragMonitor.
+        if id == workspaces.focusedWindow { drag.noteExternalFrameChange() }
 
         if workspaces.isFloating(id) {
             workspaces.floatingFrames[id] = window.element.frame
@@ -312,6 +316,7 @@ final class Coordinator: WindowTrackerDelegate {
 
     private func updateBorder() {
         guard config.border.enabled,
+              !drag.isDragging,
               let focused = workspaces.focusedWindow,
               let window = tracker.window(focused),
               !window.isStashed

--- a/Sources/toe/Input/DragMonitor.swift
+++ b/Sources/toe/Input/DragMonitor.swift
@@ -1,0 +1,42 @@
+import AppKit
+
+/// Tells a window move the user is making by hand from one an app — or toe — made on its own.
+///
+/// toe learns about moves from Accessibility notifications, which arrive well behind the window
+/// itself, so anything drawn around a window trails it across the screen for as long as the drag
+/// lasts. The focus border is hidden for the duration instead.
+final class DragMonitor {
+
+    /// Fires when the user lets go, so whatever was hidden can come back.
+    var onEnd: (() -> Void)?
+
+    private(set) var isDragging = false
+    private var mouseUp: Any?
+
+    /// Records a window moving or resizing on its own, and reports whether the user is dragging
+    /// it: a held mouse button means the hand on the window is the user's.
+    ///
+    /// Polling the button here rather than tracking mouse-downs keeps the state honest — the
+    /// answer is read from the system every time, so a missed release cannot strand the drag.
+    @discardableResult
+    func noteExternalFrameChange() -> Bool {
+        if NSEvent.pressedMouseButtons != 0 { begin() } else { end() }
+        return isDragging
+    }
+
+    private func begin() {
+        guard !isDragging else { return }
+        isDragging = true
+        // toe never sees the drag itself: the events all belong to the window's own application.
+        mouseUp = NSEvent.addGlobalMonitorForEvents(
+            matching: [.leftMouseUp, .rightMouseUp, .otherMouseUp]) { [weak self] _ in self?.end() }
+    }
+
+    private func end() {
+        guard isDragging else { return }
+        isDragging = false
+        if let mouseUp { NSEvent.removeMonitor(mouseUp) }
+        mouseUp = nil
+        onEnd?()
+    }
+}


### PR DESCRIPTION
The focus border is repositioned from Accessibility notifications, which arrive a good few frames behind the window itself. During a drag that means the border visibly trails the window across the screen. Hiding it for the duration of the drag looks far better than a border chasing its window.

`DragMonitor` answers one question — is the hand on this window the user's? Whenever the focused window moves or resizes on its own, the Coordinator asks it; a held mouse button means a drag, so the overlay is hidden. A global mouse-up monitor ends the drag and brings the border back around the window's settled frame.

Two details worth noting:

- It polls `NSEvent.pressedMouseButtons` at each frame change rather than tracking mouse-downs, so a missed release can never strand the border in the hidden state — the next move corrects it, which is exactly when a stuck hidden border would be visible anyway.
- Only moves of the focused window count, since that is the only one wearing a border.

Live resizes from a window edge arrive on the same notification, so they are covered too.

## Testing

`make run`, then dragging and edge-resizing windows: the border disappears as the window starts moving and returns in place on release. The selftest suite (180 assertions) still passes; the new logic is NSEvent-bound, so there was nothing to add to the pure ToeCore suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kzt4v276bVVpj67moYNvGA