### PR TITLE
Bump toe cask to 0.2.0

### DIFF
--- a/Casks/toe.rb
+++ b/Casks/toe.rb
@@ -2,8 +2,8 @@
 
 cask "toe" do
   # Both lines below are rewritten by .github/workflows/release.yml on each tag.
-  version "0.1.0"
-  sha256 "fb26a036f2572d716287d97b2e7e676686f1806b6c4b6b2df9c3b9c17cd58791"
+  version "0.2.0"
+  sha256 "ea516cb1dc0534cd39ac939584b6acd6a3ea6f62bae21811d878f650a9d25338"
 
   url "https://github.com/theclifmeister/toe/releases/download/v#{version}/toe-#{version}-arm64.zip"
   name "toe"


### PR DESCRIPTION
The v0.2.0 release job could not do this itself. Its final step pushes the cask bump directly to `main`, and that push was rejected:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
```

Everything before that step succeeded — build, signing, `codesign --verify`, the `--version` smoke test, packaging and the release upload. `toe-0.2.0-arm64.zip` is published and downloadable. Only the cask on `main` was left pointing at 0.1.0, so `brew upgrade` had nothing new to find.

### Verification

- **sha256 verified against the published asset**, computed locally rather than copied out of the workflow log: `ea516cb1dc0534cd39ac939584b6acd6a3ea6f62bae21811d878f650a9d25338`
- `brew audit --cask --online` on the bumped cask — passes, which re-downloads the asset and checks the checksum end to end
- `brew info` reports `toe (toe): 0.2.0`
- **Designated requirement unchanged** from v0.1.0 — `identifier "com.clifmeister.toe" and certificate root = H"ff45326077f9636b8a26ca257991bf6cb5791408"` in both — so existing Accessibility grants survive the upgrade
- `codesign --verify --deep --strict` clean, and the bundled binary reports `0.2.0`

### Follow-up, not fixed here

The ruleset means this step will fail on **every** future release, leaving each one half-finished the same way. Worth fixing separately in `release.yml`; there's a choice to make about how (open a PR from the job, or grant a bypass) so I left it out of this PR.