### PR TITLE
Swap tiles by dragging a window onto them

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ as the defaults.
 | `SUPER` + `W` | Close window |
 | `SUPER` + `J` | Toggle split orientation |
 | `SUPER` + `T` | Toggle floating |
+| Drag a tiled window | Swap it with the tile you drag it over |
 
 `SUPER` is **Option (⌥)** — the same physical key position as SUPER on a PC keyboard, and it
 leaves ⌘S ⌘F ⌘T ⌘W ⌘1-9 ⌘Tab untouched. Configurable.
@@ -108,6 +109,9 @@ by `make test` against hand-computed Hyprland output:
 - `SUPER+SHIFT+arrow` is Omarchy's `swapwindow`: the two windows trade places and the tree
   shape does not change. (`movewindow` — i3-style reparenting — is available in the config if
   you prefer it.)
+- Dragging a tiled window swaps it with whichever tile the pointer crosses, live, and keeps
+  going for as long as you hold it — Hyprland's `switchWindows` under the pointer, the mouse
+  equivalent of `SUPER+SHIFT+arrow`.
 - Directional focus is **edge adjacency**, not nearest-centre: a window qualifies only if its
   opposing edge lines up with yours within 2px, computed on un-gapped node boxes. Ties go to
   the most recently focused window.
@@ -132,8 +136,27 @@ frame write and restores it afterwards, which is what makes those apps tile.
 geometry a beat after a window opens, clobbering the frame toe just wrote, so toe re-asserts the
 layout when a window moves or resizes behind its back. That is bounded at three attempts: an app
 whose minimum size exceeds its tile (Safari will not go narrower than ~574px) is written once and
-then left alone rather than fought with forever. The same mechanism snaps a window back when you
-drag it out of its tile.
+then left alone rather than fought with forever. A tile is re-asserted against an app, never
+against you: a window you have hold of is left alone until you let go — see **Dragging**.
+
+**Dragging.** Pick a tiled window up by its title bar and the tile under the pointer trades
+places with it, the way Hyprland's `IHyprLayout::onMouseMove` does — only the two windows move,
+the tree shape does not change, and crossing onto another display takes the window and the focus
+with it. It keeps swapping as you sweep across tiles, so where you let go is where the window
+lands; let go over the tile you started on and nothing has changed. The focus border stays behind
+on the tile the window will land in, so the target is visible the whole way across — a border
+chasing the window itself would only trail behind it, because toe hears about its movement
+through Accessibility, well after the fact. It sits *under* the window you are dragging, which is
+where Hyprland puts it: a border there is drawn inside its own window's render pass, and the
+focused window is drawn last of all, so a dragged window passes over the tiles it crosses. macOS
+will not slot a panel behind one particular window — `order(_:relativeTo:)` stops at the process
+boundary — but it does not have to, because toe is a background app and its normal-level panel
+lands directly beneath the frontmost window, which is the one being dragged. toe cannot see the drag
+itself — those events belong to the window's own application — so it infers one from an
+Accessibility move notification arriving while a mouse button is down, and follows the pointer
+with a read-only global event monitor rather than an event tap. For as long as you have hold of
+a window toe writes nothing to it, which is what stops it being yanked out from under the cursor;
+its frame is written once, into whatever tile it now owns, when you release.
 
 **Floating windows.** `togglefloating` lifts a window out of the tree and centres it, at a
 consistent fraction of the display — 70% wide by 80% tall by default — so every floating window

--- a/Sources/ToeCore/Layout/WorkspaceManager.swift
+++ b/Sources/ToeCore/Layout/WorkspaceManager.swift
@@ -269,6 +269,43 @@ public final class WorkspaceManager {
         return true
     }
 
