### PR TITLE
Bind togglefloating to SUPER+T

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ as the defaults.
 | `SUPER` + `SHIFT` + `ENTER` | New browser window |
 | `SUPER` + `W` | Close window |
 | `SUPER` + `J` | Toggle split orientation |
-| `SUPER` + `SHIFT` + `V` | Toggle floating |
+| `SUPER` + `T` | Toggle floating |
 
 `SUPER` is **Option (⌥)** — the same physical key position as SUPER on a PC keyboard, and it
 leaves ⌘S ⌘F ⌘T ⌘W ⌘1-9 ⌘Tab untouched. Configurable.

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -106,7 +106,7 @@ persistent_workspaces = 5
 # ── Windows ───────────────────────────────────────────────────────────────────
 "super-w"       = "killactive"
 "super-j"       = "togglesplit"
-"super-shift-v" = "togglefloating"
+"super-t"       = "togglefloating"
 
 # ── Launch ────────────────────────────────────────────────────────────────────
 # AppleScript's `new window` reuses the running instance, so the window opens on the current

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -527,13 +527,9 @@ h.test("the shipped default config parses cleanly") { t in
     t.equal(binding("super-w")?.command, .killActive, "SUPER+W closes")
     t.equal(binding("super-tab")?.command, .workspace(.next), "SUPER+TAB")
 
-    // SUPER+T is not a shipped default — it is a local-config binding, so assert the parser
-    // rather than the default table.
-    let (mods, code, key) = try BindingParser.parse("super-t", superKey: .option)
-    t.equal(mods, Modifiers.option, "super-t: SUPER resolves to Option")
-    t.equal(code, 0x11, "super-t: T key code")
-    t.equal(key, "t", "super-t: key name")
-    t.equal(try CommandParser.parse("togglefloating"), .toggleFloating, "togglefloating dispatcher")
+    t.equal(binding("super-t")?.command, .toggleFloating, "SUPER+T floats")
+    t.equal(binding("super-t")?.keyCode, 0x11, "T key code")
+    t.equal(binding("super-shift-v"), nil, "SUPER+SHIFT+V is no longer bound")
 
     let arrows = ["super-left", "super-right", "super-up", "super-down"]
     t.equal(arrows.allSatisfy { binding($0) != nil }, true, "all four focus arrows bound")

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -99,7 +99,7 @@ persistent_workspaces = 5
 # ── Windows ───────────────────────────────────────────────────────────────────
 "super-w"       = "killactive"
 "super-j"       = "togglesplit"
-"super-shift-v" = "togglefloating"
+"super-t"       = "togglefloating"
 
 # ── Launch ────────────────────────────────────────────────────────────────────
 # AppleScript's `new window` reuses the running instance, so the window opens on the current


### PR DESCRIPTION
`SUPER+SHIFT+V` was a two-hand chord for something you reach for about as often as closing a window. `T` is free, sits next to the other window keys, and since `SUPER` is Option it does not collide with the `Cmd+T` every app already uses — the same reasoning the README already gives for leaving ⌘S ⌘F ⌘T ⌘W ⌘1-9 ⌘Tab untouched.

One binding per action, so `SHIFT+V` goes rather than becoming an alias.

| | |
|---|---|
| `Sources/ToeCore/Config/DefaultConfig.swift` | `"super-shift-v"` → `"super-t"` |
| `toe.example.toml` | regenerated with `make example-config` |
| `README.md` | bindings table row |
| `Sources/toe-selftest/main.swift` | asserts the default table now, not the parser |

`make test` — 208 assertions, including that `super-t` resolves to `.toggleFloating` in the shipped defaults and that `super-shift-v` is no longer bound.

**Only new installs pick this up.** `writeDefaultConfigIfMissing()` never overwrites an existing `~/.config/toe/toe.toml`, so anyone already running toe has to add `"super-t" = "togglefloating"` to `[binds]` by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXaoo2FCM1oXYLqUFrz9aL