### PR TITLE
Bump toe cask to 0.3.0

### DIFF
--- a/Casks/toe.rb
+++ b/Casks/toe.rb
@@ -2,8 +2,8 @@
 
 cask "toe" do
   # Both lines below are rewritten by .github/workflows/release.yml on each tag.
-  version "0.2.0"
-  sha256 "ea516cb1dc0534cd39ac939584b6acd6a3ea6f62bae21811d878f650a9d25338"
+  version "0.3.0"
+  sha256 "5829bf15d335b48bf3169bc9e7028483bd045b4d74b74413605999766bb385d4"
 
   url "https://github.com/theclifmeister/toe/releases/download/v#{version}/toe-#{version}-arm64.zip"
   name "Toe"


### PR DESCRIPTION
Completes the v0.3.0 release. The release job built, signed, verified and published the asset, then staged this branch — but its own `gh pr create` was refused:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to
create or approve pull requests (createPullRequest)
```

So the branch is the job's work, unmodified; only the PR had to be opened by hand.

`version` and `sha256` are the two lines the release workflow rewrites. The checksum was verified against the **published asset** rather than copied from the workflow log:

```
$ shasum -a 256 toe-0.3.0-arm64.zip
5829bf15d335b48bf3169bc9e7028483bd045b4d74b74413605999766bb385d4
```

The shipped artifact was also unpacked and checked end to end: `CFBundleDisplayName` and `CFBundleName` both `Toe`, `CFBundleIconFile` present with `Toe.icns` in `Contents/Resources`, `toe --version` reports `0.3.0`, and `codesign --verify --deep --strict` passes. The designated requirement is `identifier "com.clifmeister.toe" and certificate root = H"ff45326077..."` — the same certificate root as v0.1.0 and v0.2.0, so existing Accessibility grants survive the upgrade.

**Follow-up needed:** the repo setting *Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"* is off, so every future release will fail this step the same way. #14 moved the cask bump onto a PR specifically to get around branch protection on `main`; that approach needs this setting enabled to work unattended.