+    /// The workspace currently shown on the monitor holding `point`. Scoped to the monitor's
+    /// whole frame rather than its usable area, the way `focalPoint(on:)` is.
+    private func visibleWorkspace(at point: Point) -> Workspace? {
+        guard let monitor = monitors.first(where: { $0.frame.contains(point) }),
+              let index = activeWorkspace[monitor.id]
+        else { return nil }
+        return workspaces[index]
+    }
+
+    /// The tiled branch of `IHyprLayout::onMouseMove`: a window dragged by hand trades places
+    /// with whichever tile the pointer is over. That is Hyprland's `switchWindows` — the same
+    /// primitive `swapwindow` uses, so the tree shape never changes — and it crosses monitors,
+    /// because a tile on another display is just another leaf under the pointer.
+    ///
+    /// A stream of pointer moves needs no throttling: `swap` exchanges node payloads, so the
+    /// node under the pointer ends up holding the dragged window itself and every further move
+    /// inside it is a no-op. The next swap waits for the pointer to enter a different tile.
+    ///
+    /// Only tiled leaves are targets. Dragging over a floating window swaps with the tile
+    /// underneath it.
+    @discardableResult
+    public func swapWithWindow(at point: Point, dragging source: WindowID) -> Bool {
+        guard let sourceIndex = workspaceIndex(of: source),
+              let sourceWorkspace = workspaces[sourceIndex],
+              sourceWorkspace.layout.contains(source),
+              let targetWorkspace = visibleWorkspace(at: point),
+              let target = targetWorkspace.layout.node(at: point)?.window,
+              target != source
+        else { return false }
+
+        DwindleLayout.swap(source, in: sourceWorkspace.layout,
+                           with: target, in: targetWorkspace.layout)
+        // Dragged onto another display, focus goes with the window.
+        if targetWorkspace !== sourceWorkspace { noteFocus(source) }
+        return true
+    }
+
     /// `movewindow <dir>` — reparent the focused window towards a direction.
     @discardableResult
     public func moveWindow(_ dir: Direction) -> Bool {

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -498,6 +498,106 @@ h.test("a workspace follows its monitor") { t in
     t.equal(wm.focusedMonitorID, home, "workspace 5 pulled focus back to its monitor")
 }
 
+// MARK: - Dragging
+
+/// Four windows opened in order on one monitor, each splitting the one before it:
+///
+///     ┌────────┬────────┐
+///     │        │   w2   │
+///     │   w1   ├───┬────┤
+///     │        │w3 │ w4 │
+///     └────────┴───┴────┘
+func draggingFixture() -> WorkspaceManager {
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
+    wm.addWindow(1); wm.addWindow(2); wm.addWindow(3); wm.addWindow(4)
+    return wm
+}
+
+h.test("dragging a window over a tile trades their places") { t in
+    let wm = draggingFixture()
+    let layout = wm.focusedWorkspace.layout
+    t.equalBox(layout.idealBox(of: 1), box(0, 0, 756, 982), "fixture: w1")
+    t.equalBox(layout.idealBox(of: 2), box(756, 0, 756, 491), "fixture: w2")
+    t.equalBox(layout.idealBox(of: 3), box(756, 491, 378, 491), "fixture: w3")
+    t.equalBox(layout.idealBox(of: 4), box(1134, 491, 378, 491), "fixture: w4")
+
+    t.equal(wm.swapWithWindow(at: Point(x: 1000, y: 100), dragging: 1), true, "the pointer is over w2")
+
+    t.equalBox(layout.idealBox(of: 1), box(756, 0, 756, 491), "w1 took w2's slot")
+    t.equalBox(layout.idealBox(of: 2), box(0, 0, 756, 982), "w2 took w1's")
+    t.equalBox(layout.idealBox(of: 3), box(756, 491, 378, 491), "w3 untouched — only the payloads moved")
+    t.equalBox(layout.idealBox(of: 4), box(1134, 491, 378, 491), "and w4")
+}
+
+h.test("a drag settles: the tile under the pointer now holds the dragged window") { t in
+    let wm = draggingFixture()
+    let point = Point(x: 1000, y: 100)
+
+    t.equal(wm.swapWithWindow(at: point, dragging: 1), true, "first move onto w2 swaps")
+    t.equal(wm.swapWithWindow(at: point, dragging: 1), false,
+            "every further move inside that tile is a no-op: it holds w1 now")
+    t.equal(wm.swapWithWindow(at: Point(x: 300, y: 300), dragging: 1), true,
+            "moving on to a different tile swaps again")
+    t.equalBox(wm.focusedWorkspace.layout.idealBox(of: 1), box(0, 0, 756, 982), "w1 ended up where it started")
+}
+
+h.test("dragging is not restricted to neighbours the way swapwindow is") { t in
+    let wm = draggingFixture()
+    wm.noteFocus(4)
+    t.equal(wm.swapWindow(.left), true, "the keyboard can only reach w4's neighbour, w3")
+    t.equalBox(wm.focusedWorkspace.layout.idealBox(of: 4), box(756, 491, 378, 491), "w4 moved one slot left")
+
+    let wm2 = draggingFixture()
+    t.equal(wm2.swapWithWindow(at: Point(x: 300, y: 300), dragging: 4), true, "the pointer reaches w1 directly")
+    t.equalBox(wm2.focusedWorkspace.layout.idealBox(of: 4), box(0, 0, 756, 982), "w4 crossed the tree in one drag")
+    t.equalBox(wm2.focusedWorkspace.layout.idealBox(of: 1), box(1134, 491, 378, 491), "w1 came the other way")
+}
+
+h.test("dragging onto another monitor takes the window and the focus there") { t in
+    let left = box(0, 0, 1512, 982)
+    let right = box(1512, 0, 1920, 1080)
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: left, usable: left),
+                    Monitor(id: 2, frame: right, usable: right)])
+
+    let leftWS = wm.activeWorkspace[1]!
+    let rightWS = wm.activeWorkspace[2]!
+    wm.switchTo(workspace: leftWS)
+    wm.addWindow(1); wm.addWindow(2)
+    wm.switchTo(workspace: rightWS)
+    wm.addWindow(10); wm.addWindow(11)
+    wm.noteFocus(2)
+    t.equal(wm.focusedMonitorID, 1, "the drag starts on the left monitor")
+
+    t.equal(wm.swapWithWindow(at: Point(x: 3000, y: 500), dragging: 2), true, "the pointer is over w11")
+
+    t.equal(wm.workspaceIndex(of: 2), rightWS, "w2 now lives on the right monitor's workspace")
+    t.equal(wm.workspaceIndex(of: 11), leftWS, "and w11 on the left one's")
+    t.equalBox(wm.workspaces[rightWS]?.layout.idealBox(of: 2), box(2472, 0, 960, 1080), "w2 took w11's exact slot")
+    t.equalBox(wm.workspaces[leftWS]?.layout.idealBox(of: 11), box(756, 0, 756, 982), "w11 took w2's")
+    t.equalBox(wm.workspaces[rightWS]?.layout.idealBox(of: 10), box(1512, 0, 960, 1080), "w10 untouched")
+    t.equal(wm.focusedMonitorID, 2, "focus followed the window across")
+}
+
+h.test("only tiled windows are dragged, and only onto tiles") { t in
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
+    wm.addWindow(1); wm.addWindow(2)
+    wm.addWindow(3, floating: true)
+    wm.floatingFrames[3] = box(800, 100, 400, 300)          // sitting over w2
+
+    t.equal(wm.swapWithWindow(at: Point(x: 300, y: 300), dragging: 3), false,
+            "a floating window is dragged by its app alone; toe just remembers where it lands")
+
+    t.equal(wm.swapWithWindow(at: Point(x: 900, y: 200), dragging: 1), true,
+            "dragging over the floating w3 swaps with the tile underneath it")
+    t.equalBox(wm.focusedWorkspace.layout.idealBox(of: 1), box(756, 0, 756, 982), "w1 took w2's slot")
+
+    t.equal(wm.swapWithWindow(at: Point(x: -500, y: -500), dragging: 1), false,
+            "a pointer on no monitor at all is not a drop target")
+}
+
 // MARK: - Config
 
 h.test("the shipped default config parses cleanly") { t in

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -25,6 +25,10 @@ final class Coordinator: WindowTrackerDelegate {
     /// than fought with forever.
     private var corrections: [WindowID: Int] = [:]
     private var focusApplied: WindowID?
+    /// The window the user has hold of. Its frame is theirs until they let go: toe neither
+    /// re-asserts its tile nor writes it a new one, the same courtesy `apply` already extends
+    /// to a floating window.
+    private var draggedWindow: WindowID? { drag.isDragging ? drag.window : nil }
     private var signalSources: [any DispatchSourceSignal] = []
 
     // MARK: - Start-up
@@ -61,7 +65,13 @@ final class Coordinator: WindowTrackerDelegate {
         watcher?.start()
 
         hotkeys.onTrigger = { [weak self] binding in self?.dispatch(binding.command) }
-        drag.onEnd = { [weak self] in self?.updateBorder() }
+        // Dragging a tiled window over another one trades their places, live, the way
+        // Hyprland's `IHyprLayout::onMouseMove` does.
+        drag.onMove = { [weak self] id, point in
+            guard let self, self.workspaces.swapWithWindow(at: point, dragging: id) else { return }
+            self.apply(refocus: false)
+        }
+        drag.onEnd = { [weak self] id in self?.endDrag(id) }
 
         guard waitForAccessibility() else {
             Log.error("no Accessibility permission — hotkeys are live but windows cannot be moved. "
@@ -263,11 +273,21 @@ final class Coordinator: WindowTrackerDelegate {
     func windowFrameChangedExternally(_ id: WindowID) {
         guard let window = tracker.window(id), !window.isStashed else { return }
         // A move the user is making by hand hides the border until they let go; see DragMonitor.
-        if id == workspaces.focusedWindow { drag.noteExternalFrameChange() }
+        if id == workspaces.focusedWindow { drag.noteExternalFrameChange(id) }
 
         if workspaces.isFloating(id) {
             workspaces.floatingFrames[id] = window.element.frame
             if id == workspaces.focusedWindow { updateBorder() }
+            return
+        }
+
+        // A tile is re-asserted against an app that fights it, never against the user. Where the
+        // window has got to during the drag says nothing about where it belongs — the pointer
+        // decides that, in `swapWithWindow` — so leave it alone until they let go. The border
+        // still gets a look in: this is where it drops behind the window at the start of a drag,
+        // and where it re-takes that place if the app raises itself mid-drag.
+        if id == draggedWindow {
+            updateBorder()
             return
         }
 
@@ -330,6 +350,10 @@ final class Coordinator: WindowTrackerDelegate {
             guard desired[id] != box else { continue }
             desired[id] = box
             corrections[id] = 0
+            // Writing this one would yank it out from under the cursor mid-drag; `endDrag`
+            // puts it in its tile once the drag is over. Its swap partner moves normally,
+            // and that is the feedback the user sees.
+            if id == draggedWindow { continue }
             WindowMover.setFrame(box, element: window.element, pid: window.pid)
         }
 
@@ -345,20 +369,47 @@ final class Coordinator: WindowTrackerDelegate {
 
     private func updateBorder() {
         guard config.border.enabled,
-              !drag.isDragging,
-              let focused = workspaces.focusedWindow,
+              let focused = draggedWindow ?? workspaces.focusedWindow,
               let window = tracker.window(focused),
               !window.isStashed
         else {
             border.hide()
             return
         }
+
+        // While the user has hold of a window the border marks the tile it will land in rather
+        // than the window itself. Two reasons, and they point the same way: toe hears about the
+        // window's own movement through Accessibility, well behind the fact, so a border chasing
+        // it would trail across the screen — and the tile is the useful thing to show anyway,
+        // because the swap has already happened and that is where letting go puts it. A floating
+        // window has no tile, so it keeps the old behaviour of no border until it is dropped.
+        if focused == draggedWindow {
+            // Behind the window being dragged, and above every other one — where Hyprland puts
+            // it, since it draws each border with its own window and the focused window last.
+            if let tile = desired[focused] {
+                border.show(around: tile, depth: .behindFrontmost)
+            } else {
+                border.hide()
+            }
+            return
+        }
+
         // Prefer the frame we wrote; fall back to asking the window for floating ones.
         if let box = window.element.frame ?? desired[focused] {
             border.show(around: box)
         } else {
             border.hide()
         }
+    }
+
+    /// The user has let go. The window has been off its tile for the length of the drag, so
+    /// clearing `desired` is what makes `apply` write it into whichever tile it now owns —
+    /// its own, if the drag never crossed another one. `apply` ends in `updateBorder`, which
+    /// brings the focus border back now that the drag is over.
+    private func endDrag(_ id: WindowID) {
+        desired.removeValue(forKey: id)
+        corrections.removeValue(forKey: id)
+        apply(refocus: false)
     }
 
     private func unstashEverything() {

--- a/Sources/toe/Input/DragMonitor.swift
+++ b/Sources/toe/Input/DragMonitor.swift
@@ -1,17 +1,26 @@
 import AppKit
+import ToeCore
 
-/// Tells a window move the user is making by hand from one an app — or toe — made on its own.
+/// Tells a window move the user is making by hand from one an app — or toe — made on its own,
+/// and follows the pointer for as long as it lasts.
 ///
 /// toe learns about moves from Accessibility notifications, which arrive well behind the window
 /// itself, so anything drawn around a window trails it across the screen for as long as the drag
-/// lasts. The focus border is hidden for the duration instead.
+/// lasts, so for the duration the border marks the tile the window will land in instead — which
+/// is somewhere toe knows exactly. The pointer, on the other hand,
+/// can be read live — which is what lets a tiled window trade places with the tile it is dragged
+/// over, the way Hyprland's `IHyprLayout::onMouseMove` does.
 final class DragMonitor {
 
+    /// Fires for each pointer move while a drag is live, with the window being dragged.
+    var onMove: ((WindowID, Point) -> Void)?
     /// Fires when the user lets go, so whatever was hidden can come back.
-    var onEnd: (() -> Void)?
+    var onEnd: ((WindowID) -> Void)?
 
     private(set) var isDragging = false
-    private var mouseUp: Any?
+    /// The window in the user's hand, for as long as they have hold of it.
+    private(set) var window: WindowID?
+    private var monitors: [Any] = []
 
     /// Records a window moving or resizing on its own, and reports whether the user is dragging
     /// it: a held mouse button means the hand on the window is the user's.
@@ -19,24 +28,37 @@ final class DragMonitor {
     /// Polling the button here rather than tracking mouse-downs keeps the state honest — the
     /// answer is read from the system every time, so a missed release cannot strand the drag.
     @discardableResult
-    func noteExternalFrameChange() -> Bool {
-        if NSEvent.pressedMouseButtons != 0 { begin() } else { end() }
+    func noteExternalFrameChange(_ id: WindowID) -> Bool {
+        if NSEvent.pressedMouseButtons != 0 { begin(id) } else { end() }
         return isDragging
     }
 
-    private func begin() {
+    private func begin(_ id: WindowID) {
         guard !isDragging else { return }
         isDragging = true
+        window = id
         // toe never sees the drag itself: the events all belong to the window's own application.
-        mouseUp = NSEvent.addGlobalMonitorForEvents(
-            matching: [.leftMouseUp, .rightMouseUp, .otherMouseUp]) { [weak self] _ in self?.end() }
+        // Global monitors are read-only and consume nothing, so this stays clear of the event
+        // tap toe deliberately does without.
+        add([.leftMouseUp, .rightMouseUp, .otherMouseUp]) { [weak self] _ in self?.end() }
+        add([.leftMouseDragged, .rightMouseDragged, .otherMouseDragged]) { [weak self] _ in
+            guard let self, let window = self.window else { return }
+            self.onMove?(window, Coordinates.toAX(NSEvent.mouseLocation))
+        }
+    }
+
+    private func add(_ mask: NSEvent.EventTypeMask, _ handler: @escaping (NSEvent) -> Void) {
+        if let monitor = NSEvent.addGlobalMonitorForEvents(matching: mask, handler: handler) {
+            monitors.append(monitor)
+        }
     }
 
     private func end() {
-        guard isDragging else { return }
+        guard isDragging, let dragged = window else { return }
         isDragging = false
-        if let mouseUp { NSEvent.removeMonitor(mouseUp) }
-        mouseUp = nil
-        onEnd?()
+        window = nil
+        for monitor in monitors { NSEvent.removeMonitor(monitor) }
+        monitors.removeAll()
+        onEnd?(dragged)
     }
 }

--- a/Sources/toe/UI/BorderOverlay.swift
+++ b/Sources/toe/UI/BorderOverlay.swift
@@ -14,6 +14,25 @@ final class BorderOverlay {
     private let band = CALayer()
     private var config = BorderConfig()
 
+    /// Where the border sits in the window stack.
+    enum Depth {
+        /// Above every ordinary window — the focused window's own outline, which nothing
+        /// should cover.
+        case aboveEverything
+        /// Just behind the frontmost window, above all the rest.
+        ///
+        /// Hyprland draws a border inside its own window's render pass, and draws the focused
+        /// window last of all, so a window being dragged passes *over* the borders of the tiles
+        /// it crosses rather than under them. A macOS panel cannot be slotted behind one
+        /// specific window — `order(_:relativeTo:)` does not reach across processes, and the
+        /// window level decides the order regardless — but the ordinary level arrives at the
+        /// same place anyway: toe is a background app, so a normal-level panel lands directly
+        /// beneath the frontmost application's window, which is the one in the user's hand.
+        case behindFrontmost
+
+        var level: NSWindow.Level { self == .aboveEverything ? .floating : .normal }
+    }
+
     init() {
         panel = NSPanel(contentRect: .zero,
                         styleMask: [.borderless, .nonactivatingPanel],
@@ -54,7 +73,7 @@ final class BorderOverlay {
     }
 
     /// `box` is the window's own frame in AX coordinates; the border is drawn just outside it.
-    func show(around box: Box) {
+    func show(around box: Box, depth: Depth = .aboveEverything) {
         guard config.enabled, config.width > 0 else { hide(); return }
 
         let w = config.width
@@ -85,6 +104,10 @@ final class BorderOverlay {
         if band.contentsScale != scale { band.contentsScale = scale }
         CATransaction.commit()
 
+        // Re-ordered on every show, not just when the depth changes: `behindFrontmost` is a
+        // position in the stack rather than a fixed level, so it has to be re-taken whenever
+        // the application in front of it changes.
+        if panel.level != depth.level { panel.level = depth.level }
         panel.orderFront(nil)
     }
 


### PR DESCRIPTION
Rearranging the layout meant `SUPER+SHIFT+arrow`. A window dragged by its title bar was written straight back to its tile, because the machinery that re-asserts a frame against Chromium and JetBrains apps could not tell an app clobbering a frame from the user moving one.

Hyprland has no such problem. `IHyprLayout::onMouseMove` trades a dragged tiled window with whichever tile the pointer crosses, live, through `switchWindows` — the same primitive `swapwindow` uses, so the tree shape never changes. Every piece that needed was already here: `DwindleLayout.swap`, its cross-tree overload, and `node(at:)`. What was missing was a drag toe could follow.

## What changed

**`DragMonitor`** now records *which* window is in the user's hand and follows the pointer, through a second read-only global `NSEvent` monitor. toe never sees the drag itself — those events belong to the window's own application — so it still infers one from an Accessibility move notification arriving while a mouse button is down, and it still uses no event tap.

**`WorkspaceManager.swapWithWindow(at:dragging:)`** resolves the pointer to a monitor, its active workspace, and the leaf under it, then calls the existing cross-tree `DwindleLayout.swap`. Dragging onto another display takes the window and the focus with it.

**`Coordinator`** stops fighting the drag. A tile is re-asserted against an app, never against the user: for as long as a window is in the user's hand toe writes nothing to it, and writes it once, into whatever tile it then owns, on release.

No throttling, and that is load-bearing rather than lucky: `swap` exchanges node payloads, so the tile under the pointer ends up holding the dragged window and every further move inside it is a no-op. The next swap waits for the pointer to enter a different tile.

## The border

It stays behind on the tile the window will land in rather than hiding for the duration (#8). A border chasing the window would only trail it, since toe hears about its movement well after the fact, but the tile is somewhere toe knows exactly.

It sits *under* the dragged window, where Hyprland puts it. A border there is drawn inside its own window's render pass (`CHyprBorderDecoration` at `DECORATION_LAYER_OVER`, drawn within `renderWindow`), and the focused window is drawn last of all — so a dragged window passes over the tiles it crosses. macOS will not slot a panel behind one particular window: `order(_:relativeTo:)` stops at the process boundary, and the window level decides the order regardless. It does not have to, though. toe is a background app, so its normal-level panel lands directly beneath the frontmost window — which is the one being dragged.

## Testing

`make test` — 238 assertions, five new cases covering the basic trade, the convergence property that makes throttling unnecessary, a cross-tree jump the keyboard cannot make, the two-monitor case, and the floating and off-monitor rejections.

Checked by hand: sweeping across several tiles, releasing over the starting tile, the two-display case, and that floating windows and freshly-opened Chromium windows both still behave.

Known edge: `noteExternalFrameChange` fires on resize as well as move, so resizing a tiled window by its corner counts as a drag — it will not snap back until release, and dragging a corner deep into a neighbouring tile swaps with it. toe ships no resize bindings, so this only comes up with a mouse on a window edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1exgAU3CuthNCkarELiJ7