### PR TITLE
Fix the cask definition brew refuses to load

### DIFF
--- a/Casks/toe.rb
+++ b/Casks/toe.rb
@@ -15,7 +15,7 @@ cask "toe" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
   depends_on arch: :arm64
 
   app "Toe.app"
@@ -39,7 +39,7 @@ cask "toe" do
       invisible. If macOS refuses to open the app, clear the quarantine attribute by hand:
         xattr -dr com.apple.quarantine /Applications/Toe.app
 
-      To start toe at login, see "Start at login" at #{homepage}
+      To start toe at login, see "Start at login" at #{cask.homepage}
     EOS
   end
 end


### PR DESCRIPTION
`brew install theclifmeister/toe/toe` fails outright, before it ever reaches the download:

```
Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :sonoma` instead.
Error: Cask 'toe' definition is invalid: undefined method 'homepage' for Cask 'toe'
The file /Applications/Toe.app does not exist.
```

Two independent problems, both in `Casks/toe.rb`.

### `undefined method 'homepage'` — the hard failure

`caveats do` is `instance_eval`'d against `Cask::DSL::Caveats`, and `Cask::DSL::Base` delegates only `token`, `version`, `caskroom_path`, `staged_path`, `appdir`, `language` and `arch` to the cask. Every other name falls through to `Base#method_missing`, which raises `NoMethodError` with exactly the message above — so the `#{homepage}` interpolation in the caveats heredoc was never reachable.

Interpolate `#{cask.homepage}` instead: `Base` exposes `cask` as a public reader and `Cask` delegates `:homepage` to its DSL, so the URL stays defined in exactly one place rather than being duplicated into the caveats text.

### Deprecated `depends_on macos:` comparison

`">= :sonoma"` becomes the bare symbol `:sonoma`.

Worth stating explicitly, since the two contexts disagree: for *formulae* a bare version symbol means "at least", while for *casks* it historically meant "exactly this version". Here the bare symbol is correct and the minimum-version semantics are preserved — `Cask::DSL::DependsOn#macos=` always parses with `comparator: ">="`, and this is Homebrew's own suggested replacement (`requirements/macos_requirement.rb:46`).

### Verification

Against the real tap checkout, not in the abstract:

- `brew info --cask theclifmeister/toe/toe` — parses, caveats render with the homepage interpolated, no deprecation warning, requirement still reports `macOS >= 14`
- `brew audit --cask --online theclifmeister/toe/toe` — exits 0
- `brew style --cask theclifmeister/toe/toe` — 1 file inspected, no offenses

Needed on `main` before the next release: `release.yml`'s bump step rewrites the cask on `origin/main`, so the cask users receive comes from `main` rather than from the tagged commit.