### PR TITLE
Add Omarchy's quick menu on SUPER+SPACE

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ as the defaults.
 | `SUPER` + `1`…`9`, `0` | Switch to workspace 1…10 |
 | `SUPER` + `SHIFT` + `1`…`9`, `0` | Move window to workspace and follow it |
 | `SUPER` + `TAB` / `SHIFT`+`TAB` / `CTRL`+`TAB` | Next / previous / former workspace |
+| `SUPER` + `SPACE` | The quick menu |
 | `SUPER` + `ENTER` | New terminal window |
 | `SUPER` + `SHIFT` + `ENTER` | New browser window |
 | `SUPER` + `W` | Close window |
@@ -65,6 +66,60 @@ Config loaded
 Rows are live: click a workspace to switch to it, or an application to focus its window —
 including one on a hidden workspace, which brings that workspace forward first. The list is
 built when the menu opens, so nothing is maintained while it is closed.
+
+## The quick menu
+
+`SUPER`+`SPACE` opens Omarchy's menu — the `walker --dmenu` panel its `omarchy-menu` script drives,
+at walker's own 295pt width. Type to filter, arrows or `CTRL`+`N`/`P` to move, `ENTER` to pick,
+`ESC` to go back a level and again to dismiss, `SUPER`+`SPACE` to close it outright. `BACKSPACE` on
+an empty query goes back a level too, but never out of the menu: only `ESC` does that.
+
+```
+┌─────────────────────────────┐
+│ Go…                         │
+├─────────────────────────────┤
+│  Windows                   ›│
+│  Workspaces                ›│
+│  Layout                    ›│
+│  Style                     ›│
+│  Setup                     ›│
+│  System                    ›│
+│  About                      │
+└─────────────────────────────┘
+```
+
+Omarchy's Install, Remove, Update and Learn are pacman, the AUR and Arch's own documentation, so
+they have no counterpart here. What is left maps onto what toe actually does:
+
+- **Windows** — every window, this workspace's first and the rest one level down, with its current
+  title. Picking one on a hidden workspace brings that workspace forward first, exactly as the menu
+  bar's rows do.
+- **Workspaces** — all ten, whatever `[bar] persistent_workspaces` shows, plus next, previous, last
+  visited, and move-window-to. All ten always have a row so their positions never shift under your
+  muscle memory.
+- **Layout** — `togglesplit`, `swapsplit`, `togglefloating`, `killactive` and the four
+  `swapwindow` directions, each showing your own binding for it. Nothing for resize or window
+  groups, because there is nothing to show.
+- **Style** — Omarchy's theme names, and picking one **rewrites `[border]` in your config**, which
+  the watcher then reloads. That is what Omarchy's own Style menu does, and it means a theme
+  persists without toe keeping any state of its own. Gaps presets sit beside it rather than inside
+  it — in Omarchy `looknfeel.conf` is shared across every theme and only the colours change.
+- **Setup** — open or reveal the config, reload it, start toe at login, the Accessibility pane.
+- **System** — lock, sleep, log out, restart, shut down. Restart and shut down ask first, as a
+  Cancel/Confirm level whose preselected row is the one that does nothing, so `ENTER` twice in a row
+  cannot reboot you. Log out is not asked about here because the system asks itself.
+- **About** — the version, and **Keybindings**, generated from the live config, where each row runs
+  the command it describes. This is Omarchy's `Learn`, for the only part of it toe can answer.
+
+Rows are built when the menu opens and nothing is kept while it is closed — the same discipline the
+menu bar item keeps. Everything a hotkey can do is dispatched through the same command a hotkey
+would, so there is no second implementation of anything.
+
+Entries are compiled in rather than configurable. A menu you have to configure is the scripting API
+under **Not included**, with a friendlier name.
+
+`SUPER`+`SPACE` is a default, so a config written by an earlier version will not have it — add
+`"super-space" = "menu"` to `[binds]`, or delete `~/.config/toe/toe.toml` to get a fresh one.
 
 ## Install
 
@@ -158,6 +213,32 @@ with a read-only global event monitor rather than an event tap. For as long as y
 a window toe writes nothing to it, which is what stops it being yanked out from under the cursor;
 its frame is written once, into whatever tile it now owns, when you release.
 
+**The quick menu's keyboard.** toe is a background app, and a borderless panel in one does not get
+keystrokes for free: `NSWindow.canBecomeKey` is false for a borderless window, and macOS's
+cooperative activation can refuse to activate an app it cannot attribute recent input to. Both are
+handled — the panel overrides `canBecomeKey`, and after activating, toe checks that the panel really
+did become key and closes rather than leaving a visible menu quietly swallowing what you type into
+whatever was underneath. Carbon hotkeys are dispatched ahead of key-window delivery and keep firing
+while toe is frontmost, so they are gated for as long as the menu is open; the focus border is hidden
+for the same span, which is the courtesy already extended to a window being dragged. Dismissing
+without picking anything puts focus back on the window you came from explicitly, rather than trusting
+macOS to reactivate the app you were in — it reactivates the next one in order, which is not always
+the same thing.
+
+There is no text field: typed characters go straight into the menu's own query, which keeps one
+source of truth for what is on screen and makes every key rule testable without AppKit. The cost is
+no input method, so the query is Latin-only. Two other honest edges: while a password field has
+secure input engaged, Carbon hotkeys can be suppressed altogether, so `SUPER`+`SPACE` may not fire —
+that is pre-existing toe behaviour, not the menu's; and the rows are drawn rather than built from
+controls, so VoiceOver sees the list and the selected row but not yet each row as its own element.
+
+**Restyling from the menu writes your config.** `Style` edits the `[border]` and gaps keys in
+`~/.config/toe/toe.toml` in place, preserving every comment and the `=` alignment, and then leaves
+the reload to the watcher rather than reloading itself — a second reload inside the watcher's debounce
+would rewrite every window's frame and flicker the whole screen for the sake of a colour. Two
+properties this shares with Omarchy's own theme switching: an editor holding unsaved changes to that
+file wins on its next save, and there is no undo beyond picking something else.
+
 **Floating windows.** `togglefloating` lifts a window out of the tree and centres it, at a
 consistent fraction of the display — 70% wide by 80% tall by default — so every floating window
 is the same shape whichever window it came from. No floating window is ever wider than 1.6 times
@@ -186,7 +267,10 @@ one: `"alt-shift-1"`, `"super+shift+1"` and `"SUPER SHIFT, 1"` are the same bind
 
 Commands: `movefocus`, `swapwindow`, `movewindow`, `workspace`, `movetoworkspace`,
 `movetoworkspacesilent`, `killactive`, `togglefloating`, `togglesplit`, `swapsplit`, `exec`,
-`reload`.
+`reload`, `menu`.
+
+`menu` is the only one with no Hyprland counterpart — Omarchy reaches its menu through
+`exec walker`, and toe's is built in.
 
 The TOML parser is a dependency-free subset: tables, arrays of tables, bare and quoted keys,
 basic and literal strings, numbers, booleans, arrays and inline tables. No multi-line strings
@@ -220,7 +304,8 @@ log stream --predicate 'subsystem == "com.clifmeister.toe"' --level info
 ## Not included
 
 By design: no scratchpads, no binding modes, no scripting API, no resize bindings, no window
-groups. It is a layout engine and the bindings that drive it.
+groups. It is a layout engine and the bindings that drive it — and a menu onto the bindings, whose
+entries are compiled in for the same reason.
 
 ## License
 

--- a/Sources/ToeCore/Colour.swift
+++ b/Sources/ToeCore/Colour.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// A parsed colour, in the `#RRGGBB` / `#RRGGBBAA` spellings Hyprland's `rgba()` uses.
+///
+/// Lives here rather than beside the AppKit code that draws it so it can be tested headlessly:
+/// three surfaces need it now — the focus border, the quick menu's accent, and the theme
+/// swatch — and a hex parser is exactly the kind of thing that quietly forks into three
+/// slightly different versions.
+public struct RGBA: Equatable, Sendable {
+    public var r: Double
+    public var g: Double
+    public var b: Double
+    public var a: Double
+
+    public init(r: Double, g: Double, b: Double, a: Double) {
+        self.r = r; self.g = g; self.b = b; self.a = a
+    }
+
+    /// Parses `#RRGGBB` and `#RRGGBBAA`, with `#` or `0x` optional. Alpha defaults to opaque.
+    /// Returns nil rather than a fallback colour: the caller knows what its fallback should be.
+    public static func parse(hex: String) -> RGBA? {
+        var text = hex.trimmingCharacters(in: .whitespaces)
+        if text.hasPrefix("#") { text.removeFirst() }
+        if text.hasPrefix("0x") || text.hasPrefix("0X") { text.removeFirst(2) }
+        guard text.count == 6 || text.count == 8, let value = UInt64(text, radix: 16) else {
+            return nil
+        }
+        let hasAlpha = text.count == 8
+        return RGBA(r: Double((value >> (hasAlpha ? 24 : 16)) & 0xFF) / 255,
+                    g: Double((value >> (hasAlpha ? 16 : 8)) & 0xFF) / 255,
+                    b: Double((value >> (hasAlpha ? 8 : 0)) & 0xFF) / 255,
+                    a: hasAlpha ? Double(value & 0xFF) / 255 : 1)
+    }
+
+    public func withAlpha(_ alpha: Double) -> RGBA {
+        RGBA(r: r, g: g, b: b, a: alpha)
+    }
+}

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -108,6 +108,12 @@ persistent_workspaces = 5
 "super-j"       = "togglesplit"
 "super-t"       = "togglefloating"
 
+# ── The menu ──────────────────────────────────────────────────────────────────
+# Omarchy binds SUPER+SPACE to `walker`, its launcher and command menu. toe's is built in:
+# type to filter, arrows or CTRL+N/P to move, ENTER to pick, ESC to go back, SUPER+SPACE again
+# to dismiss.
+"super-space" = "menu"
+
 # ── Launch ────────────────────────────────────────────────────────────────────
 # AppleScript's `new window` reuses the running instance, so the window opens on the current
 # workspace without a second app process lingering. `ghostty +new-window` is not supported on

--- a/Sources/ToeCore/Config/TOMLEdit.swift
+++ b/Sources/ToeCore/Config/TOMLEdit.swift
@@ -1,0 +1,208 @@
+import Foundation
+
+/// Rewrites individual scalar values in an existing TOML document, in place.
+///
+/// Deliberately *not* a serialiser. `TOML.swift` cannot round-trip a config file: its parser
+/// discards comments and hands back an unordered dictionary, and toe.toml is roughly two-thirds
+/// comments — comments that *are* the documentation, explaining hot reloading and carrying each
+/// section's Omarchy provenance. Regenerating the file would throw all of that away.
+///
+/// So this only ever replaces the value span of a bare key inside a named single table, inserts
+/// that key if the table is there without it, or appends the table if it is missing entirely.
+/// Leading whitespace, the alignment padding before `=`, and any trailing comment all survive.
+/// It never touches `[[arrays of tables]]`.
+public enum TOMLEdit {
+
+    public struct Edit: Equatable {
+        public let table: String
+        public let key: String
+        public let value: TOMLValue
+        public init(table: String, key: String, value: TOMLValue) {
+            self.table = table
+            self.key = key
+            self.value = value
+        }
+    }
+
+    public static func apply(_ edits: [Edit], to text: String) -> String {
+        var lines = text.components(separatedBy: "\n")
+        // Grouped so a table is only walked once however many of its keys are being set.
+        for table in orderedTables(of: edits) {
+            let keyed = edits.filter { $0.table == table }
+            lines = applyToTable(table, keyed, lines)
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    // MARK: - One table at a time
+
+    private static func orderedTables(of edits: [Edit]) -> [String] {
+        var seen = Set<String>()
+        return edits.compactMap { seen.insert($0.table).inserted ? $0.table : nil }
+    }
+
+    private static func applyToTable(_ table: String, _ edits: [Edit], _ lines: [String]) -> [String] {
+        var lines = lines
+        var pending = edits
+        /// The index just past the table's last key-bearing line — where a missing key goes, so it
+        /// lands inside its own section rather than at the end of the file.
+        var insertionPoint: Int?
+        var current: String?
+
+        var index = 0
+        while index < lines.count {
+            let line = lines[index]
+            if let header = tableHeader(of: line) {
+                // `nil` for `[[array]]`: a header we must never treat as a target, so that
+                // `[[float]]` can never be mistaken for `[float]`.
+                current = header
+                if header == table { insertionPoint = index + 1 }
+                index += 1
+                continue
+            }
+            guard current == table else { index += 1; continue }
+
+            if let name = keyName(of: line) {
+                insertionPoint = index + 1
+                if let edit = pending.first(where: { $0.key == name }) {
+                    lines[index] = replacingValue(in: line, with: serialise(edit.value))
+                    pending.removeAll { $0.key == name }
+                }
+            }
+            index += 1
+        }
+
+        guard !pending.isEmpty else { return lines }
+
+        if let point = insertionPoint {
+            lines.insert(contentsOf: pending.map { "\($0.key) = \(serialise($0.value))" }, at: point)
+        } else {
+            // The table is not in the file at all. Append it, with a blank line to separate it
+            // from whatever came before.
+            if lines.last?.isEmpty == false { lines.append("") }
+            lines.append("[\(table)]")
+            lines.append(contentsOf: pending.map { "\($0.key) = \(serialise($0.value))" })
+            lines.append("")
+        }
+        return lines
+    }
+
+    // MARK: - Line classification
+
+    /// The table this line opens, or nil if it is not a single-table header. `[[float]]` returns
+    /// nil *and* is treated as leaving the target table, which the caller relies on.
+    private static func tableHeader(of line: String) -> String? {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix("[") else { return nil }
+        if trimmed.hasPrefix("[[") { return "" }        // an array of tables: never a target
+        guard let close = trimmed.firstIndex(of: "]") else { return nil }
+        let name = String(trimmed[trimmed.index(after: trimmed.startIndex)..<close])
+            .trimmingCharacters(in: .whitespaces)
+        return name.isEmpty ? nil : unquoted(name)
+    }
+
+    /// The bare or quoted key this line assigns to, or nil for a comment, a blank line, or
+    /// anything without an `=` outside a string.
+    private static func keyName(of line: String) -> String? {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { return nil }
+        guard let equals = equalsIndex(in: line) else { return nil }
+        let name = String(line[line.startIndex..<equals]).trimmingCharacters(in: .whitespaces)
+        return name.isEmpty ? nil : unquoted(name)
+    }
+
+    /// The first `=` that is not inside a quoted string.
+    private static func equalsIndex(in line: String) -> String.Index? {
+        var quote: Character?
+        var escaped = false
+        var i = line.startIndex
+        while i < line.endIndex {
+            let c = line[i]
+            if escaped {
+                escaped = false
+            } else if c == "\\", quote == "\"" {
+                escaped = true
+            } else if let q = quote {
+                if c == q { quote = nil }
+            } else if c == "\"" || c == "'" {
+                quote = c
+            } else if c == "#" {
+                return nil                      // a comment before any `=`
+            } else if c == "=" {
+                return i
+            }
+            i = line.index(after: i)
+        }
+        return nil
+    }
+
+    private static func unquoted(_ s: String) -> String {
+        guard s.count >= 2, let first = s.first, first == "\"" || first == "'", s.last == first
+        else { return s }
+        return String(s.dropFirst().dropLast())
+    }
+
+    /// Replaces only the span between `=` and any trailing comment, so the leading whitespace, the
+    /// padding that keeps a block's `=` in a column, and the comment itself are all preserved.
+    private static func replacingValue(in line: String, with value: String) -> String {
+        guard let equals = equalsIndex(in: line) else { return line }
+        let afterEquals = line.index(after: equals)
+        let rest = line[afterEquals...]
+
+        // Where the value starts, and where a trailing comment starts (outside any string).
+        var quote: Character?
+        var escaped = false
+        var commentStart: String.Index?
+        var i = rest.startIndex
+        while i < rest.endIndex {
+            let c = rest[i]
+            if escaped {
+                escaped = false
+            } else if c == "\\", quote == "\"" {
+                escaped = true
+            } else if let q = quote {
+                if c == q { quote = nil }
+            } else if c == "\"" || c == "'" {
+                quote = c
+            } else if c == "#" {
+                commentStart = i
+                break
+            }
+            i = rest.index(after: i)
+        }
+
+        let leading = rest.prefix { $0 == " " || $0 == "\t" }
+        let gap = leading.isEmpty ? " " : String(leading)
+        if let commentStart {
+            // Keep the run of whitespace immediately before the comment, so the comment column
+            // survives too.
+            let beforeComment = rest[rest.startIndex..<commentStart]
+            let trailing = beforeComment.reversed().prefix { $0 == " " || $0 == "\t" }
+            return String(line[line.startIndex...equals]) + gap + value
+                + String(trailing) + String(rest[commentStart...])
+        }
+        return String(line[line.startIndex...equals]) + gap + value
+    }
+
+    // MARK: - Values
+
+    /// Only the scalars this ever writes. Arrays and inline tables are not expressible on
+    /// purpose: this is a value substituter, not a serialiser.
+    private static func serialise(_ value: TOMLValue) -> String {
+        switch value {
+        case .string(let s):
+            let escaped = s.replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "\"", with: "\\\"")
+            return "\"\(escaped)\""
+        case .int(let i):
+            return String(i)
+        case .double(let d):
+            // `5.0` rather than `5`, so the value still reads as a float on the way back in.
+            return d == d.rounded() ? String(format: "%.1f", d) : String(d)
+        case .bool(let b):
+            return b ? "true" : "false"
+        case .array, .table:
+            preconditionFailure("TOMLEdit writes scalars only; got \(value)")
+        }
+    }
+}

--- a/Sources/ToeCore/Dispatch/Command.swift
+++ b/Sources/ToeCore/Dispatch/Command.swift
@@ -7,7 +7,10 @@ public enum WorkspaceTarget: Equatable {
     case former         // `workspace previous` in Hyprland: the last one you were on
 }
 
-/// The dispatchers toe implements. Names match Hyprland's so bindings can be copied over.
+/// The dispatchers toe implements. Names match Hyprland's so bindings can be copied over —
+/// with one exception: `menu` has no Hyprland counterpart, because Omarchy reaches SUPER+SPACE's
+/// menu through `exec walker`. toe's is built in, so it gets a dispatcher of its own rather than
+/// hiding inside an `exec` string.
 public enum Command: Equatable {
     case moveFocus(Direction)
     case swapWindow(Direction)
@@ -20,6 +23,34 @@ public enum Command: Equatable {
     case swapSplit
     case exec(String)
     case reload
+    /// The quick menu — toe's own, see the note above.
+    case menu
+
+    /// The command written back out in the spelling `CommandParser` accepts, so
+    /// `parse(described) == self` for every case. The quick menu shows this beside a binding.
+    public var described: String {
+        switch self {
+        case .moveFocus(let d):     return "movefocus \(d.hyprlandLetter)"
+        case .swapWindow(let d):    return "swapwindow \(d.hyprlandLetter)"
+        case .moveWindow(let d):    return "movewindow \(d.hyprlandLetter)"
+        case .workspace(let t):
+            switch t {
+            case .index(let n):  return "workspace \(n)"
+            case .next:          return "workspace next"
+            case .previous:      return "workspace prev"
+            case .former:        return "workspace previous"
+            }
+        case .moveToWorkspace(let n, let follow):
+            return follow ? "movetoworkspace \(n)" : "movetoworkspacesilent \(n)"
+        case .killActive:       return "killactive"
+        case .toggleFloating:   return "togglefloating"
+        case .toggleSplit:      return "togglesplit"
+        case .swapSplit:        return "swapsplit"
+        case .exec(let line):   return "exec \(line)"
+        case .reload:           return "reload"
+        case .menu:             return "menu"
+        }
+    }
 }
 
 public enum CommandError: Error, CustomStringConvertible {
@@ -72,6 +103,7 @@ public enum CommandParser {
         case "togglesplit":                 return .toggleSplit
         case "swapsplit":                   return .swapSplit
         case "reload":                      return .reload
+        case "menu":                        return .menu
 
         case "exec", "exec-and-forget":
             guard !argument.isEmpty else { throw CommandError.missingArgument(name) }

--- a/Sources/ToeCore/Layout/Direction.swift
+++ b/Sources/ToeCore/Layout/Direction.swift
@@ -14,6 +14,19 @@ public enum Direction: String, CaseIterable, Sendable {
         }
     }
 
+    /// The single letter Hyprland writes, which is also what `Direction.init` reads back.
+    public var hyprlandLetter: String {
+        switch self {
+        case .left: return "l"
+        case .right: return "r"
+        case .up: return "u"
+        case .down: return "d"
+        }
+    }
+
+    /// For menu rows and anything else user-facing.
+    public var label: String { rawValue.capitalized }
+
     public var opposite: Direction {
         switch self {
         case .left: return .right

--- a/Sources/ToeCore/Menu/BorderTheme.swift
+++ b/Sources/ToeCore/Menu/BorderTheme.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// A focus-border gradient, named after the Omarchy theme it comes from.
+///
+/// Hyprland writes `col.active_border = rgba(7aa2f7ee) rgba(bb9af7ee) 45deg`; toe's spelling is
+/// `#rrggbbaa`, so an Omarchy theme converts by dropping `rgba(` and `)` and prefixing `#` — the
+/// `ee` alpha is already toe's own default. Values are lifted from each theme's `hyprland.conf`
+/// rather than eyeballed from its palette, which is the same standard the dwindle port holds
+/// itself to.
+public struct BorderTheme: Equatable, Sendable {
+    public let id: String
+    public let name: String
+    public let activeStart: String
+    public let activeEnd: String
+
+    public init(id: String, name: String, activeStart: String, activeEnd: String) {
+        self.id = id
+        self.name = name
+        self.activeStart = activeStart
+        self.activeEnd = activeEnd
+    }
+
+    public static let all: [BorderTheme] = [
+        BorderTheme(id: "toe",         name: "toe",         activeStart: "#33ccffee", activeEnd: "#00ff99ee"),
+        BorderTheme(id: "tokyonight",  name: "Tokyo Night", activeStart: "#7aa2f7ee", activeEnd: "#bb9af7ee"),
+        BorderTheme(id: "catppuccin",  name: "Catppuccin",  activeStart: "#89b4faee", activeEnd: "#cba6f7ee"),
+        BorderTheme(id: "nord",        name: "Nord",        activeStart: "#88c0d0ee", activeEnd: "#5e81acee"),
+        BorderTheme(id: "gruvbox",     name: "Gruvbox",     activeStart: "#fabd2fee", activeEnd: "#d65d0eee"),
+        BorderTheme(id: "everforest",  name: "Everforest",  activeStart: "#a7c080ee", activeEnd: "#7fbbb3ee"),
+        BorderTheme(id: "rosepine",    name: "Rosé Pine",   activeStart: "#ebbcbaee", activeEnd: "#c4a7e7ee"),
+        BorderTheme(id: "kanagawa",    name: "Kanagawa",    activeStart: "#7e9cd8ee", activeEnd: "#957fb8ee"),
+        BorderTheme(id: "matteblack",  name: "Matte Black", activeStart: "#8a8a8dee", activeEnd: "#4a4a4dee"),
+    ]
+
+    /// Which theme, if any, the running config matches — so the menu can tick one without
+    /// storing any state of its own. Compared on the parsed colours rather than the strings, so
+    /// `#7AA2F7EE` and `#7aa2f7ee` are the same theme.
+    public static func matching(_ border: BorderConfig) -> BorderTheme? {
+        let start = RGBA.parse(hex: border.activeStart)
+        let end = RGBA.parse(hex: border.activeEnd)
+        return all.first {
+            RGBA.parse(hex: $0.activeStart) == start && RGBA.parse(hex: $0.activeEnd) == end
+        }
+    }
+}
+
+/// The three gaps presets under Style.
+///
+/// Deliberately separate from the themes rather than folded into them: in Omarchy `looknfeel.conf`
+/// is shared across every theme and only the colours change, so a "theme" that also moved your
+/// gaps would be inventing a relationship the reference does not have.
+public struct GapsPreset: Equatable, Sendable {
+    public let id: String
+    public let name: String
+    public let inner: Int
+    public let outer: Int
+
+    public static let all: [GapsPreset] = [
+        GapsPreset(id: "tight",   name: "Tight",   inner: 0,  outer: 0),
+        GapsPreset(id: "omarchy", name: "Omarchy", inner: 5,  outer: 10),
+        GapsPreset(id: "roomy",   name: "Roomy",   inner: 10, outer: 20),
+    ]
+}

--- a/Sources/ToeCore/Menu/FuzzyMatch.swift
+++ b/Sources/ToeCore/Menu/FuzzyMatch.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// walker's filter, near enough: a case-insensitive subsequence match with a score, so typing
+/// `sf` finds Safari before it finds "Transfer files".
+public enum FuzzyMatch {
+
+    public struct Result: Equatable {
+        public let score: Int
+        /// Which characters of the candidate matched, for bold highlighting in the view.
+        public let offsets: [Int]
+    }
+
+    // Scoring weights. Small integers rather than doubles so tests can assert exact orderings.
+    private static let wordStartBonus = 12
+    private static let consecutiveBonus = 8
+    private static let prefixBonus = 10
+    private static let gapPenalty = 1
+    private static let leadingGapPenalty = 2
+
+    /// Greedy left-to-right match. Not optimal-alignment scoring, which for menu titles of a
+    /// handful of words buys nothing you can see and costs a table per keystroke.
+    public static func score(_ query: String, in candidate: String) -> Result? {
+        guard !query.isEmpty else { return Result(score: 0, offsets: []) }
+
+        let haystack = Array(candidate)
+        let lowerHaystack = haystack.map { Character($0.lowercased()) }
+        let needle = Array(query.lowercased())
+
+        var offsets: [Int] = []
+        var score = 0
+        var position = 0
+        var previousMatch = -1
+
+        for target in needle {
+            guard target != " " else { continue }   // spaces in a query never have to match
+            var found = -1
+            var index = position
+            while index < lowerHaystack.count {
+                if lowerHaystack[index] == target { found = index; break }
+                index += 1
+            }
+            guard found >= 0 else { return nil }
+
+            if found == previousMatch + 1 {
+                score += previousMatch >= 0 ? consecutiveBonus : 0
+            } else {
+                let gap = found - max(previousMatch, 0)
+                score -= (previousMatch < 0 ? leadingGapPenalty : gapPenalty) * gap
+            }
+            if isWordStart(haystack, found) { score += wordStartBonus }
+            if found == 0 { score += prefixBonus }
+
+            offsets.append(found)
+            previousMatch = found
+            position = found + 1
+        }
+
+        guard !offsets.isEmpty else { return Result(score: 0, offsets: []) }
+        // Shorter candidates win ties: "Nord" should beat "Nordic something" for `nord`.
+        score -= haystack.count / 8
+        return Result(score: score, offsets: offsets)
+    }
+
+    private static func isWordStart(_ chars: [Character], _ index: Int) -> Bool {
+        guard index > 0 else { return true }
+        let previous = chars[index - 1]
+        if previous == " " || previous == "-" || previous == "_" || previous == "." || previous == "/" {
+            return true
+        }
+        // camelCase, so `mw` finds "macWindow".
+        return previous.isLowercase && chars[index].isUppercase
+    }
+
+    /// Filters and orders a level. Keywords can match but score below the title and contribute no
+    /// offsets, so an entry found by a keyword shows no highlighting rather than misleading
+    /// highlighting.
+    ///
+    /// Stable: entries with equal scores keep their original order, which is what makes the
+    /// selftest's assertions deterministic and what keeps `Workspace 1…10` in numeric order.
+    public static func rank(_ query: String, _ entries: [MenuEntry]) -> [MenuRow] {
+        guard !query.trimmingCharacters(in: .whitespaces).isEmpty else {
+            return entries.map { MenuRow(entry: $0, offsets: []) }
+        }
+
+        var scored: [(row: MenuRow, score: Int, order: Int)] = []
+        for (order, entry) in entries.enumerated() {
+            if let hit = score(query, in: entry.title) {
+                scored.append((MenuRow(entry: entry, offsets: hit.offsets), hit.score, order))
+                continue
+            }
+            let best = entry.keywords.compactMap { score(query, in: $0)?.score }.max()
+            if let best {
+                scored.append((MenuRow(entry: entry, offsets: []), best - wordStartBonus, order))
+            }
+        }
+        return scored
+            .sorted { $0.score != $1.score ? $0.score > $1.score : $0.order < $1.order }
+            .map(\.row)
+    }
+}

--- a/Sources/ToeCore/Menu/MenuAction.swift
+++ b/Sources/ToeCore/Menu/MenuAction.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// Everything a quick menu row can do, as data rather than as a closure.
+///
+/// Anything a hotkey can already do arrives as `.command`, so those rows take the identical path
+/// through `Coordinator.dispatch` — there is no parallel implementation of any dispatcher.
+public enum MenuAction: Equatable {
+    case command(Command)
+    /// Switch to the window's workspace if it is hidden, then focus it. The menu bar's window
+    /// rows already do exactly this; both call `Coordinator.reveal(_:)`.
+    case revealWindow(WindowID)
+
+    // Style. Each writes ~/.config/toe/toe.toml and lets ConfigWatcher reload it.
+    case applyBorderTheme(BorderTheme)
+    case applyGaps(inner: Int, outer: Int)
+    case setBorderEnabled(Bool)
+
+    // Setup
+    case reveal(RevealTarget)
+    case setStartAtLogin(Bool)
+    case removeLegacyLaunchAgent
+
+    // System
+    case system(SystemAction)
+    case restartToe
+    case quitToe
+
+    // About
+    case openURL(String)
+    case copyToClipboard(String)
+
+    /// Unused until the Apps section lands; the shape is fixed now so that change is additive.
+    case launchApp(bundlePath: String)
+}
+
+public enum RevealTarget: Equatable {
+    case configFile
+    case configFolder
+    case accessibilitySettings
+}
+
+/// The macOS equivalents of Omarchy's system menu.
+///
+/// There is no public lock API. `SACLockScreenImmediate` via `dlopen` on `login.framework` would
+/// work, but it would be off-key in a project whose README makes a point of *not* reaching for
+/// private SkyLight calls; `CGSession -suspend` is fast user switching rather than locking, and its
+/// `User.menu` host no longer ships on macOS 26 anyway. So `lock` sends ⌃⌘Q — the same thing the
+/// user's own fingers would do, through the Accessibility grant toe already holds.
+public enum SystemAction: String, Equatable, CaseIterable {
+    case lock
+    case sleepDisplay
+    case sleep
+    case logOut
+    case restart
+    case shutDown
+
+    public var title: String {
+        switch self {
+        case .lock:         return "Lock screen"
+        case .sleepDisplay: return "Sleep display"
+        case .sleep:        return "Sleep"
+        case .logOut:       return "Log out…"
+        case .restart:      return "Restart…"
+        case .shutDown:     return "Shut down…"
+        }
+    }
+
+    /// Policy as pure data; only the `NSAlert` lives in the app layer.
+    ///
+    /// `restart` and `shutDown` sent as System Events commands go straight through without the
+    /// Apple menu's own confirmation, so they need ours. `logOut` *does* raise the system dialog,
+    /// so confirming it here would double up.
+    public var needsConfirmation: Bool {
+        self == .restart || self == .shutDown
+    }
+
+    public var confirmationVerb: String {
+        switch self {
+        case .restart:  return "Restart"
+        case .shutDown: return "Shut Down"
+        default:        return title
+        }
+    }
+
+    public var confirmationMessage: String {
+        switch self {
+        case .restart:  return "Restart your Mac? Applications will be asked to close."
+        case .shutDown: return "Shut down your Mac? Applications will be asked to close."
+        default:        return title
+        }
+    }
+}

--- a/Sources/ToeCore/Menu/MenuContext.swift
+++ b/Sources/ToeCore/Menu/MenuContext.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// One installed application, for the Apps section.
+public struct AppEntry: Equatable, Comparable {
+    public let name: String
+    public let bundlePath: String
+    public init(name: String, bundlePath: String) {
+        self.name = name
+        self.bundlePath = bundlePath
+    }
+    public static func < (a: AppEntry, b: AppEntry) -> Bool {
+        a.name.localizedCaseInsensitiveCompare(b.name) == .orderedAscending
+    }
+}
+
+/// Whether toe launches at login, and by which of the two mechanisms.
+public enum StartAtLoginState: Equatable {
+    case on
+    case off
+    /// `make start-at-login` wrote a LaunchAgent. Registering `SMAppService` on top of it would
+    /// launch a *second* toe, and two instances fight over every window — so the toggle is shown
+    /// disabled and a row offers to remove the plist instead.
+    case legacyLaunchAgent
+    case unavailable
+}
+
+/// Everything the tree is built from, gathered the moment the menu opens.
+///
+/// Nothing is cached between opens — the same discipline `StatusItem.menuNeedsUpdate` already
+/// keeps, and the reason the whole tree can be a pure function of this value.
+public struct MenuContext: Equatable {
+    public var workspaces: [WorkspaceSummary]
+    public var focusedWindow: WindowID?
+    public var focusedWorkspace: Int
+    /// For `isOn` state and for showing the user's own shortcut beside a command.
+    public var config: Config
+    public var version: String
+    public var startAtLogin: StartAtLoginState
+    /// Empty until the Apps section lands.
+    public var apps: [AppEntry]
+
+    public init(workspaces: [WorkspaceSummary] = [],
+                focusedWindow: WindowID? = nil,
+                focusedWorkspace: Int = 1,
+                config: Config = Config(),
+                version: String = "unknown",
+                startAtLogin: StartAtLoginState = .off,
+                apps: [AppEntry] = []) {
+        self.workspaces = workspaces
+        self.focusedWindow = focusedWindow
+        self.focusedWorkspace = focusedWorkspace
+        self.config = config
+        self.version = version
+        self.startAtLogin = startAtLogin
+        self.apps = apps
+    }
+
+    public static let empty = MenuContext()
+
+    public var hasFocusedWindow: Bool { focusedWindow != nil }
+
+    /// The user's own shortcut for a command, so a menu row never claims a binding they have
+    /// rebound. Nil when nothing is bound to it.
+    public func shortcut(for command: Command) -> String? {
+        config.bindings.first { $0.command == command }?.describedShortcut
+    }
+
+    public func workspace(_ index: Int) -> WorkspaceSummary? {
+        workspaces.first { $0.index == index }
+    }
+}

--- a/Sources/ToeCore/Menu/MenuEntry.swift
+++ b/Sources/ToeCore/Menu/MenuEntry.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+/// One row of the quick menu.
+///
+/// Deliberately AppKit-free: an icon is *named*, not drawn, and an action is *described*, not
+/// closed over. That is what lets the whole tree be a value the selftest can assert against, and
+/// it keeps every side effect in `Sources/toe` where it belongs.
+public struct MenuEntry: Equatable {
+
+    public enum Kind: Equatable {
+        case action(MenuAction)
+        /// Recurses through `Array`, so no `indirect` is needed and `Equatable` synthesises.
+        case submenu([MenuEntry])
+        /// A label you cannot select: "No windows", the version row.
+        case info
+    }
+
+    /// Stable and hierarchical — `"windows"`, `"windows.4271"`, `"style.theme.nord"`. Tests
+    /// assert against these rather than against titles, which are free to be reworded.
+    public let id: String
+    public let title: String
+    /// Right-aligned hint: a shortcut, a window count, a workspace number, "empty".
+    public let detail: String?
+    public let icon: MenuIcon?
+    /// Matchable but never displayed — "browser" finds Safari.
+    public let keywords: [String]
+    public let kind: Kind
+    public var isEnabled: Bool
+    /// A checkmark: the current workspace, the active theme.
+    public var isOn: Bool
+
+    public init(id: String,
+                title: String,
+                detail: String? = nil,
+                icon: MenuIcon? = nil,
+                keywords: [String] = [],
+                kind: Kind,
+                isEnabled: Bool = true,
+                isOn: Bool = false) {
+        self.id = id
+        self.title = title
+        self.detail = detail
+        self.icon = icon
+        self.keywords = keywords
+        self.kind = kind
+        self.isEnabled = isEnabled
+        self.isOn = isOn
+    }
+
+    public var isSubmenu: Bool { if case .submenu = kind { return true }; return false }
+    public var isSelectable: Bool {
+        guard isEnabled else { return false }
+        if case .info = kind { return false }
+        return true
+    }
+    public var children: [MenuEntry] {
+        if case .submenu(let items) = kind { return items }
+        return []
+    }
+
+    // Small conveniences, so MenuTree reads as a list of rows rather than a wall of initialisers.
+    /// No `detail` by default: a row that drills down already says so with its chevron, and a bare
+    /// count beside every top-level row is noise Omarchy's own menu does without. An empty submenu
+    /// is disabled rather than a dead end you can walk into.
+    public static func submenu(_ id: String, _ title: String, icon: MenuIcon? = nil,
+                               keywords: [String] = [], _ items: [MenuEntry]) -> MenuEntry {
+        MenuEntry(id: id, title: title, detail: nil,
+                  icon: icon, keywords: keywords, kind: .submenu(items),
+                  isEnabled: !items.isEmpty)
+    }
+
+    public static func action(_ id: String, _ title: String, _ action: MenuAction,
+                              detail: String? = nil, icon: MenuIcon? = nil,
+                              keywords: [String] = [], isEnabled: Bool = true,
+                              isOn: Bool = false) -> MenuEntry {
+        MenuEntry(id: id, title: title, detail: detail, icon: icon, keywords: keywords,
+                  kind: .action(action), isEnabled: isEnabled, isOn: isOn)
+    }
+
+    public static func info(_ id: String, _ title: String, detail: String? = nil,
+                            icon: MenuIcon? = nil) -> MenuEntry {
+        MenuEntry(id: id, title: title, detail: detail, icon: icon, kind: .info, isEnabled: false)
+    }
+}
+
+/// Semantic, so ToeCore names an icon and `Sources/toe` decides how to draw it.
+///
+/// SF Symbols rather than Omarchy's Nerd Font glyphs, and on purpose: `StatusItem.marker` draws
+/// its workspace square rather than setting a glyph precisely so toe needs no font installed, and
+/// shipping glyphs here would be tofu on a stock Mac. The nerd-font name each symbol stands in for
+/// is recorded beside it in `MenuIcon.Section.symbolName`.
+public enum MenuIcon: Equatable {
+    case section(Section)
+    /// Reuses the marker `StatusItem` already draws for the menu bar strip.
+    case workspace(index: Int, filled: Bool)
+    /// `NSRunningApplication(processIdentifier:)?.icon`
+    case runningApp(pid: Int32)
+    /// A theme swatch, drawn with the same gradient as the focus border.
+    case gradient(start: String, end: String)
+    /// An SF Symbol name, for one-offs.
+    case symbol(String)
+
+    public enum Section: String, Equatable, CaseIterable {
+        case apps, windows, workspaces, layout, style, setup, system, about
+
+        /// The SF Symbol, and the Omarchy glyph it stands in for.
+        public var symbolName: String {
+            switch self {
+            case .apps:       return "square.grid.2x2"          // nf-md-apps
+            case .windows:    return "macwindow.on.rectangle"   // nf-md-window_restore
+            case .workspaces: return "rectangle.3.group"        // nf-md-view_dashboard
+            case .layout:     return "rectangle.split.2x1"      // nf-md-view_split_vertical
+            case .style:      return "paintpalette"             // nf-md-palette
+            case .setup:      return "slider.horizontal.3"      // nf-md-tune
+            case .system:     return "power"                    // nf-md-power
+            case .about:      return "info.circle"              // nf-md-information_outline
+            }
+        }
+    }
+}

--- a/Sources/ToeCore/Menu/MenuKeyMapping.swift
+++ b/Sources/ToeCore/Menu/MenuKeyMapping.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// A keystroke, once the quick menu has decided what it means.
+public enum MenuKey: Equatable {
+    case character(Character)
+    case backspace
+    case deleteWord
+    case clearLine
+    case up, down, home, end, pageUp, pageDown
+    case enter, escape, tab
+}
+
+public extension MenuKey {
+
+    /// Translates a raw keystroke. `characters` must be `NSEvent.charactersIgnoringModifiers`.
+    ///
+    /// That last part is load-bearing, and it is why this mapping lives in ToeCore where the
+    /// selftest can pin it: SUPER *is* Option by default, so a user who opens the menu with
+    /// ⌥Space and keeps ⌥ held while typing produces `å ∂ ƒ` in `event.characters`. Option-modified
+    /// letters have to come through as the plain letter or the filter is unusable for exactly the
+    /// people most likely to be using it.
+    ///
+    /// Returns nil for anything the menu should not act on — Command-anything, in particular, so
+    /// ⌘Q and ⌘Tab still mean what they always mean.
+    static func from(keyCode: UInt32, characters: String, modifiers: Modifiers) -> MenuKey? {
+        if modifiers.contains(.command) { return nil }
+
+        switch keyCode {
+        case 0x7E: return .up
+        case 0x7D: return .down
+        case 0x24, 0x4C: return .enter          // Return and the keypad's Enter
+        case 0x35: return .escape
+        case 0x33: return .backspace
+        case 0x30: return .tab
+        case 0x73: return .home
+        case 0x77: return .end
+        case 0x74: return .pageUp
+        case 0x79: return .pageDown
+        default: break
+        }
+
+        // Emacs-style navigation, as walker and every dmenu-alike accept it.
+        if modifiers.contains(.control) {
+            switch characters.lowercased() {
+            case "n": return .down
+            case "p": return .up
+            case "w": return .deleteWord
+            case "u": return .clearLine
+            case "a": return .home
+            case "e": return .end
+            case "h": return .backspace
+            default: return nil
+            }
+        }
+
+        guard let character = characters.first, characters.count == 1 else { return nil }
+        // Printable only: no control characters, no function-key private-use scalars.
+        guard !character.isNewline,
+              let scalar = character.unicodeScalars.first,
+              scalar.value >= 0x20, scalar.value < 0xE000
+        else { return nil }
+        return .character(character)
+    }
+}

--- a/Sources/ToeCore/Menu/MenuState.swift
+++ b/Sources/ToeCore/Menu/MenuState.swift
@@ -1,0 +1,182 @@
+import Foundation
+
+/// One visible row: an entry plus which of its title's characters the query matched.
+public struct MenuRow: Equatable {
+    public let entry: MenuEntry
+    public let offsets: [Int]
+    public init(entry: MenuEntry, offsets: [Int]) {
+        self.entry = entry
+        self.offsets = offsets
+    }
+}
+
+/// What the host should do about a keystroke.
+public enum MenuOutcome: Equatable {
+    case ignored
+    case redraw
+    case dismiss
+    /// A leaf action. `.submenu` is pushed internally and never surfaces here.
+    case perform(MenuAction)
+}
+
+/// The whole quick menu interaction as a value: the level stack, the query, the selection and the
+/// scroll window. Everything the panel draws comes from here, so the view holds no state of its own
+/// and every rule below is assertable headlessly.
+public struct MenuState {
+
+    public struct Level: Equatable {
+        public let title: String
+        public let items: [MenuEntry]
+        var query: String = ""
+        var selection: Int = 0
+        var scrollOffset: Int = 0
+    }
+
+    private var stack: [Level]
+    public let wraps: Bool
+    public var visibleRows: Int
+
+    public init(root: MenuEntry, visibleRows: Int, wraps: Bool = true) {
+        self.stack = [Level(title: root.title, items: root.children)]
+        self.visibleRows = max(1, visibleRows)
+        self.wraps = wraps
+    }
+
+    // MARK: - What the view reads
+
+    public var query: String { stack[stack.count - 1].query }
+    public var selection: Int { stack[stack.count - 1].selection }
+    public var scrollOffset: Int { stack[stack.count - 1].scrollOffset }
+    public var depth: Int { stack.count - 1 }
+    public var breadcrumb: [String] { stack.map(\.title) }
+    /// walker's `-p` prompt: the level you are in, with an ellipsis.
+    public var prompt: String { "\(stack[stack.count - 1].title)…" }
+    public var rows: [MenuRow] {
+        FuzzyMatch.rank(stack[stack.count - 1].query, stack[stack.count - 1].items)
+    }
+    public var selectedRow: MenuRow? {
+        let rows = self.rows
+        guard rows.indices.contains(selection) else { return nil }
+        return rows[selection]
+    }
+
+    /// Pushes a level built by the host — used for the `Confirm / Cancel` step, which needs to
+    /// exist only for as long as the question is on screen.
+    public mutating func push(title: String, items: [MenuEntry]) {
+        stack.append(Level(title: title, items: items))
+    }
+
+    // MARK: - Key handling
+
+    public mutating func handle(_ key: MenuKey) -> MenuOutcome {
+        switch key {
+        case .character(let c):
+            stack[stack.count - 1].query.append(c)
+            resetSelection()
+            return .redraw
+
+        case .backspace:
+            if stack[stack.count - 1].query.isEmpty {
+                // Nothing left to delete, so Backspace means "back" — except at the root, where
+                // only Esc dismisses. Backspacing your way out of the menu entirely would be
+                // surprising.
+                return pop() ? .redraw : .ignored
+            }
+            stack[stack.count - 1].query.removeLast()
+            resetSelection()
+            return .redraw
+
+        case .deleteWord:
+            guard !stack[stack.count - 1].query.isEmpty else { return .ignored }
+            var text = stack[stack.count - 1].query
+            while let last = text.last, last == " " { text.removeLast() }
+            while let last = text.last, last != " " { text.removeLast() }
+            stack[stack.count - 1].query = text
+            resetSelection()
+            return .redraw
+
+        case .clearLine:
+            guard !stack[stack.count - 1].query.isEmpty else { return .ignored }
+            stack[stack.count - 1].query = ""
+            resetSelection()
+            return .redraw
+
+        case .up:      return move(by: -1)
+        case .down:    return move(by: 1)
+        case .pageUp:  return move(by: -visibleRows)
+        case .pageDown: return move(by: visibleRows)
+
+        case .home:
+            guard !rows.isEmpty else { return .ignored }
+            return select(0)
+
+        case .end:
+            guard !rows.isEmpty else { return .ignored }
+            return select(rows.count - 1)
+
+        case .enter, .tab:
+            guard let row = selectedRow, row.entry.isSelectable else { return .ignored }
+            switch row.entry.kind {
+            case .submenu(let items):
+                stack.append(Level(title: row.entry.title, items: items))
+                return .redraw
+            case .action(let action):
+                // Tab is descend-only: it should never fire an action by accident while
+                // someone is reaching for it as a navigation key.
+                guard key == .enter else { return .ignored }
+                return .perform(action)
+            case .info:
+                return .ignored
+            }
+
+        case .escape:
+            return pop() ? .redraw : .dismiss
+        }
+    }
+
+    // MARK: - Selection and scrolling
+
+    private mutating func resetSelection() {
+        stack[stack.count - 1].selection = 0
+        stack[stack.count - 1].scrollOffset = 0
+    }
+
+    private mutating func move(by delta: Int) -> MenuOutcome {
+        let count = rows.count
+        guard count > 0 else { return .ignored }
+        var next = selection + delta
+        if wraps, abs(delta) == 1 {
+            next = (next + count) % count
+        } else {
+            next = min(max(next, 0), count - 1)
+        }
+        return select(next)
+    }
+
+    private mutating func select(_ index: Int) -> MenuOutcome {
+        let count = rows.count
+        guard count > 0 else { return .ignored }
+        let clamped = min(max(index, 0), count - 1)
+        stack[stack.count - 1].selection = clamped
+        stack[stack.count - 1].scrollOffset = clampedScroll(for: clamped, count: count)
+        return .redraw
+    }
+
+    /// Keeps the selection inside the visible window, scrolling by the minimum needed — so paging
+    /// down through a long list moves one row at a time at the bottom edge rather than jumping.
+    private func clampedScroll(for selection: Int, count: Int) -> Int {
+        var offset = scrollOffset
+        if selection < offset { offset = selection }
+        if selection >= offset + visibleRows { offset = selection - visibleRows + 1 }
+        let maxOffset = max(0, count - visibleRows)
+        return min(max(0, offset), maxOffset)
+    }
+
+    /// Leaves the level you were in behind entirely, query and all: coming back to a level with
+    /// your old filter still applied would be a small mystery every time.
+    private mutating func pop() -> Bool {
+        guard stack.count > 1 else { return false }
+        stack.removeLast()
+        return true
+    }
+}

--- a/Sources/ToeCore/Menu/MenuTree.swift
+++ b/Sources/ToeCore/Menu/MenuTree.swift
@@ -1,0 +1,360 @@
+import Foundation
+
+/// The quick menu's contents.
+///
+/// Compiled in rather than configurable, which is the same call the README's "Not included" list
+/// makes about a scripting API: toe is a layout engine and the bindings that drive it, and a menu
+/// you have to configure is a scripting API with a nicer name.
+///
+/// The shape follows Omarchy's `omarchy-menu` — a top-level "Go" that drills into submenus — with
+/// the entries adapted to macOS. Omarchy's Install, Remove, Update and Learn are pacman, AUR and
+/// Arch documentation, so they have no counterpart here; Learn's `Keybindings` survives, under
+/// About, where it is generated from the live config.
+public enum MenuTree {
+
+    public static func root(_ c: MenuContext) -> MenuEntry {
+        MenuEntry(id: "root", title: "Go", kind: .submenu([
+            .submenu("windows", "Windows", icon: .section(.windows),
+                     keywords: ["window", "switch", "focus", "jump"], windows(c)),
+            .submenu("workspaces", "Workspaces", icon: .section(.workspaces),
+                     keywords: ["workspace", "desktop", "move"], workspaces(c)),
+            .submenu("layout", "Layout", icon: .section(.layout),
+                     keywords: ["split", "float", "tile", "dwindle"], layout(c)),
+            .submenu("style", "Style", icon: .section(.style),
+                     keywords: ["theme", "colour", "color", "border", "gaps"], style(c)),
+            .submenu("setup", "Setup", icon: .section(.setup),
+                     keywords: ["config", "settings", "preferences"], setup(c)),
+            .submenu("system", "System", icon: .section(.system),
+                     keywords: ["lock", "sleep", "restart", "shutdown", "power"], system()),
+            .submenu("about", "About", icon: .section(.about),
+                     keywords: ["version", "help", "keybindings"], about(c)),
+        ]))
+    }
+
+    // MARK: - Windows
+
+    /// The focused workspace's windows flat at the top, because that is what you nearly always
+    /// want, with everything else one level down.
+    public static func windows(_ c: MenuContext) -> [MenuEntry] {
+        var entries: [MenuEntry] = []
+
+        let here = c.workspace(c.focusedWorkspace)?.apps ?? []
+        for app in here {
+            entries.append(windowRow(app, workspace: c.focusedWorkspace, showWorkspace: false))
+        }
+
+        let elsewhere = c.workspaces.filter { $0.index != c.focusedWorkspace && !$0.isEmpty }
+        if !elsewhere.isEmpty {
+            var rows: [MenuEntry] = []
+            for workspace in elsewhere {
+                for app in workspace.apps {
+                    rows.append(windowRow(app, workspace: workspace.index, showWorkspace: true))
+                }
+            }
+            entries.append(.submenu("windows.elsewhere", "On other workspaces",
+                                    icon: .section(.workspaces),
+                                    keywords: ["hidden", "all"], rows))
+        }
+
+        if entries.isEmpty {
+            entries.append(.info("windows.none", "No windows"))
+        }
+        return entries
+    }
+
+    private static func windowRow(_ app: AppSummary, workspace: Int, showWorkspace: Bool) -> MenuEntry {
+        // `Safari  ×2` is the spelling the menu bar already uses for a grouped app.
+        let title = app.windowCount > 1 ? "\(app.name)  ×\(app.windowCount)" : app.name
+        let detail = showWorkspace ? "Workspace \(workspace)" : app.windowTitle
+        return .action("windows.\(app.representativeWindow)", title,
+                       .revealWindow(app.representativeWindow),
+                       detail: detail,
+                       icon: .runningApp(pid: app.pid),
+                       keywords: [app.windowTitle, showWorkspace ? nil : "Workspace \(workspace)"]
+                           .compactMap { $0 })
+    }
+
+    // MARK: - Workspaces
+
+    /// All ten, always — deliberately *not* filtered through `bar.persistent_workspaces`. That
+    /// setting exists to keep the menu bar strip short; a navigator wants stable row positions so
+    /// muscle memory works, and switching to an empty workspace is a legitimate thing to want.
+    public static func workspaces(_ c: MenuContext) -> [MenuEntry] {
+        var entries: [MenuEntry] = []
+
+        for index in 1...WorkspaceManager.workspaceCount {
+            let summary = c.workspace(index)
+            let count = summary?.windowCount ?? 0
+            let isFocused = index == c.focusedWorkspace
+            var detail = count == 0 ? "empty" : (count == 1 ? "1 window" : "\(count) windows")
+            if let name = summary?.monitorName, !isFocused { detail += " · \(name)" }
+            entries.append(.action("workspaces.\(index)", "Workspace \(index)",
+                                   .command(.workspace(.index(index))),
+                                   detail: isFocused
+                                       ? c.shortcut(for: .workspace(.index(index)))
+                                       : detail,
+                                   icon: .workspace(index: index, filled: isFocused),
+                                   isOn: isFocused))
+        }
+
+        // Named for what they do, not for how Hyprland spells them. There is a genuine trap in
+        // `CommandParser`: `workspace prev` is index − 1 while `workspace previous` is the last
+        // one you were on. The menu must not inherit that confusion.
+        entries.append(.action("workspaces.next", "Next workspace", .command(.workspace(.next)),
+                               detail: c.shortcut(for: .workspace(.next)),
+                               icon: .symbol("arrow.right")))
+        entries.append(.action("workspaces.prev", "Previous workspace",
+                               .command(.workspace(.previous)),
+                               detail: c.shortcut(for: .workspace(.previous)),
+                               icon: .symbol("arrow.left"),
+                               keywords: ["before"]))
+        entries.append(.action("workspaces.former", "Back to last visited",
+                               .command(.workspace(.former)),
+                               detail: c.shortcut(for: .workspace(.former)),
+                               icon: .symbol("arrow.uturn.backward"),
+                               keywords: ["former", "toggle"]))
+
+        entries.append(moveWindowSubmenu(c, follow: true))
+        entries.append(moveWindowSubmenu(c, follow: false))
+        return entries
+    }
+
+    private static func moveWindowSubmenu(_ c: MenuContext, follow: Bool) -> MenuEntry {
+        let rows = (1...WorkspaceManager.workspaceCount).map { index in
+            MenuEntry.action("workspaces.move\(follow ? "" : "silent").\(index)",
+                             "Workspace \(index)",
+                             .command(.moveToWorkspace(index, follow: follow)),
+                             detail: c.shortcut(for: .moveToWorkspace(index, follow: follow)),
+                             icon: .workspace(index: index, filled: index == c.focusedWorkspace),
+                             isEnabled: index != c.focusedWorkspace)
+        }
+        var entry = MenuEntry.submenu(follow ? "workspaces.move" : "workspaces.movesilent",
+                                      follow ? "Move window to…" : "Send window to…",
+                                      icon: .symbol(follow ? "arrow.right.square"
+                                                           : "arrow.right.to.line"),
+                                      keywords: follow ? ["send", "throw"]
+                                                       : ["silent", "stay", "without following"],
+                                      rows)
+        entry.isEnabled = c.hasFocusedWindow
+        return entry
+    }
+
+    // MARK: - Layout
+
+    /// Only what toe actually has. No resize rows, no window groups, no fullscreen or monocle —
+    /// there is no `Command` for any of them and the README says as much out loud. `movefocus` is
+    /// left out too: four rows that move focus, offered while you are already holding a menu open,
+    /// are hotkey territory. So is `movewindow`, which is the deliberately non-default i3-style
+    /// reparenting variant and stays a config choice.
+    public static func layout(_ c: MenuContext) -> [MenuEntry] {
+        let enabled = c.hasFocusedWindow
+        var entries: [MenuEntry] = [
+            .action("layout.togglesplit", "Toggle split orientation", .command(.toggleSplit),
+                    detail: c.shortcut(for: .toggleSplit), icon: .symbol("rectangle.split.2x1"),
+                    keywords: ["rotate", "horizontal", "vertical"], isEnabled: enabled),
+            .action("layout.swapsplit", "Swap the two halves", .command(.swapSplit),
+                    detail: c.shortcut(for: .swapSplit),
+                    icon: .symbol("arrow.left.arrow.right.square"),
+                    keywords: ["mirror", "flip"], isEnabled: enabled),
+            .action("layout.togglefloating", "Toggle floating", .command(.toggleFloating),
+                    detail: c.shortcut(for: .toggleFloating), icon: .symbol("macwindow"),
+                    keywords: ["float", "untile"], isEnabled: enabled),
+            .action("layout.killactive", "Close window", .command(.killActive),
+                    detail: c.shortcut(for: .killActive), icon: .symbol("xmark.square"),
+                    keywords: ["quit", "kill"], isEnabled: enabled),
+        ]
+
+        let swaps = Direction.allCases.map { direction in
+            MenuEntry.action("layout.swap.\(direction.rawValue)", direction.label,
+                             .command(.swapWindow(direction)),
+                             detail: c.shortcut(for: .swapWindow(direction)),
+                             icon: .symbol(arrowSymbol(direction)),
+                             isEnabled: enabled)
+        }
+        var swap = MenuEntry.submenu("layout.swap", "Swap window with neighbour",
+                                     icon: .symbol("arrow.up.arrow.down.square"),
+                                     keywords: ["move", "exchange"], swaps)
+        swap.isEnabled = enabled
+        entries.append(swap)
+        return entries
+    }
+
+    private static func arrowSymbol(_ d: Direction) -> String {
+        switch d {
+        case .left: return "arrow.left"
+        case .right: return "arrow.right"
+        case .up: return "arrow.up"
+        case .down: return "arrow.down"
+        }
+    }
+
+    // MARK: - Style
+
+    /// Omarchy's Style menu rewrites config and reloads; so does this. Picking a theme writes
+    /// `[border]` in toe.toml and `ConfigWatcher` does the rest, which is why nothing here has to
+    /// hold any state — `BorderTheme.matching` reads the tick straight back off the live config.
+    public static func style(_ c: MenuContext) -> [MenuEntry] {
+        let active = BorderTheme.matching(c.config.border)
+        let themes = BorderTheme.all.map { theme in
+            MenuEntry.action("style.theme.\(theme.id)", theme.name, .applyBorderTheme(theme),
+                             icon: .gradient(start: theme.activeStart, end: theme.activeEnd),
+                             isOn: theme.id == active?.id)
+        }
+
+        // Gaps are a separate group on purpose. In Omarchy `looknfeel.conf` is shared across every
+        // theme and only the colours change, so a theme that also moved your gaps would be
+        // inventing a relationship the reference does not have.
+        let gaps = GapsPreset.all.map { preset in
+            MenuEntry.action("style.gaps.\(preset.id)", preset.name,
+                             .applyGaps(inner: preset.inner, outer: preset.outer),
+                             detail: "\(preset.inner) / \(preset.outer)",
+                             icon: .symbol("square.dashed"),
+                             isOn: c.config.gaps.inner == Double(preset.inner)
+                                 && c.config.gaps.outer == Double(preset.outer))
+        }
+
+        return [
+            .submenu("style.theme", "Theme", icon: .section(.style),
+                     keywords: ["colour", "color", "gradient", "border"], themes),
+            .submenu("style.gaps", "Gaps", icon: .symbol("square.dashed"),
+                     keywords: ["spacing", "padding", "margin"], gaps),
+            .action("style.border", "Show focus border",
+                    .setBorderEnabled(!c.config.border.enabled),
+                    detail: c.config.border.enabled ? "on" : "off",
+                    icon: .symbol("square.on.square.dashed"),
+                    keywords: ["outline", "highlight"],
+                    isOn: c.config.border.enabled),
+        ]
+    }
+
+    // MARK: - Setup
+
+    public static func setup(_ c: MenuContext) -> [MenuEntry] {
+        var entries: [MenuEntry] = [
+            // No $EDITOR: toe is launched by launchd or Finder, so its environment has none, and
+            // recovering it through a login shell would still leave a second guess about which
+            // terminal to run it in — a choice that lives only inside an opaque `exec` string.
+            // Opening the file is one guess, and it is the user's own.
+            .action("setup.config", "Open config…", .reveal(.configFile),
+                    detail: "~/.config/toe/toe.toml", icon: .symbol("doc.text"),
+                    keywords: ["toml", "edit", "settings"]),
+            .action("setup.folder", "Reveal config folder", .reveal(.configFolder),
+                    icon: .symbol("folder"), keywords: ["finder"]),
+            .action("setup.reload", "Reload config", .command(.reload),
+                    detail: c.shortcut(for: .reload), icon: .symbol("arrow.clockwise")),
+        ]
+
+        switch c.startAtLogin {
+        case .legacyLaunchAgent:
+            entries.append(.action("setup.legacylaunchagent",
+                                   "Started by a LaunchAgent — remove it",
+                                   .removeLegacyLaunchAgent,
+                                   detail: "make start-at-login",
+                                   icon: .symbol("exclamationmark.triangle"),
+                                   keywords: ["login", "startup", "plist"]))
+        case .on, .off:
+            let on = c.startAtLogin == .on
+            entries.append(.action("setup.startatlogin", "Start toe at login",
+                                   .setStartAtLogin(!on),
+                                   detail: on ? "on" : "off",
+                                   icon: .symbol("power.circle"),
+                                   keywords: ["startup", "boot"],
+                                   isOn: on))
+        case .unavailable:
+            break
+        }
+
+        entries.append(.action("setup.accessibility", "Accessibility settings…",
+                               .reveal(.accessibilitySettings),
+                               icon: .symbol("lock.shield"),
+                               keywords: ["permission", "privacy", "grant"]))
+        return entries
+    }
+
+    // MARK: - System
+
+    public static func system() -> [MenuEntry] {
+        var entries = SystemAction.allCases.map { action in
+            MenuEntry.action("system.\(action.rawValue)", action.title, .system(action),
+                             icon: .symbol(systemSymbol(action)),
+                             keywords: systemKeywords(action))
+        }
+        entries.append(.action("system.restarttoe", "Restart toe", .restartToe,
+                               icon: .symbol("arrow.triangle.2.circlepath"),
+                               keywords: ["relaunch"]))
+        entries.append(.action("system.quittoe", "Quit toe", .quitToe,
+                               icon: .symbol("xmark.circle"), keywords: ["exit"]))
+        return entries
+    }
+
+    private static func systemSymbol(_ a: SystemAction) -> String {
+        switch a {
+        case .lock:         return "lock"
+        case .sleepDisplay: return "display"
+        case .sleep:        return "moon"
+        case .logOut:       return "rectangle.portrait.and.arrow.right"
+        case .restart:      return "restart"
+        case .shutDown:     return "power"
+        }
+    }
+
+    private static func systemKeywords(_ a: SystemAction) -> [String] {
+        switch a {
+        case .lock:         return ["screen", "secure"]
+        case .sleepDisplay: return ["screen", "off", "monitor"]
+        case .sleep:        return ["suspend"]
+        case .logOut:       return ["logout", "sign out"]
+        case .restart:      return ["reboot"]
+        case .shutDown:     return ["shutdown", "off", "halt"]
+        }
+    }
+
+    /// The two-row question a hierarchical menu asks instead of a dialog. Pushed by the host when
+    /// an action says it `needsConfirmation`, so it exists only while the question is on screen.
+    ///
+    /// Cancel comes first, and is a label rather than an action, so the row a fresh level preselects
+    /// is one that does nothing: ENTER pressed twice in quick succession cannot restart your Mac.
+    /// You have to move down to the row that acts, or press ESC to back out.
+    public static func confirmation(_ action: SystemAction) -> [MenuEntry] {
+        [
+            .info("confirm.no", "Cancel — or press ESC", icon: .symbol("xmark.circle")),
+            .action("confirm.yes", action.confirmationVerb, .system(action),
+                    icon: .symbol("exclamationmark.triangle")),
+        ]
+    }
+
+    // MARK: - About
+
+    public static func about(_ c: MenuContext) -> [MenuEntry] {
+        // Omarchy's Learn → Keybindings, generated from the live config so it is always accurate.
+        // Each row *runs* its command rather than merely describing it, and this is the one honest
+        // place for a raw `exec` shell string to be shown.
+        let keys = c.config.bindings.map { binding in
+            MenuEntry.action("about.bind.\(binding.source)", binding.describedShortcut,
+                             .command(binding.command),
+                             detail: binding.command.described,
+                             icon: .symbol("keyboard"),
+                             keywords: [binding.command.described, binding.source])
+        }
+
+        return [
+            .action("about.version", "toe \(c.version)",
+                    .copyToClipboard("toe \(c.version)"),
+                    detail: "copy", icon: .section(.about),
+                    keywords: ["version", "build"]),
+            .submenu("about.keybindings", "Keybindings", icon: .symbol("keyboard"),
+                     keywords: ["shortcuts", "learn", "bindings"], keys),
+            .action("about.repo", "toe on GitHub",
+                    .openURL("https://github.com/theclifmeister/toe"),
+                    icon: .symbol("link"), keywords: ["source", "code"]),
+            .action("about.issues", "Report an issue",
+                    .openURL("https://github.com/theclifmeister/toe/issues"),
+                    icon: .symbol("exclamationmark.bubble"), keywords: ["bug"]),
+            .action("about.omarchy", "Omarchy", .openURL("https://omarchy.org"),
+                    icon: .symbol("link"), keywords: ["reference"]),
+            .action("about.dwindle", "Hyprland's dwindle layout",
+                    .openURL("https://wiki.hyprland.org/Configuring/Dwindle-Layout/"),
+                    icon: .symbol("link"), keywords: ["hyprland", "tiling"]),
+        ]
+    }
+}

--- a/Sources/ToeCore/Menu/QuickMenuGeometry.swift
+++ b/Sources/ToeCore/Menu/QuickMenuGeometry.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// walker's metrics, so toe's menu is the same size and shape as the one it is reproducing.
+///
+/// Omarchy calls `omarchy-launch-walker --dmenu --width 295 --minheight 1 --maxheight 630`. Those
+/// two numbers are kept as-is. 295pt is tight for a long window title, which is why the row
+/// renderer gives the title priority and truncates the trailing detail instead: walker is
+/// fixed-width, and growing the panel per submenu would break the resemblance more than a
+/// truncated hint does.
+public enum QuickMenuGeometry {
+
+    public static let width: Double = 295
+    public static let maxHeight: Double = 630
+    public static let promptHeight: Double = 40
+    public static let rowHeight: Double = 30
+    public static let padding: Double = 8
+    public static let cornerRadius: Double = 12
+    /// The hairline between the prompt and the list.
+    public static let separatorHeight: Double = 1
+
+    /// How many rows fit. Never less than one — an empty list still needs somewhere to say so.
+    public static func visibleRows(maxHeight: Double = QuickMenuGeometry.maxHeight) -> Int {
+        let forRows = maxHeight - chrome
+        return max(1, Int((forRows / rowHeight).rounded(.down)))
+    }
+
+    /// Everything that is not a row: the prompt line, the separator, and the padding above and
+    /// below the list.
+    public static var chrome: Double { promptHeight + separatorHeight + 2 * padding }
+
+    public static func height(rowCount: Int) -> Double {
+        min(maxHeight, chrome + Double(max(0, rowCount)) * rowHeight)
+    }
+
+    /// Centred on the given usable area, in AX coordinates. Slightly above centre — walker sits
+    /// where your eyes already are rather than in the dead middle of the screen.
+    public static func frame(rowCount: Int, on usable: Box) -> Box {
+        let h = height(rowCount: rowCount)
+        let w = min(width, usable.w)
+        let x = usable.x + (usable.w - w) / 2
+        let y = usable.y + max(0, (usable.h - h) * 0.35)
+        return Box(x: x.rounded(), y: y.rounded(), w: w, h: h)
+    }
+}

--- a/Sources/ToeCore/Menu/WorkspaceSummary.swift
+++ b/Sources/ToeCore/Menu/WorkspaceSummary.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// One application's presence on a workspace.
+///
+/// Carries `pid` rather than an `NSImage`: the icon is resolved where it is drawn, via
+/// `MenuIcon.runningApp(pid:)`. That one field was the only AppKit thing in here, and without it
+/// both of these become pure data that the quick menu's tree can be built from — which is the
+/// whole reason they moved out of `StatusItem`.
+public struct AppSummary: Equatable {
+    public let name: String
+    public let windowCount: Int
+    public let pid: Int32
+    /// Selecting the row focuses this window.
+    public let representativeWindow: WindowID
+    /// The representative window's title, read fresh when the summary is built.
+    public let windowTitle: String?
+
+    public init(name: String, windowCount: Int, pid: Int32,
+                representativeWindow: WindowID, windowTitle: String? = nil) {
+        self.name = name
+        self.windowCount = windowCount
+        self.pid = pid
+        self.representativeWindow = representativeWindow
+        self.windowTitle = windowTitle
+    }
+}
+
+public struct WorkspaceSummary: Equatable {
+    public let index: Int
+    /// Shown on the monitor that currently has focus.
+    public let isFocused: Bool
+    /// Shown on some monitor — with several displays, more than one workspace is visible.
+    public let isVisible: Bool
+    public let monitorName: String?
+    public let apps: [AppSummary]
+
+    public init(index: Int, isFocused: Bool, isVisible: Bool,
+                monitorName: String?, apps: [AppSummary]) {
+        self.index = index
+        self.isFocused = isFocused
+        self.isVisible = isVisible
+        self.monitorName = monitorName
+        self.apps = apps
+    }
+
+    public var isEmpty: Bool { apps.isEmpty }
+    public var windowCount: Int { apps.reduce(0) { $0 + $1.windowCount } }
+
+    public var stripState: WorkspaceStrip.State {
+        .init(index: index, isFocused: isFocused, isVisible: isVisible, isEmpty: isEmpty)
+    }
+}

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -865,6 +865,540 @@ h.test("clicking the strip picks the workspace under the pointer") { t in
 }
 
 // MARK: - The quick menu
+
+/// A context with three windows spread over two workspaces, so the Windows and Workspaces levels
+/// have something real to be built from.
+func menuFixture() -> MenuContext {
+    let ws1 = WorkspaceSummary(
+        index: 1, isFocused: true, isVisible: true, monitorName: nil,
+        apps: [AppSummary(name: "Ghostty", windowCount: 2, pid: 501,
+                          representativeWindow: 1001, windowTitle: "~/src/toe"),
+               AppSummary(name: "Safari", windowCount: 1, pid: 502,
+                          representativeWindow: 1002, windowTitle: "Hyprland Wiki")])
+    let ws4 = WorkspaceSummary(
+        index: 4, isFocused: false, isVisible: false, monitorName: nil,
+        apps: [AppSummary(name: "Google Chrome", windowCount: 1, pid: 503,
+                          representativeWindow: 1003, windowTitle: "Inbox")])
+    let others = [2, 3, 5, 6, 7, 8, 9, 10].map {
+        WorkspaceSummary(index: $0, isFocused: false, isVisible: false, monitorName: nil, apps: [])
+    }
+    let config = Config.makeDefault()
+    return MenuContext(workspaces: ([ws1, ws4] + others).sorted { $0.index < $1.index },
+                       focusedWindow: 1001,
+                       focusedWorkspace: 1,
+                       config: config,
+                       version: "0.2.0")
+}
+
+h.test("menu parses as a command and round-trips") { t in
+    t.equal(try? CommandParser.parse("menu"), .some(.menu), "the dispatcher exists")
+    // Like `reload`, a trailing argument is ignored rather than rejected — the house style for
+    // commands that take none.
+    t.equal(try? CommandParser.parse("menu extra"), .some(.menu), "an argument is ignored")
+
+    let every: [Command] = [
+        .moveFocus(.left), .moveFocus(.right), .moveFocus(.up), .moveFocus(.down),
+        .swapWindow(.left), .moveWindow(.down),
+        .workspace(.index(1)), .workspace(.index(10)),
+        .workspace(.next), .workspace(.previous), .workspace(.former),
+        .moveToWorkspace(3, follow: true), .moveToWorkspace(7, follow: false),
+        .killActive, .toggleFloating, .toggleSplit, .swapSplit,
+        .exec("osascript -e 'tell application \"Ghostty\" to new window'"),
+        .reload, .menu,
+    ]
+    for command in every {
+        t.equal(try? CommandParser.parse(command.described), .some(command),
+                "\(command.described) round-trips")
+    }
+}
+
+h.test("the shipped config binds SUPER+SPACE to the menu") { t in
+    let config = try! Config.parse(Config.defaultTOML)
+    let binding = config.bindings.first { $0.command == .menu }
+    t.expect(binding != nil, "the default config binds the menu")
+    t.equal(binding?.keyCode, .some(0x31), "kVK_Space")
+    t.equal(binding?.modifiers, .some(Modifiers.option), "SUPER is Option by default")
+    t.equal(binding?.source, .some("super-space"), "written the way Omarchy writes it")
+}
+
+h.test("the root menu drills into seven destinations") { t in
+    let root = MenuTree.root(menuFixture())
+    t.equal(root.children.map(\.id),
+            ["windows", "workspaces", "layout", "style", "setup", "system", "about"],
+            "Omarchy's shape, minus the pacman-shaped sections")
+    t.expect(root.children.allSatisfy(\.isSubmenu), "every top-level row drills down")
+}
+
+h.test("the Windows level puts this workspace first and the rest one level down") { t in
+    let rows = MenuTree.windows(menuFixture())
+    t.equal(rows.map(\.id), ["windows.1001", "windows.1002", "windows.elsewhere"],
+            "the focused workspace's apps, then everything else")
+    t.equal(rows[0].title, "Ghostty  ×2", "grouped apps carry their count")
+    t.equal(rows[0].detail, .some("~/src/toe"), "and the window's current title")
+    t.equal(rows[1].title, "Safari", "a single window needs no count")
+
+    let elsewhere = rows[2].children
+    t.equal(elsewhere.map(\.id), ["windows.1003"], "one window on workspace 4")
+    t.equal(elsewhere[0].detail, .some("Workspace 4"), "which says where it is")
+
+    let empty = MenuTree.windows(MenuContext.empty)
+    t.equal(empty.map(\.id), ["windows.none"], "and an honest empty case")
+    t.expect(!empty[0].isSelectable, "which you cannot activate")
+}
+
+h.test("workspace rows keep all ten slots and tick the one you are on") { t in
+    let rows = MenuTree.workspaces(menuFixture())
+    let numbered = rows.filter { $0.id.hasPrefix("workspaces.") && Int($0.id.dropFirst(11)) != nil }
+    t.equal(numbered.count, 10, "all ten, whatever the bar shows")
+    t.equal(numbered.filter(\.isOn).map(\.id), ["workspaces.1"], "exactly one is current")
+    t.equal(numbered[3].detail, .some("1 window"), "workspace 4 says what is on it")
+    t.equal(numbered[1].detail, .some("empty"), "and an empty one says so")
+
+    if case .action(.command(.workspace(.index(let n)))) = numbered[6].kind {
+        t.equal(n, 7, "row seven switches to workspace seven, through the same dispatcher")
+    } else {
+        t.expect(false, "workspace rows dispatch a command")
+    }
+
+    let move = rows.first { $0.id == "workspaces.move" }
+    t.expect(move?.isEnabled == true, "move-to is available with a focused window")
+    t.expect(move?.children.first { $0.id == "workspaces.move.1" }?.isEnabled == false,
+             "except to the workspace you are already on")
+
+    var noWindow = menuFixture()
+    noWindow.focusedWindow = nil
+    let disabled = MenuTree.workspaces(noWindow).first { $0.id == "workspaces.move" }
+    t.expect(disabled?.isEnabled == false, "and not at all without one")
+}
+
+h.test("layout rows need a window and show the user's own shortcut") { t in
+    let rows = MenuTree.layout(menuFixture())
+    t.equal(rows.map(\.id), ["layout.togglesplit", "layout.swapsplit", "layout.togglefloating",
+                             "layout.killactive", "layout.swap"],
+            "the four commands toe has, plus the swap directions")
+    t.equal(rows[0].detail, .some("alt-j"), "read live from the config, not hardcoded")
+    t.equal(rows[3].detail, .some("alt-w"), "so a rebound key is never misreported")
+
+    var noWindow = menuFixture()
+    noWindow.focusedWindow = nil
+    t.expect(MenuTree.layout(noWindow).allSatisfy { !$0.isEnabled },
+             "all of them are disabled with nothing focused")
+}
+
+h.test("the style level ticks the running theme and gaps") { t in
+    let rows = MenuTree.style(menuFixture())
+    t.equal(rows.map(\.id), ["style.theme", "style.gaps", "style.border"], "three groups")
+
+    let themes = rows[0].children
+    t.equal(themes.filter(\.isOn).map(\.id), ["style.theme.toe"],
+            "the shipped gradient is toe's own theme")
+
+    let gaps = rows[1].children
+    t.equal(gaps.filter(\.isOn).map(\.id), ["style.gaps.omarchy"],
+            "and 5/10 is Omarchy's")
+
+    var recoloured = menuFixture()
+    recoloured.config.border.activeStart = "#7AA2F7EE"      // upper case on purpose
+    recoloured.config.border.activeEnd = "#bb9af7ee"
+    t.equal(MenuTree.style(recoloured)[0].children.filter(\.isOn).map(\.id),
+            ["style.theme.tokyonight"], "matched on colour, not on how the hex is spelled")
+}
+
+h.test("BorderTheme.matching only claims a theme it really is") { t in
+    t.equal(BorderTheme.matching(BorderConfig())?.id, .some("toe"), "the default is toe's own")
+    var odd = BorderConfig()
+    odd.activeStart = "#123456ff"
+    odd.activeEnd = "#654321ff"
+    t.expect(BorderTheme.matching(odd) == nil, "a hand-picked gradient matches nothing")
+}
+
+h.test("the setup level offers the LaunchAgent escape hatch instead of the toggle") { t in
+    var context = menuFixture()
+    context.startAtLogin = .off
+    t.expect(MenuTree.setup(context).contains { $0.id == "setup.startatlogin" },
+             "normally you get a toggle")
+
+    context.startAtLogin = .legacyLaunchAgent
+    let rows = MenuTree.setup(context)
+    t.expect(!rows.contains { $0.id == "setup.startatlogin" },
+             "but not while a LaunchAgent would launch a second toe")
+    t.expect(rows.contains { $0.id == "setup.legacylaunchagent" },
+             "you get the removal row instead")
+}
+
+h.test("only restart and shut down ask twice, and the safe row comes first") { t in
+    t.equal(SystemAction.allCases.filter(\.needsConfirmation), [.restart, .shutDown],
+            "log out raises the system's own dialog, so confirming it here would double up")
+
+    let rows = MenuTree.confirmation(.restart)
+    t.equal(rows.map(\.id), ["confirm.no", "confirm.yes"],
+            "asked as two rows, with Cancel first")
+    t.expect(!rows[0].isSelectable, "Cancel is a label; ESC is the key that means it")
+
+    // A fresh level preselects row 0, so the row ENTER lands on must be the one that does nothing.
+    var menu = MenuState(root: MenuEntry(id: "root", title: "Go", kind: .submenu([])),
+                         visibleRows: 12)
+    menu.push(title: "Restart", items: rows)
+    t.equal(menu.selection, 0, "the selection starts on Cancel")
+    t.equal(menu.handle(.enter), .ignored, "so ENTER twice in a row cannot restart your Mac")
+    t.equal(menu.handle(.down), .redraw, "you have to move to the row that acts")
+    t.equal(menu.handle(.enter), .perform(.system(.restart)), "and then it does")
+    t.equal(menu.handle(.escape), .redraw, "ESC backs out of the question")
+}
+
+h.test("the about level generates keybindings from the live config") { t in
+    let context = menuFixture()
+    let keys = MenuTree.about(context).first { $0.id == "about.keybindings" }?.children ?? []
+    t.equal(keys.count, context.config.bindings.count, "every binding, and only those")
+    let split = keys.first { $0.detail == "togglesplit" }
+    t.equal(split?.title, .some("alt-j"), "shown as the shortcut it is")
+    if case .action(.command(let c)) = split?.kind {
+        t.equal(c, .toggleSplit, "and the row runs it, not just describes it")
+    } else {
+        t.expect(false, "keybinding rows dispatch their command")
+    }
+}
+
+h.test("fuzzy match prefers word starts and runs") { t in
+    func s(_ q: String, _ c: String) -> Int? { FuzzyMatch.score(q, in: c)?.score }
+
+    t.expect(s("sf", "Safari") ?? -999 > s("sf", "Transfer files") ?? 999,
+             "initials beat letters buried mid-word")
+    t.expect(s("tog", "Toggle floating") ?? -999 > s("tog", "Back to last visited group") ?? 999,
+             "a consecutive run beats a scattered one")
+    t.expect(s("nord", "Nord") ?? -999 > s("nord", "Nord Extended Theme") ?? 999,
+             "and the shorter candidate wins a tie")
+    t.expect(s("SAF", "Safari") != nil, "matching is case-insensitive")
+    t.expect(s("xyz", "Safari") == nil, "a non-subsequence does not match at all")
+    t.equal(FuzzyMatch.score("", in: "Safari")?.offsets, .some([]), "an empty query matches with no highlight")
+    t.equal(FuzzyMatch.score("sfr", in: "Safari")?.offsets, .some([0, 2, 4]),
+            "offsets point at the characters that matched")
+}
+
+h.test("ranking is stable, so ten workspaces stay in order") { t in
+    let entries = (1...10).map {
+        MenuEntry.action("w.\($0)", "Workspace \($0)", .command(.workspace(.index($0))))
+    }
+    t.equal(FuzzyMatch.rank("", entries).map(\.entry.id), entries.map(\.id),
+            "an empty query keeps the original order")
+    t.equal(FuzzyMatch.rank("workspace", entries).map(\.entry.id), entries.map(\.id),
+            "and so does a query every row scores the same on")
+}
+
+h.test("keywords match but never highlight") { t in
+    let entries = [
+        MenuEntry.action("a", "Sleep display", .system(.sleepDisplay), keywords: ["monitor"]),
+        MenuEntry.action("b", "Monitor layout", .command(.reload)),
+    ]
+    let rows = FuzzyMatch.rank("monitor", entries)
+    t.equal(rows.map(\.entry.id), ["b", "a"], "a title match outranks a keyword match")
+    t.equal(rows[1].offsets, [], "a keyword hit shows no highlighting rather than misleading it")
+}
+
+h.test("CTRL+N and CTRL+P move like the arrows, and Option-held still types letters") { t in
+    func key(_ code: UInt32, _ chars: String, _ mods: Modifiers = []) -> MenuKey? {
+        MenuKey.from(keyCode: code, characters: chars, modifiers: mods)
+    }
+
+    t.equal(key(0x2D, "n", .control), .some(.down), "ctrl-n")
+    t.equal(key(0x23, "p", .control), .some(.up), "ctrl-p")
+    t.equal(key(0x0D, "w", .control), .some(.deleteWord), "ctrl-w")
+    t.equal(key(0x20, "u", .control), .some(.clearLine), "ctrl-u")
+    t.equal(key(0x00, "a", .control), .some(.home), "ctrl-a")
+    t.equal(key(0x0E, "e", .control), .some(.end), "ctrl-e")
+
+    t.equal(key(0x7E, ""), .some(.up), "the up arrow")
+    t.equal(key(0x24, "\r"), .some(.enter), "return")
+    t.equal(key(0x35, "\u{1B}"), .some(.escape), "escape")
+    t.equal(key(0x33, "\u{7F}"), .some(.backspace), "backspace")
+
+    // The regression this whole mapping exists for. SUPER is Option, so someone who opens the
+    // menu with ⌥Space and keeps ⌥ down must still be typing letters — `charactersIgnoringModifiers`
+    // gives "a" where `characters` would have given "å".
+    t.equal(key(0x00, "a", .option), .some(.character("a")), "option-a is still an a")
+    t.equal(key(0x11, "t", [.option, .shift]), .some(.character("t")), "and so is option-shift-t")
+
+    t.expect(key(0x0C, "q", .command) == nil, "⌘Q is never the menu's to take")
+    t.expect(key(0x30, "\t", .command) == nil, "nor ⌘Tab")
+}
+
+/// Twenty rows, so scrolling has somewhere to go.
+func longMenu(visible: Int) -> MenuState {
+    let items = (1...20).map { MenuEntry.action("row.\($0)", "Row \($0)", .command(.reload)) }
+    return MenuState(root: MenuEntry(id: "root", title: "Go", kind: .submenu(items)),
+                     visibleRows: visible)
+}
+
+h.test("typing filters and puts the selection back at the top") { t in
+    var menu = MenuState(root: MenuTree.root(menuFixture()), visibleRows: 12)
+    t.equal(menu.rows.count, 7, "everything, to begin with")
+    t.equal(menu.handle(.down), .redraw, "move down one")
+    t.equal(menu.selection, 1, "so the selection is on the second row")
+
+    t.equal(menu.handle(.character("s")), .redraw, "start typing")
+    t.equal(menu.selection, 0, "and the selection returns to the top")
+    // Still seven: `s` reaches every row, several of them only through a keyword — "layout" by
+    // "split", "about" by "keybindings". Broadening like that is the point of keywords.
+    t.equal(menu.rows.count, 7, "a single letter can still reach everything")
+
+    for c in "ty" { _ = menu.handle(.character(c)) }
+    t.expect(menu.rows.count < 7, "two more characters narrow it")
+
+    for c in "le" { _ = menu.handle(.character(c)) }
+    t.equal(menu.rows.map(\.entry.id), ["style"], "down to one match")
+    t.equal(menu.query, "style", "and the query reads back")
+}
+
+h.test("the selection wraps and keeps itself in view") { t in
+    var menu = longMenu(visible: 5)
+    t.equal(menu.scrollOffset, 0, "starts at the top")
+
+    for _ in 0..<4 { _ = menu.handle(.down) }
+    t.equal(menu.selection, 4, "the last visible row")
+    t.equal(menu.scrollOffset, 0, "needs no scrolling yet")
+
+    _ = menu.handle(.down)
+    t.equal(menu.selection, 5, "one further")
+    t.equal(menu.scrollOffset, 1, "scrolls by exactly one, not a page")
+
+    _ = menu.handle(.up)
+    t.equal(menu.scrollOffset, 1, "coming back up does not scroll again")
+
+    _ = menu.handle(.end)
+    t.equal(menu.selection, 19, "End goes to the last row")
+    t.equal(menu.scrollOffset, 15, "with the window against the bottom")
+
+    _ = menu.handle(.down)
+    t.equal(menu.selection, 0, "and one more wraps to the top")
+    t.equal(menu.scrollOffset, 0, "bringing the window with it")
+
+    _ = menu.handle(.up)
+    t.equal(menu.selection, 19, "wrapping backwards too")
+}
+
+h.test("ENTER descends, ESC comes back, and ESC at the root dismisses") { t in
+    var menu = MenuState(root: MenuTree.root(menuFixture()), visibleRows: 12)
+    t.equal(menu.depth, 0, "at the root")
+    t.equal(menu.prompt, "Go…", "walker's prompt")
+
+    for c in "layout" { _ = menu.handle(.character(c)) }
+    t.equal(menu.handle(.enter), .redraw, "ENTER on a submenu descends rather than performing")
+    t.equal(menu.depth, 1, "one level down")
+    t.equal(menu.query, "", "with the query cleared")
+    t.equal(menu.breadcrumb, ["Go", "Layout"], "and a trail back")
+
+    t.equal(menu.handle(.escape), .redraw, "ESC pops")
+    t.equal(menu.depth, 0, "back at the root")
+    t.equal(menu.handle(.escape), .dismiss, "and ESC there closes the menu")
+}
+
+h.test("BACKSPACE edits the query but never backs out of the menu") { t in
+    var menu = MenuState(root: MenuTree.root(menuFixture()), visibleRows: 12)
+    t.equal(menu.handle(.backspace), .ignored,
+            "an empty query at the root has nothing to do — only ESC dismisses")
+
+    _ = menu.handle(.character("s"))
+    _ = menu.handle(.character("t"))
+    t.equal(menu.handle(.backspace), .redraw, "with a query it deletes")
+    t.equal(menu.query, "s", "one character at a time")
+
+    for c in "tyle" { _ = menu.handle(.character(c)) }
+    _ = menu.handle(.enter)
+    t.equal(menu.depth, 1, "inside Style")
+    t.equal(menu.handle(.backspace), .redraw, "an empty query in a submenu")
+    t.equal(menu.depth, 0, "pops back out")
+}
+
+h.test("ENTER performs an action, and cannot perform what is not there") { t in
+    var menu = MenuState(root: MenuTree.root(menuFixture()), visibleRows: 12)
+    for c in "workspaces" { _ = menu.handle(.character(c)) }
+    _ = menu.handle(.enter)
+    for c in "workspace 7" { _ = menu.handle(.character(c)) }
+    t.equal(menu.handle(.enter), .perform(.command(.workspace(.index(7)))),
+            "the row dispatches through the same command a hotkey would")
+
+    var empty = MenuState(root: MenuTree.root(menuFixture()), visibleRows: 12)
+    for c in "zzzz" { _ = empty.handle(.character(c)) }
+    t.equal(empty.rows.count, 0, "nothing matches")
+    t.equal(empty.handle(.enter), .ignored, "so ENTER does nothing")
+    t.equal(empty.handle(.down), .ignored, "and neither does moving")
+
+    var info = MenuState(root: MenuEntry(id: "root", title: "Go",
+                                         kind: .submenu([.info("i", "No windows")])),
+                         visibleRows: 12)
+    t.equal(info.handle(.enter), .ignored, "a label is not activatable")
+}
+
+h.test("TAB descends but never fires an action") { t in
+    var menu = MenuState(root: MenuTree.root(menuFixture()), visibleRows: 12)
+    for c in "system" { _ = menu.handle(.character(c)) }
+    t.equal(menu.handle(.tab), .redraw, "TAB into a submenu")
+    t.equal(menu.depth, 1, "descends")
+    t.equal(menu.handle(.tab), .ignored,
+            "but on an action it does nothing — reaching for it must never restart your Mac")
+}
+
+h.test("CTRL+W and CTRL+U clear the query") { t in
+    var menu = MenuState(root: MenuTree.root(menuFixture()), visibleRows: 12)
+    for c in "sty le" { _ = menu.handle(.character(c)) }
+    t.equal(menu.handle(.deleteWord), .redraw, "delete a word")
+    t.equal(menu.query, "sty ", "back to the previous one")
+    t.equal(menu.handle(.clearLine), .redraw, "clear the line")
+    t.equal(menu.query, "", "all of it")
+    t.equal(menu.handle(.clearLine), .ignored, "and again does nothing")
+}
+
+h.test("the panel keeps walker's geometry") { t in
+    t.equal(QuickMenuGeometry.width, 295, "walker's --width")
+    t.equal(QuickMenuGeometry.height(rowCount: 100), 630, "clamped to walker's --maxheight")
+    t.equal(QuickMenuGeometry.height(rowCount: 0), QuickMenuGeometry.chrome,
+            "and an empty list is just the prompt")
+    t.equal(QuickMenuGeometry.height(rowCount: 3),
+            QuickMenuGeometry.chrome + 3 * QuickMenuGeometry.rowHeight, "three rows deep")
+    t.expect(QuickMenuGeometry.visibleRows() >= 18, "630pt holds a useful number of rows")
+
+    let screen = box(0, 0, 1512, 900)
+    let frame = QuickMenuGeometry.frame(rowCount: 5, on: screen)
+    t.equal(frame.w, 295, "the panel is walker's width")
+    t.equal(frame.x, ((1512 - 295) / 2).rounded(), "horizontally centred")
+    t.expect(frame.y > 0 && frame.maxY < 900, "and sits on the screen, a little above centre")
+
+    let narrow = QuickMenuGeometry.frame(rowCount: 5, on: box(0, 0, 200, 900))
+    t.equal(narrow.w, 200, "never wider than the display it is on")
+}
+
+h.test("TOMLEdit replaces a value and leaves the file otherwise alone") { t in
+    let before = """
+    # toe
+    [border]
+    enabled      = true
+    width        = 2
+    active_start = "#33ccffee"   # the gradient's first stop
+    active_end   = "#00ff99ee"
+    angle        = 45
+
+    [[float]]
+    app = "com.apple.finder"
+    """
+    let after = TOMLEdit.apply([
+        .init(table: "border", key: "active_start", value: .string("#7aa2f7ee")),
+        .init(table: "border", key: "active_end", value: .string("#bb9af7ee")),
+    ], to: before)
+
+    t.expect(after.contains("active_start = \"#7aa2f7ee\"   # the gradient's first stop"),
+             "the value changes, the alignment and the comment do not")
+    t.expect(after.contains("active_end   = \"#bb9af7ee\""), "and the column is kept")
+    t.expect(after.contains("# toe"), "the header comment survives")
+    t.expect(after.contains("width        = 2"), "untouched keys are untouched")
+    t.expect(after.contains("app = \"com.apple.finder\""), "and so is the float rule")
+
+    let parsed = try Config.parse(after)
+    t.equal(parsed.border.activeStart, "#7aa2f7ee", "and it parses back to the new theme")
+    t.equal(parsed.border.activeEnd, "#bb9af7ee", "both stops")
+    t.equal(parsed.border.width, 2, "with everything else intact")
+}
+
+h.test("TOMLEdit inserts a missing key inside its own section") { t in
+    let before = """
+    [border]
+    enabled = true
+
+    [bar]
+    persistent_workspaces = 5
+    """
+    let after = TOMLEdit.apply([
+        .init(table: "border", key: "active_start", value: .string("#7aa2f7ee")),
+    ], to: before)
+
+    let lines = after.components(separatedBy: "\n")
+    let inserted = lines.firstIndex { $0.contains("active_start") }
+    let barHeader = lines.firstIndex { $0.trimmingCharacters(in: .whitespaces) == "[bar]" }
+    t.expect(inserted != nil, "the key is added")
+    t.expect((inserted ?? 99) < (barHeader ?? 0),
+             "above the next section header, not at the end of the file")
+    t.equal(try Config.parse(after).border.activeStart, "#7aa2f7ee", "and it takes effect")
+}
+
+h.test("TOMLEdit appends a section that is not there at all") { t in
+    let after = TOMLEdit.apply([
+        .init(table: "border", key: "active_start", value: .string("#7aa2f7ee")),
+        .init(table: "border", key: "active_end", value: .string("#bb9af7ee")),
+    ], to: "[general]\nsuper_key = \"alt\"\n")
+    t.expect(after.contains("[border]"), "the section is created")
+    let parsed = try Config.parse(after)
+    t.equal(parsed.border.activeStart, "#7aa2f7ee", "and read back")
+    t.equal(parsed.superKey, Modifiers.option, "without disturbing what was there")
+}
+
+h.test("TOMLEdit is not fooled by lookalike headers") { t in
+    let before = """
+    # A [border] mentioned in a comment is not a section.
+    [general]
+    note = "see [border] below"
+    gaps_in = 5
+
+    [[float]]
+    app = "com.apple.finder"
+
+    [border]
+    active_start = "#33ccffee"
+    """
+    let after = TOMLEdit.apply([
+        .init(table: "border", key: "active_start", value: .string("#7aa2f7ee")),
+    ], to: before)
+
+    t.expect(after.contains("note = \"see [border] below\""),
+             "a header inside a string is left alone")
+    t.expect(after.contains("# A [border] mentioned in a comment is not a section."),
+             "and so is one inside a comment")
+    t.expect(after.contains("active_start = \"#7aa2f7ee\""), "the real section is edited")
+    t.expect(!after.contains("#33ccffee"), "exactly once")
+    t.equal(after.components(separatedBy: "active_start").count - 1, 1,
+            "and no duplicate key is inserted")
+}
+
+h.test("TOMLEdit writes ints, floats and bools, and is idempotent") { t in
+    let before = "[general]\ngaps_in  = 5\ngaps_out = 10\n\n[border]\nenabled = true\n"
+    let once = TOMLEdit.apply([
+        .init(table: "general", key: "gaps_in", value: .int(10)),
+        .init(table: "general", key: "gaps_out", value: .int(20)),
+        .init(table: "border", key: "enabled", value: .bool(false)),
+    ], to: before)
+    let twice = TOMLEdit.apply([
+        .init(table: "general", key: "gaps_in", value: .int(10)),
+        .init(table: "general", key: "gaps_out", value: .int(20)),
+        .init(table: "border", key: "enabled", value: .bool(false)),
+    ], to: once)
+    t.equal(once, twice, "applying the same edit twice changes nothing the second time")
+
+    let parsed = try Config.parse(once)
+    t.equal(parsed.gaps.inner, 10, "gaps_in")
+    t.equal(parsed.gaps.outer, 20, "gaps_out")
+    t.equal(parsed.border.enabled, false, "and a bool")
+
+    let floated = TOMLEdit.apply([
+        .init(table: "dwindle", key: "default_split_ratio", value: .double(1.0)),
+    ], to: "[dwindle]\ndefault_split_ratio = 0.5\n")
+    t.expect(floated.contains("= 1.0"), "a whole float still reads as a float")
+}
+
+h.test("the shipped default config survives a theme apply intact") { t in
+    let after = TOMLEdit.apply([
+        .init(table: "border", key: "active_start", value: .string("#88c0d0ee")),
+        .init(table: "border", key: "active_end", value: .string("#5e81acee")),
+    ], to: Config.defaultTOML)
+
+    let beforeLines = Config.defaultTOML.components(separatedBy: "\n")
+    let afterLines = after.components(separatedBy: "\n")
+    t.equal(afterLines.count, beforeLines.count, "no lines added or removed")
+    let changed = zip(beforeLines, afterLines).filter { $0 != $1 }
+    t.equal(changed.count, 2, "exactly the two lines the theme touches")
+
+    let config = try Config.parse(after)
+    t.equal(BorderTheme.matching(config.border)?.id, .some("nord"), "and the menu ticks Nord")
+    t.equal(config.bindings.count, try Config.parse(Config.defaultTOML).bindings.count,
+            "with every binding still bound")
+}
 h.test("RGBA parses the spellings Hyprland writes") { t in
     t.equal(RGBA.parse(hex: "#33ccffee"), .some(RGBA(r: 0x33 / 255, g: 0xcc / 255,
                                                      b: 0xff / 255, a: 0xee / 255)),

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -864,4 +864,18 @@ h.test("clicking the strip picks the workspace under the pointer") { t in
     t.equal(WorkspaceStrip.hit(x: 30, widths: [], gap: 7, buttonWidth: 60), nil, "no items, no hit")
 }
 
+// MARK: - The quick menu
+h.test("RGBA parses the spellings Hyprland writes") { t in
+    t.equal(RGBA.parse(hex: "#33ccffee"), .some(RGBA(r: 0x33 / 255, g: 0xcc / 255,
+                                                     b: 0xff / 255, a: 0xee / 255)),
+            "#RRGGBBAA, Hyprland's rgba() ordering")
+    t.equal(RGBA.parse(hex: "#33ccff")?.a, .some(1.0), "#RRGGBB is opaque")
+    t.equal(RGBA.parse(hex: "0x33ccff"), RGBA.parse(hex: "#33ccff"), "0x is accepted too")
+    t.equal(RGBA.parse(hex: "  #33CCFF  "), RGBA.parse(hex: "#33ccff"),
+            "as is whitespace and upper case")
+    t.expect(RGBA.parse(hex: "#33cc") == nil, "a wrong-length value is nil, not a guess")
+    t.expect(RGBA.parse(hex: "#zzzzzz") == nil, "and so is a non-hex one")
+    t.equal(RGBA.parse(hex: "#33ccffee")?.withAlpha(0.18).a, .some(0.18), "alpha can be replaced")
+}
+
 exit(h.report())

--- a/Sources/toe/Coordinator+QuickMenu.swift
+++ b/Sources/toe/Coordinator+QuickMenu.swift
@@ -1,0 +1,118 @@
+import AppKit
+import ToeCore
+
+/// The quick menu's two halves that need `Coordinator`'s state: the context its tree is built from,
+/// and the side effects its rows ask for. In an extension because Coordinator.swift is long enough
+/// already, and this is one concern.
+extension Coordinator {
+
+    /// Gathered afresh every time the menu opens — nothing here is maintained while it is closed,
+    /// the same contract `StatusItem.menuNeedsUpdate` keeps.
+    func menuContext() -> MenuContext {
+        MenuContext(workspaces: workspaceSummaries(),
+                    focusedWindow: workspaces.focusedWindow,
+                    focusedWorkspace: workspaces.focusedWorkspaceIndex,
+                    config: config,
+                    version: Coordinator.version,
+                    startAtLogin: StartAtLogin.state)
+    }
+
+    static var version: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+    }
+
+    func perform(_ action: MenuAction) {
+        switch action {
+        case .command(let command):
+            dispatch(command)
+
+        case .revealWindow(let id):
+            reveal(id)
+
+        case .applyBorderTheme(let theme):
+            writeConfig([
+                .init(table: "border", key: "active_start", value: .string(theme.activeStart)),
+                .init(table: "border", key: "active_end", value: .string(theme.activeEnd)),
+            ])
+
+        case .applyGaps(let inner, let outer):
+            writeConfig([
+                .init(table: "general", key: "gaps_in", value: .int(inner)),
+                .init(table: "general", key: "gaps_out", value: .int(outer)),
+            ])
+
+        case .setBorderEnabled(let enabled):
+            writeConfig([.init(table: "border", key: "enabled", value: .bool(enabled))])
+
+        case .reveal(.configFile):
+            NSWorkspace.shared.open(Coordinator.configURL)
+
+        case .reveal(.configFolder):
+            NSWorkspace.shared.activateFileViewerSelecting([Coordinator.configURL])
+
+        case .reveal(.accessibilitySettings):
+            Coordinator.openAccessibilitySettings()
+
+        case .setStartAtLogin(let enabled):
+            StartAtLogin.set(enabled)
+
+        case .removeLegacyLaunchAgent:
+            StartAtLogin.removeLegacyLaunchAgent()
+
+        case .system(let system):
+            // No second confirmation here. `QuickMenuController` has already pushed the
+            // Cancel/Confirm level for anything that `needsConfirmation`, and its Confirm row is
+            // what sent this — asking again with an NSAlert would be the same question twice.
+            SystemActions.perform(system)
+
+        case .restartToe:
+            unstashEverything()
+            SystemActions.relaunch()
+
+        case .quitToe:
+            quit()
+
+        case .openURL(let string):
+            guard let url = URL(string: string) else { return }
+            NSWorkspace.shared.open(url)
+
+        case .copyToClipboard(let text):
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(text, forType: .string)
+
+        case .launchApp(let path):
+            let configuration = NSWorkspace.OpenConfiguration()
+            configuration.activates = true
+            // Activate the running instance rather than spawning a duplicate. Note this launches
+            // an app; it does not open a new window — which is exactly why the shipped
+            // `super-enter` binding goes through AppleScript instead.
+            configuration.createsNewApplicationInstance = false
+            NSWorkspace.shared.openApplication(at: URL(fileURLWithPath: path),
+                                               configuration: configuration) { _, error in
+                if let error { Log.error("launch failed: \(error.localizedDescription)") }
+            }
+        }
+    }
+
+    /// Writes the user's own config and lets `ConfigWatcher` reload it.
+    ///
+    /// Deliberately *not* followed by `loadConfig()`. That ends in `desired.removeAll()` plus a full
+    /// `apply`, which rewrites every window's frame through the Accessibility API — doing it twice
+    /// inside the watcher's debounce would flicker every tiled window for the sake of a border
+    /// colour. One write, one reload.
+    ///
+    /// Two honest properties, both of which Omarchy's own theme switching shares: if the file is
+    /// open in an editor with unsaved changes, that editor's next save wins; and there is no undo
+    /// beyond choosing something else.
+    private func writeConfig(_ edits: [TOMLEdit.Edit]) {
+        let url = Coordinator.configURL
+        let existing = (try? String(contentsOf: url, encoding: .utf8)) ?? Config.defaultTOML
+        let updated = TOMLEdit.apply(edits, to: existing)
+        guard updated != existing else { return }
+        do {
+            try updated.write(to: url, atomically: true, encoding: .utf8)
+        } catch {
+            Log.error("could not write \(url.lastPathComponent): \(error.localizedDescription)")
+        }
+    }
+}

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -8,15 +8,16 @@ final class Coordinator: WindowTrackerDelegate {
     static let configURL = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent(".config/toe/toe.toml")
 
-    private let workspaces = WorkspaceManager()
+    let workspaces = WorkspaceManager()
     private let tracker = WindowTracker()
     private let hotkeys = HotkeyManager()
     private let border = BorderOverlay()
     private let drag = DragMonitor()
     private let status = StatusItem()
+    private let quickMenu = QuickMenuController()
     private var watcher: ConfigWatcher?
 
-    private var config = Config.makeDefault()
+    private(set) var config = Config.makeDefault()
     private var warnings: [String] = []
     /// The frame each window is supposed to occupy, so a re-render does not churn every window.
     private var desired: [WindowID: Box] = [:]
@@ -30,6 +31,8 @@ final class Coordinator: WindowTrackerDelegate {
     /// to a floating window.
     private var draggedWindow: WindowID? { drag.isDragging ? drag.window : nil }
     private var signalSources: [any DispatchSourceSignal] = []
+    /// While the quick menu is up it owns the keyboard, and the focus border stays out of its way.
+    private var quickMenuOpen = false
 
     // MARK: - Start-up
 
@@ -39,22 +42,27 @@ final class Coordinator: WindowTrackerDelegate {
         status.onSelectWorkspace = { [weak self] index in
             self?.dispatch(.workspace(.index(index)))
         }
-        status.onSelectWindow = { [weak self] id in
-            guard let self else { return }
-            // Focusing a window on a hidden workspace should bring that workspace forward.
-            if let index = self.workspaces.workspaceIndex(of: id),
-               index != self.workspaces.focusedWorkspaceIndex {
-                self.dispatch(.workspace(.index(index)))
-            }
-            self.focus(id)
-        }
+        status.onSelectWindow = { [weak self] id in self?.reveal(id) }
         status.onReload = { [weak self] in self?.loadConfig() }
         status.onOpenConfig = { NSWorkspace.shared.open(Coordinator.configURL) }
         status.onOpenAccessibility = { Self.openAccessibilitySettings() }
-        status.onQuit = { [weak self] in
-            self?.unstashEverything()
-            NSApp.terminate(nil)
+        status.onQuit = { [weak self] in self?.quit() }
+        // The status item's NSMenu blocks the run loop while it tracks, so it must not come up
+        // over a live key panel.
+        status.onMenuWillOpen = { [weak self] in self?.quickMenu.closeForStatusMenu() }
+
+        quickMenu.contextProvider = { [weak self] in self?.menuContext() ?? .empty }
+        quickMenu.focusProvider = { [weak self] in self?.workspaces.focusedWindow }
+        quickMenu.monitorProvider = { [weak self] in
+            guard let self else { return nil }
+            return self.workspaces.monitor(id: self.workspaces.focusedMonitorID)?.usable
         }
+        quickMenu.onPerform = { [weak self] action in self?.perform(action) }
+        quickMenu.onRestoreFocus = { [weak self] id in
+            guard let self, let id, let window = self.tracker.window(id) else { return }
+            WindowMover.focus(window)
+        }
+        quickMenu.onOpenChanged = { [weak self] open in self?.quickMenuOpenChanged(open) }
 
         installSignalHandlers()
         writeDefaultConfigIfMissing()
@@ -64,7 +72,22 @@ final class Coordinator: WindowTrackerDelegate {
         watcher?.onChange = { [weak self] in self?.loadConfig() }
         watcher?.start()
 
-        hotkeys.onTrigger = { [weak self] binding in self?.dispatch(binding.command) }
+        // Carbon hotkeys are dispatched before key-window delivery and fire while toe is
+        // frontmost, so with the menu open SUPER+3 would switch workspaces behind it. Gated here
+        // rather than by unregistering: `unregisterAll` would race `loadConfig`, and a slip there
+        // leaves the user with no keyboard at all.
+        //
+        // One consequence is worth knowing: a binding written with no modifier at all would be
+        // taken from the menu's own key handling. No shipped default is modifier-less.
+        hotkeys.onTrigger = { [weak self] binding in
+            guard let self else { return }
+            if case .menu = binding.command {
+                self.quickMenu.toggle()
+                return
+            }
+            guard !self.quickMenu.isOpen else { return }
+            self.dispatch(binding.command)
+        }
         // Dragging a tiled window over another one trades their places, live, the way
         // Hyprland's `IHyprLayout::onMouseMove` does.
         drag.onMove = { [weak self] id, point in
@@ -164,6 +187,7 @@ final class Coordinator: WindowTrackerDelegate {
         workspaces.floatingSize = newConfig.floating
         tracker.floatRules = newConfig.floatRules
         border.apply(newConfig.border)
+        quickMenu.applyStyle(newConfig.border)
         status.persistentWorkspaces = newConfig.bar.persistentWorkspaces
 
         refreshStatus()
@@ -183,7 +207,7 @@ final class Coordinator: WindowTrackerDelegate {
 
     /// What the menu bar shows: every workspace, the applications on it, and which display
     /// (if any) is currently showing it.
-    private func workspaceSummaries() -> [WorkspaceSummary] {
+    func workspaceSummaries() -> [WorkspaceSummary] {
         let focusedIndex = workspaces.focusedWorkspaceIndex
 
         return (1...WorkspaceManager.workspaceCount).map { index in
@@ -192,11 +216,16 @@ final class Coordinator: WindowTrackerDelegate {
                 self?.tracker.window(id)?.appName
             }
             let apps = groups.compactMap { group -> AppSummary? in
-                guard let first = group.windows.first else { return nil }
-                let icon = tracker.window(first)
-                    .flatMap { NSRunningApplication(processIdentifier: $0.pid) }?.icon
+                guard let first = group.windows.first, let window = tracker.window(first) else {
+                    return nil
+                }
+                // Read the title now rather than trusting the one recorded at adopt time.
+                // `WindowTracker` observes no `kAXTitleChangedNotification`, so the stored title is
+                // whatever the window was called when it first appeared — a browser's first-ever
+                // tab, forever. One AX read per window, only while a menu is being built.
                 return AppSummary(name: group.name, windowCount: group.count,
-                                  icon: icon, representativeWindow: first)
+                                  pid: window.pid, representativeWindow: first,
+                                  windowTitle: window.element.title)
             }
 
             let showingOn = workspaces.monitorShowing(workspace: index)
@@ -367,7 +396,34 @@ final class Coordinator: WindowTrackerDelegate {
         refreshStatus()
     }
 
+    /// The border is hidden outright while the quick menu is open, which is the same courtesy
+    /// already extended to a window being dragged. It also matters for correctness: `Depth`'s
+    /// reasoning about a normal-level panel landing beneath the frontmost window assumes toe is not
+    /// itself frontmost, and while the menu is up it is.
+    private func quickMenuOpenChanged(_ open: Bool) {
+        quickMenuOpen = open
+        if open { border.hide() } else { updateBorder() }
+    }
+
+    func quit() {
+        unstashEverything()
+        NSApp.terminate(nil)
+    }
+
+    /// Focusing a window on a hidden workspace brings that workspace forward first. Shared by the
+    /// menu bar's window rows and the quick menu's.
+    func reveal(_ id: WindowID) {
+        if let index = workspaces.workspaceIndex(of: id),
+           index != workspaces.focusedWorkspaceIndex {
+            dispatch(.workspace(.index(index)))
+        }
+        focus(id)
+    }
+
     private func updateBorder() {
+        // `apply` and `refreshStatus` can fire from the config watcher or an AX notification while
+        // the menu is up, so the guard belongs here rather than only at the call sites.
+        guard !quickMenuOpen else { border.hide(); return }
         guard config.border.enabled,
               let focused = draggedWindow ?? workspaces.focusedWindow,
               let window = tracker.window(focused),
@@ -412,7 +468,7 @@ final class Coordinator: WindowTrackerDelegate {
         apply(refocus: false)
     }
 
-    private func unstashEverything() {
+    func unstashEverything() {
         for window in tracker.windows.values where window.isStashed {
             window.isStashed = false
             if let frame = window.frameBeforeStash {
@@ -493,6 +549,9 @@ final class Coordinator: WindowTrackerDelegate {
 
         case .reload:
             loadConfig()
+
+        case .menu:
+            quickMenu.toggle()
         }
     }
 }

--- a/Sources/toe/SystemActions.swift
+++ b/Sources/toe/SystemActions.swift
@@ -1,0 +1,125 @@
+import AppKit
+import ServiceManagement
+import ToeCore
+
+/// The system rows' side effects. Each one is either a plain subprocess or an Apple event, and
+/// between the Accessibility grant toe already holds and the `NSAppleEventsUsageDescription` already
+/// in Info.plist, none of them needs a new entitlement.
+enum SystemActions {
+
+    static func perform(_ action: SystemAction) {
+        switch action {
+        case .lock:
+            // There is no public lock API. `SACLockScreenImmediate` via `dlopen` on
+            // login.framework would work, but a project whose README makes a point of *not*
+            // reaching for private SkyLight calls should not reach for a private symbol here
+            // either — and `CGSession -suspend` is fast user switching rather than locking, with
+            // its `User.menu` host no longer shipping on recent macOS. ⌃⌘Q is Lock Screen: the same
+            // thing the user's own fingers would do, through the grant toe already has.
+            systemEvents("keystroke \"q\" using {command down, control down}")
+        case .sleepDisplay:
+            // Named honestly: this locks only if "Require password immediately after sleep" is set,
+            // which is why it is not called Lock.
+            shell("/usr/bin/pmset", ["displaysleepnow"])
+        case .sleep:
+            // pmset rather than an Apple event, so it works before any Automation prompt has been
+            // answered — it needs no permission from the console user at all.
+            shell("/usr/bin/pmset", ["sleepnow"])
+        case .logOut:
+            systemEvents("log out")
+        case .restart:
+            systemEvents("restart")
+        case .shutDown:
+            systemEvents("shut down")
+        }
+    }
+
+    /// Relaunch. `unstashEverything` has to have run first — the comment on
+    /// `Coordinator.installSignalHandlers` spells out why: windows left parked in the stash corner
+    /// are adopted there by the next launch, which then records the corner as the frame to float
+    /// them back to.
+    static func relaunch() {
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.createsNewApplicationInstance = true
+        configuration.activates = false
+        NSWorkspace.shared.openApplication(at: Bundle.main.bundleURL,
+                                           configuration: configuration) { _, error in
+            if let error { Log.error("relaunch failed: \(error.localizedDescription)") }
+            DispatchQueue.main.async { NSApp.terminate(nil) }
+        }
+    }
+
+    private static func systemEvents(_ command: String) {
+        shell("/usr/bin/osascript",
+              ["-e", "tell application \"System Events\" to \(command)"])
+    }
+
+    private static func shell(_ path: String, _ arguments: [String]) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: path)
+        process.arguments = arguments
+        do {
+            try process.run()
+        } catch {
+            Log.error("\(path) failed: \(error.localizedDescription)")
+        }
+    }
+}
+
+/// Start-at-login, via `SMAppService` rather than by writing the Makefile's LaunchAgent plist:
+/// path-independent, no `launchctl` subprocess, no second source of truth, and it shows up in
+/// System Settings › General › Login Items where people look for it.
+enum StartAtLogin {
+
+    /// What `make start-at-login` writes. If it is there, `SMAppService` must not also be
+    /// registered — two toes would launch and fight over every window.
+    static var legacyPlistURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/LaunchAgents/com.clifmeister.toe.plist")
+    }
+
+    static var state: StartAtLoginState {
+        if FileManager.default.fileExists(atPath: legacyPlistURL.path) {
+            return .legacyLaunchAgent
+        }
+        // SMAppService needs a bundle. Running the bare binary out of .build has none.
+        guard Bundle.main.bundleIdentifier != nil else { return .unavailable }
+        switch SMAppService.mainApp.status {
+        case .enabled: return .on
+        case .notRegistered, .notFound: return .off
+        case .requiresApproval: return .on      // registered; the user has yet to allow it
+        @unknown default: return .unavailable
+        }
+    }
+
+    static func set(_ enabled: Bool) {
+        do {
+            if enabled {
+                try SMAppService.mainApp.register()
+                Log.info("registered for launch at login")
+            } else {
+                try SMAppService.mainApp.unregister()
+                Log.info("unregistered from launch at login")
+            }
+        } catch {
+            Log.error("start at login: \(error.localizedDescription)")
+        }
+    }
+
+    /// Unload the LaunchAgent and delete it, so the in-app toggle becomes the single mechanism.
+    static func removeLegacyLaunchAgent() {
+        let url = legacyPlistURL
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        process.arguments = ["unload", url.path]
+        try? process.run()
+        process.waitUntilExit()
+        do {
+            try FileManager.default.removeItem(at: url)
+            Log.info("removed the legacy LaunchAgent at \(url.path)")
+        } catch {
+            Log.error("could not remove \(url.path): \(error.localizedDescription)")
+        }
+    }
+}

--- a/Sources/toe/UI/BorderOverlay.swift
+++ b/Sources/toe/UI/BorderOverlay.swift
@@ -7,11 +7,7 @@ import ToeCore
 final class BorderOverlay {
 
     private let panel: NSPanel
-    private let gradient = CAGradientLayer()
-    /// The gradient's mask. A plain CALayer, not a CAShapeLayer: only CALayer draws macOS's
-    /// continuous-curvature corners, and a mask masks by whatever alpha it renders — so a layer
-    /// with no background and a white border is exactly the band we want.
-    private let band = CALayer()
+    private let band = GradientBand()
     private var config = BorderConfig()
 
     /// Where the border sits in the window stack.
@@ -28,6 +24,10 @@ final class BorderOverlay {
         /// window level decides the order regardless — but the ordinary level arrives at the
         /// same place anyway: toe is a background app, so a normal-level panel lands directly
         /// beneath the frontmost application's window, which is the one in the user's hand.
+        ///
+        /// That reasoning holds only while toe is not itself the frontmost app. The quick menu
+        /// activates toe, which would break it — so the border is hidden outright for as long as
+        /// that panel is open, and a drag cannot be in flight while it is.
         case behindFrontmost
 
         var level: NSWindow.Level { self == .aboveEverything ? .floating : .normal }
@@ -48,11 +48,7 @@ final class BorderOverlay {
 
         let view = NSView(frame: .zero)
         view.wantsLayer = true
-        view.layer?.addSublayer(gradient)
-        gradient.mask = band
-        band.backgroundColor = nil                  // the middle stays transparent
-        band.borderColor = NSColor.white.cgColor    // mask alpha only; the colour is the gradient's
-        band.cornerCurve = .continuous              // macOS's squircle, not a circular arc
+        view.layer?.addSublayer(band.layer)
         panel.contentView = view
 
         // Resolves the system corner radius here, on the main thread, and records it once.
@@ -61,12 +57,7 @@ final class BorderOverlay {
 
     func apply(_ newConfig: BorderConfig) {
         config = newConfig
-        gradient.colors = [Self.color(newConfig.activeStart), Self.color(newConfig.activeEnd)]
-        // Hyprland measures the gradient angle counter-clockwise from "left to right".
-        let radians = newConfig.angle * .pi / 180
-        let dx = cos(radians) / 2, dy = sin(radians) / 2
-        gradient.startPoint = CGPoint(x: 0.5 - dx, y: 0.5 - dy)
-        gradient.endPoint = CGPoint(x: 0.5 + dx, y: 0.5 + dy)
+        band.apply(newConfig)
         if !newConfig.enabled { hide() }
         // The band's width and radius move together and depend on the window, so both are set
         // in show() rather than here.
@@ -90,18 +81,12 @@ final class BorderOverlay {
         panel.setFrame(rect, display: false)
         let bounds = CGRect(origin: .zero, size: rect.size)
         panel.contentView?.frame = bounds
-        gradient.frame = bounds
-        // CALayer.borderWidth draws inside the bounds, unlike a CAShapeLayer stroke, so the band
-        // fills the whole outset with no half-line-width inset. Clearing the window's radius by
-        // the band width is what lands the band's inner edge on the window's own corner.
-        band.frame = bounds
-        band.borderWidth = w
-        band.cornerRadius = BorderGeometry.outerRadius(inner: windowRadius, width: w)
-        // A mask rasterises at its own contentsScale, which defaults to 1 — without this the
-        // border is soft on Retina. Re-read every time: the panel can change display.
-        let scale = panel.backingScaleFactor
-        if gradient.contentsScale != scale { gradient.contentsScale = scale }
-        if band.contentsScale != scale { band.contentsScale = scale }
+        // Clearing the window's radius by the band width is what lands the band's inner edge on
+        // the window's own corner.
+        band.layout(in: bounds,
+                    width: w,
+                    radius: BorderGeometry.outerRadius(inner: windowRadius, width: w),
+                    scale: panel.backingScaleFactor)
         CATransaction.commit()
 
         // Re-ordered on every show, not just when the depth changes: `behindFrontmost` is a
@@ -113,21 +98,5 @@ final class BorderOverlay {
 
     func hide() {
         panel.orderOut(nil)
-    }
-
-    /// Parses `#RRGGBB` and `#RRGGBBAA` (Hyprland's `rgba()` ordering).
-    private static func color(_ hex: String) -> CGColor {
-        var text = hex.trimmingCharacters(in: .whitespaces)
-        if text.hasPrefix("#") { text.removeFirst() }
-        if text.hasPrefix("0x") { text.removeFirst(2) }
-        guard text.count == 6 || text.count == 8, let value = UInt64(text, radix: 16) else {
-            return NSColor.systemBlue.cgColor
-        }
-        let hasAlpha = text.count == 8
-        let r = Double((value >> (hasAlpha ? 24 : 16)) & 0xFF) / 255
-        let g = Double((value >> (hasAlpha ? 16 : 8)) & 0xFF) / 255
-        let b = Double((value >> (hasAlpha ? 8 : 0)) & 0xFF) / 255
-        let a = hasAlpha ? Double(value & 0xFF) / 255 : 1
-        return CGColor(red: r, green: g, blue: b, alpha: a)
     }
 }

--- a/Sources/toe/UI/GradientBand.swift
+++ b/Sources/toe/UI/GradientBand.swift
@@ -1,0 +1,61 @@
+import AppKit
+import ToeCore
+
+/// The `col.active_border` gradient, drawn as a band around a rounded rectangle.
+///
+/// Extracted from `BorderOverlay` because three surfaces want the same gradient with the same
+/// corner treatment: the focused window's outline, the quick menu panel's accent, and the theme
+/// swatches in that menu. The subtleties below are each load-bearing and were worth not
+/// reproducing three times.
+final class GradientBand {
+
+    let layer = CAGradientLayer()
+
+    /// The gradient's mask. A plain `CALayer`, not a `CAShapeLayer`: only `CALayer` draws macOS's
+    /// continuous-curvature corners, and a mask masks by whatever alpha it renders — so a layer
+    /// with no background and a white border is exactly the band we want.
+    private let band = CALayer()
+
+    init() {
+        layer.mask = band
+        band.backgroundColor = nil                  // the middle stays transparent
+        band.borderColor = NSColor.white.cgColor    // mask alpha only; the colour is the gradient's
+        band.cornerCurve = .continuous              // macOS's squircle, not a circular arc
+    }
+
+    /// Colours and angle. Hyprland measures the gradient angle counter-clockwise from
+    /// "left to right".
+    func apply(start: String, end: String, angle: Double) {
+        layer.colors = [Self.cgColor(start), Self.cgColor(end)]
+        let radians = angle * .pi / 180
+        let dx = cos(radians) / 2, dy = sin(radians) / 2
+        layer.startPoint = CGPoint(x: 0.5 - dx, y: 0.5 - dy)
+        layer.endPoint = CGPoint(x: 0.5 + dx, y: 0.5 + dy)
+    }
+
+    func apply(_ config: BorderConfig) {
+        apply(start: config.activeStart, end: config.activeEnd, angle: config.angle)
+    }
+
+    /// `radius` is the *outer* radius of the band. `scale` is the target's backing scale factor —
+    /// a mask rasterises at its own `contentsScale`, which defaults to 1, and without this the
+    /// band is soft on Retina. It has to be re-read on every layout because the panel can move
+    /// between displays.
+    func layout(in bounds: CGRect, width: Double, radius: Double, scale: CGFloat) {
+        layer.frame = bounds
+        // `CALayer.borderWidth` draws inside the bounds, unlike a `CAShapeLayer` stroke, so the
+        // band fills the whole outset with no half-line-width inset.
+        band.frame = bounds
+        band.borderWidth = width
+        band.cornerRadius = radius
+        if layer.contentsScale != scale { layer.contentsScale = scale }
+        if band.contentsScale != scale { band.contentsScale = scale }
+    }
+
+    /// Parses `#RRGGBB` and `#RRGGBBAA` (Hyprland's `rgba()` ordering), falling back to the
+    /// system accent so a typo in the config is visible rather than invisible.
+    static func cgColor(_ hex: String) -> CGColor {
+        guard let c = RGBA.parse(hex: hex) else { return NSColor.systemBlue.cgColor }
+        return CGColor(red: c.r, green: c.g, blue: c.b, alpha: c.a)
+    }
+}

--- a/Sources/toe/UI/MenuIconRenderer.swift
+++ b/Sources/toe/UI/MenuIconRenderer.swift
@@ -1,0 +1,92 @@
+import AppKit
+import ToeCore
+
+/// Turns a `MenuIcon` — which is only ever a *name* in ToeCore — into something drawable.
+///
+/// SF Symbols rather than the Nerd Font glyphs Omarchy's menu uses, for the same reason
+/// `StatusItem` draws its workspace square instead of setting a glyph: toe should not need a font
+/// installed, and a missing glyph is tofu rather than a graceful fallback. The Omarchy glyph each
+/// symbol stands in for is recorded in `MenuIcon.Section.symbolName`.
+enum MenuIconRenderer {
+
+    static let side: CGFloat = 16
+
+    static func image(for icon: MenuIcon?) -> NSImage? {
+        guard let icon else { return nil }
+        switch icon {
+        case .section(let section):
+            return symbol(section.symbolName)
+        case .symbol(let name):
+            return symbol(name)
+        case .runningApp(let pid):
+            return appIcon(pid: pid)
+        case .workspace(let index, let filled):
+            return workspace(index: index, filled: filled)
+        case .gradient(let start, let end):
+            return swatch(start: start, end: end)
+        }
+    }
+
+    private static func symbol(_ name: String) -> NSImage? {
+        guard let image = NSImage(systemSymbolName: name, accessibilityDescription: nil) else {
+            return nil
+        }
+        let configured = image.withSymbolConfiguration(
+            .init(pointSize: 13, weight: .regular)) ?? image
+        configured.isTemplate = true
+        return configured
+    }
+
+    private static func appIcon(pid: Int32) -> NSImage? {
+        guard let icon = NSRunningApplication(processIdentifier: pid)?.icon,
+              let sized = icon.copy() as? NSImage
+        else { return nil }
+        sized.size = NSSize(width: side, height: side)
+        return sized
+    }
+
+    /// The digit, or the rounded square `StatusItem` puts on the workspace you are on — so the
+    /// menu and the menu bar agree about what a workspace looks like.
+    private static func workspace(index: Int, filled: Bool) -> NSImage {
+        let image = NSImage(size: NSSize(width: side, height: side), flipped: false) { rect in
+            if filled {
+                let square = NSRect(x: (rect.width - 8) / 2, y: (rect.height - 8) / 2,
+                                    width: 8, height: 8)
+                NSColor.labelColor.setFill()
+                NSBezierPath(roundedRect: square, xRadius: 2.5, yRadius: 2.5).fill()
+            } else {
+                // Workspace 10 shows as `0`, as it does on the bar.
+                let label = index == WorkspaceManager.workspaceCount ? "0" : String(index)
+                let attributes: [NSAttributedString.Key: Any] = [
+                    .font: NSFont.monospacedDigitSystemFont(ofSize: 11, weight: .regular),
+                    .foregroundColor: NSColor.secondaryLabelColor,
+                ]
+                let text = NSAttributedString(string: label, attributes: attributes)
+                let size = text.size()
+                text.draw(at: NSPoint(x: (rect.width - size.width) / 2,
+                                      y: (rect.height - size.height) / 2))
+            }
+            return true
+        }
+        image.cacheMode = .never    // so a light/dark switch cannot leave a stale square behind
+        return image
+    }
+
+    /// A theme swatch, drawn with the same gradient at the same angle as the focus border it is
+    /// about to become.
+    private static func swatch(start: String, end: String) -> NSImage {
+        let image = NSImage(size: NSSize(width: side, height: side), flipped: false) { rect in
+            let path = NSBezierPath(roundedRect: rect.insetBy(dx: 2, dy: 2),
+                                    xRadius: 3, yRadius: 3)
+            let colours = [NSColor(cgColor: GradientBand.cgColor(start)) ?? .systemBlue,
+                           NSColor(cgColor: GradientBand.cgColor(end)) ?? .systemBlue]
+            NSGradient(colors: colours)?.draw(in: path, angle: 45)
+            NSColor.separatorColor.setStroke()
+            path.lineWidth = 0.5
+            path.stroke()
+            return true
+        }
+        image.cacheMode = .never
+        return image
+    }
+}

--- a/Sources/toe/UI/QuickMenuController.swift
+++ b/Sources/toe/UI/QuickMenuController.swift
@@ -1,0 +1,210 @@
+import AppKit
+import ToeCore
+
+/// Owns the quick menu: builds its tree when it opens, feeds it keystrokes, and hands finished
+/// actions back to `Coordinator`. The only place `NSEvent` meets `MenuKey`.
+final class QuickMenuController: NSObject, NSWindowDelegate {
+
+    /// Everything the tree is built from, gathered afresh on every open.
+    var contextProvider: (() -> MenuContext)?
+    /// The window to give focus back to on a dismissal that did nothing.
+    var focusProvider: (() -> WindowID?)?
+    /// The usable area of the display with focus, in AX coordinates.
+    var monitorProvider: (() -> Box?)?
+    var onPerform: ((MenuAction) -> Void)?
+    var onRestoreFocus: ((WindowID?) -> Void)?
+    var onOpenChanged: ((Bool) -> Void)?
+
+    private(set) var isOpen = false
+
+    private let view = QuickMenuView()
+    private lazy var chrome = QuickMenuChrome(contentView: view)
+    private var state: MenuState?
+    private var border = BorderConfig()
+
+    /// Captured before activating, because afterwards `frontmostApplication` is toe.
+    private var previousApp: NSRunningApplication?
+    private var previousWindow: WindowID?
+    /// Activating another app during `perform` fires `windowDidResignKey` synchronously, so the
+    /// close path has to be reentrancy-safe.
+    private var isClosing = false
+
+    override init() {
+        super.init()
+        view.onKey = { [weak self] event in self?.handle(event) }
+        chrome.panel.delegate = self
+        chrome.apply(border)
+    }
+
+    func applyStyle(_ config: BorderConfig) {
+        border = config
+        chrome.apply(config)
+        view.accent = chrome.accent
+        if isOpen { relayout() }
+    }
+
+    // MARK: - Opening and closing
+
+    func toggle() {
+        if isOpen {
+            close(restoreFocus: true)
+        } else {
+            open()
+        }
+    }
+
+    private func open() {
+        guard let context = contextProvider?() else { return }
+        let root = MenuTree.root(context)
+        let usable = monitorProvider?() ?? Box(x: 0, y: 0, w: 1280, h: 800)
+        state = MenuState(root: root,
+                          visibleRows: QuickMenuGeometry.visibleRows(
+                              maxHeight: min(QuickMenuGeometry.maxHeight, usable.h * 0.7)))
+
+        previousApp = NSWorkspace.shared.frontmostApplication
+        previousWindow = focusProvider?()
+        isOpen = true
+        onOpenChanged?(true)
+
+        view.state = state
+        view.accent = chrome.accent
+        relayout()
+
+        // The whole failure mode of this feature is "nothing happened", so say so when it opens.
+        Log.info("quick menu opened: \(state?.rows.count ?? 0) row(s)")
+
+        // Present on the next turn of the main queue, so the Carbon hotkey handler in
+        // `HotkeyManager` has returned before the panel takes the keyboard.
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.isOpen else { return }
+            NSApp.activate()
+            self.chrome.panel.makeKeyAndOrderFront(nil)
+            // Without this the panel itself is first responder, and `NSWindow`'s keyDown routes to
+            // the field editor rather than to the view.
+            self.chrome.panel.makeFirstResponder(self.view)
+            self.verifyKeyness(attempt: 0)
+        }
+    }
+
+    /// toe is an `.accessory` app, which may activate itself — but macOS's cooperative activation
+    /// can *deny* a non-active app activation unless it can attribute recent user input to it. A
+    /// Carbon hotkey press is delivered to toe's own event target and does count, so this succeeds
+    /// in practice; it is simply not contractual, and the failure mode is the bad one — a visible
+    /// menu that is not key, with every keystroke going into whatever the user was editing. So
+    /// check, retry twice, and then close rather than swallow.
+    private func verifyKeyness(attempt: Int) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.isOpen, !self.chrome.panel.isKeyWindow else { return }
+            guard attempt < 2 else {
+                Log.error("quick menu could not take the keyboard; closing rather than swallowing keys")
+                self.close(restoreFocus: true)
+                return
+            }
+            NSApp.activate()
+            self.chrome.panel.makeKeyAndOrderFront(nil)
+            self.verifyKeyness(attempt: attempt + 1)
+        }
+    }
+
+    /// `restoreFocus` is for a dismissal that did nothing — Esc at the root, a toggle, a failure to
+    /// take the keyboard. When a row *has* acted, the action decides where focus goes: putting the
+    /// old window back and then switching workspaces would only fight itself.
+    private func close(restoreFocus: Bool) {
+        guard isOpen, !isClosing else { return }
+        isClosing = true
+        isOpen = false
+        state = nil
+        view.state = nil
+        chrome.panel.orderOut(nil)
+        onOpenChanged?(false)
+        if restoreFocus {
+            if previousWindow != nil {
+                onRestoreFocus?(previousWindow)
+            } else {
+                // Nothing toe manages had focus — the Finder desktop, say. Hand activation back to
+                // whichever app it was, rather than letting macOS pick the next one in its own order.
+                previousApp?.activate()
+            }
+        }
+        previousApp = nil
+        previousWindow = nil
+        isClosing = false
+    }
+
+    /// Clicking another app, or anything else taking the keyboard, dismisses without restoring
+    /// focus: whoever took it is where the user wants to be. Not `hidesOnDeactivate`, which hides
+    /// the window behind our back without any of this running.
+    func windowDidResignKey(_ notification: Notification) {
+        guard isOpen, !isClosing else { return }
+        close(restoreFocus: false)
+    }
+
+    /// The status item's `NSMenu` blocks the run loop while it tracks, so it must not open over a
+    /// live key panel.
+    func closeForStatusMenu() {
+        close(restoreFocus: false)
+    }
+
+    // MARK: - Keys
+
+    private func handle(_ event: NSEvent) {
+        guard isOpen, var state else { return }
+        let modifiers = Modifiers(event.modifierFlags)
+        guard let key = MenuKey.from(keyCode: UInt32(event.keyCode),
+                                     characters: event.charactersIgnoringModifiers ?? "",
+                                     modifiers: modifiers) else { return }
+
+        let outcome = state.handle(key)
+        self.state = state
+        view.state = state
+
+        switch outcome {
+        case .ignored:
+            break
+        case .redraw:
+            relayout()
+            view.announceSelection()
+        case .dismiss:
+            close(restoreFocus: true)
+        case .perform(let action):
+            perform(action)
+        }
+    }
+
+    private func perform(_ action: MenuAction) {
+        // A system action that needs asking about becomes a level rather than a dialog — a
+        // hierarchical menu already knows how to ask a question.
+        if case .system(let system) = action, system.needsConfirmation {
+            state?.push(title: system.confirmationVerb, items: MenuTree.confirmation(system))
+            view.state = state
+            relayout()
+            return
+        }
+        close(restoreFocus: false)
+        onPerform?(action)
+    }
+
+    // MARK: - Geometry
+
+    private func relayout() {
+        guard let state else { return }
+        let usable = monitorProvider?() ?? Box(x: 0, y: 0, w: 1280, h: 800)
+        let visible = min(state.rows.count, state.visibleRows)
+        let frame = QuickMenuGeometry.frame(rowCount: max(1, visible), on: usable)
+        chrome.setFrame(frame, contentView: view)
+        view.needsDisplay = true
+    }
+}
+
+extension Modifiers {
+    /// ToeCore keeps its own Carbon-flavoured modifier set so it needs no AppKit; this is the
+    /// one place the two meet.
+    init(_ flags: NSEvent.ModifierFlags) {
+        var result: Modifiers = []
+        if flags.contains(.command) { result.insert(.command) }
+        if flags.contains(.shift) { result.insert(.shift) }
+        if flags.contains(.option) { result.insert(.option) }
+        if flags.contains(.control) { result.insert(.control) }
+        self = result
+    }
+}

--- a/Sources/toe/UI/QuickMenuPanel.swift
+++ b/Sources/toe/UI/QuickMenuPanel.swift
@@ -1,0 +1,82 @@
+import AppKit
+import ToeCore
+
+/// The quick menu's window.
+///
+/// `canBecomeKey` is the load-bearing line in this file. `NSWindow` returns false for it on a
+/// `.borderless` window by default, and without the override the panel appears, `makeKeyAndOrderFront`
+/// silently does nothing, and every keystroke lands in whatever the user was editing. It is the
+/// worst thing that can go wrong here and the cheapest to prevent.
+final class QuickMenuPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+    /// Nothing about a transient menu wants to be the main window.
+    override var canBecomeMain: Bool { false }
+}
+
+/// A borderless panel in walker's proportions: a rounded, blurred rectangle with the focus
+/// border's own gradient around its edge.
+final class QuickMenuChrome {
+
+    let panel: QuickMenuPanel
+    private let effect = NSVisualEffectView()
+    private let band = GradientBand()
+    private var border = BorderConfig()
+
+    init(contentView: NSView) {
+        panel = QuickMenuPanel(contentRect: .zero,
+                               styleMask: [.borderless, .nonactivatingPanel],
+                               backing: .buffered, defer: false)
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true                  // unlike BorderOverlay: a menu casts a shadow
+        panel.isFloatingPanel = true
+        panel.isReleasedWhenClosed = false
+        panel.hidesOnDeactivate = false          // closing is explicit, so close logic always runs
+        panel.animationBehavior = .none           // no appear animation on a surface this brief
+        panel.ignoresMouseEvents = false
+        // Above BorderOverlay's `.floating`. The focus border is hidden while this is up anyway,
+        // but nothing else should be able to cover the menu either.
+        panel.level = .popUpMenu
+        // The same set BorderOverlay uses, and for the same reason: it is what stops an accessory
+        // app's panel from kicking the user out of another app's fullscreen space.
+        panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle, .fullScreenAuxiliary]
+
+        effect.material = .hudWindow
+        effect.blendingMode = .behindWindow
+        effect.state = .active
+        effect.wantsLayer = true
+        effect.layer?.cornerRadius = QuickMenuGeometry.cornerRadius
+        effect.layer?.cornerCurve = .continuous    // macOS's squircle, as BorderOverlay's band uses
+        effect.layer?.masksToBounds = true
+        effect.addSubview(contentView)
+        effect.layer?.addSublayer(band.layer)
+
+        panel.contentView = effect
+    }
+
+    /// The panel's accent is the `[border]` gradient, so recolouring the focus border recolours the
+    /// menu — and `Style → Theme` restyles both at once, which is the point.
+    func apply(_ config: BorderConfig) {
+        border = config
+        band.apply(config)
+    }
+
+    func setFrame(_ ax: Box, contentView: NSView) {
+        let rect = Coordinates.toCocoa(ax)
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        panel.setFrame(rect, display: false)
+        let bounds = CGRect(origin: .zero, size: rect.size)
+        effect.frame = bounds
+        contentView.frame = bounds
+        band.layout(in: bounds,
+                    width: max(1, border.width),
+                    radius: QuickMenuGeometry.cornerRadius,
+                    scale: panel.backingScaleFactor)
+        CATransaction.commit()
+    }
+
+    var accent: NSColor {
+        NSColor(cgColor: GradientBand.cgColor(border.activeStart)) ?? .controlAccentColor
+    }
+}

--- a/Sources/toe/UI/QuickMenuView.swift
+++ b/Sources/toe/UI/QuickMenuView.swift
@@ -170,11 +170,17 @@ final class QuickMenuView: NSView {
         let detail = entry.detail.map { detailText($0) }
         let detailSize = detail?.size() ?? .zero
 
+        // Served first means measured against the whole row, not against what the detail leaves.
+        // Subtracting the detail first collapses this to zero for any detail wider than the row —
+        // and `draw(with:)` treats a zero-width rect as unbounded, so the title would then be laid
+        // out at full length straight over the detail rather than being dropped.
         let available = max(0, rightEdge - x)
-        let titleWidth = min(titleSize.width, max(0, available - detailSize.width - 10))
-        title.draw(with: NSRect(x: x, y: rect.midY - titleSize.height / 2,
-                                width: titleWidth, height: titleSize.height),
-                   options: [.usesLineFragmentOrigin, .truncatesLastVisibleLine])
+        let titleWidth = min(titleSize.width, available)
+        if titleWidth > 0 {
+            title.draw(with: NSRect(x: x, y: rect.midY - titleSize.height / 2,
+                                    width: titleWidth, height: titleSize.height),
+                       options: [.usesLineFragmentOrigin, .truncatesLastVisibleLine])
+        }
 
         // A hint narrower than this is unreadable anyway, so it is left off rather than shown as
         // an ellipsis.

--- a/Sources/toe/UI/QuickMenuView.swift
+++ b/Sources/toe/UI/QuickMenuView.swift
@@ -24,6 +24,34 @@ final class QuickMenuView: NSView {
     private let matchFont = NSFont.systemFont(ofSize: 13, weight: .semibold)
     private let detailFont = NSFont.systemFont(ofSize: 12, weight: .regular)
 
+    // MARK: - Palette
+    //
+    // Spelled out rather than taken from `NSColor.labelColor` and friends, because this view is a
+    // subview of an `NSVisualEffectView` and that imposes a *vibrant* appearance on everything
+    // inside it. The semantic colours mean different things there: under `darkAqua` they are white
+    // with alpha, but under `vibrantDark` they are opaque greys — `separatorColor` resolves to
+    // #232323 and `tertiaryLabelColor` to #404040. Drawn over a dark HUD blur that separator is a
+    // hard black rule and that text is invisible, which is exactly what they looked like.
+    //
+    // `bestMatch` is asked of the *effective* appearance rather than the system one on purpose: the
+    // vibrant appearance the effect view hands down already encodes which way the material itself
+    // went, so this stays right if the material ever renders light.
+
+    private var onDarkMaterial: Bool {
+        effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+    }
+
+    /// The one ink this surface has, at a given strength. The ladder is `darkAqua`'s own.
+    private func ink(_ alpha: CGFloat) -> NSColor {
+        (onDarkMaterial ? NSColor.white : NSColor.black).withAlphaComponent(alpha)
+    }
+
+    private var primaryInk: CGFloat { 0.92 }      // a row you are meant to read
+    private var secondaryInk: CGFloat { 0.50 }    // its trailing hint, and a row you cannot pick
+    private var placeholderInk: CGFloat { 0.45 }
+    private var hintInk: CGFloat { 0.35 }         // the scroll dots
+    private var separatorInk: CGFloat { 0.12 }
+
     override var acceptsFirstResponder: Bool { true }
     override var isFlipped: Bool { true }        // top-down, so row 0 is the first one drawn
 
@@ -56,10 +84,11 @@ final class QuickMenuView: NSView {
                                      width: bounds.width - 2 * pad,
                                      height: QuickMenuGeometry.promptHeight))
 
-        // The hairline between the prompt and the list.
-        NSColor.separatorColor.withAlphaComponent(0.6).setFill()
-        NSRect(x: 0, y: QuickMenuGeometry.promptHeight,
-               width: bounds.width, height: QuickMenuGeometry.separatorHeight).fill()
+        // The hairline between the prompt and the list, inset to the rows so it lines up with the
+        // selection highlight instead of running edge to edge into the gradient band.
+        ink(separatorInk).setFill()
+        NSRect(x: pad, y: QuickMenuGeometry.promptHeight,
+               width: bounds.width - 2 * pad, height: QuickMenuGeometry.separatorHeight).fill()
 
         let rows = state.rows
         var y = QuickMenuGeometry.promptHeight + QuickMenuGeometry.separatorHeight + pad
@@ -82,17 +111,21 @@ final class QuickMenuView: NSView {
     private func drawPrompt(_ state: MenuState, in rect: NSRect) {
         // Where you are, as a trail — "Go › Style › Theme" — because a filtered list gives no other
         // clue how deep you have gone.
-        let trail = state.breadcrumb.dropFirst().joined(separator: " › ")
+        // A level whose own title already trails off — "Move window to…" — would otherwise read
+        // "Move window to……" once this adds its own.
+        let trail = state.breadcrumb.dropFirst()
+            .map { $0.hasSuffix("…") ? String($0.dropLast()) : $0 }
+            .joined(separator: " › ")
         let placeholder = trail.isEmpty ? state.prompt : "\(state.breadcrumb[0]) › \(trail)…"
 
         let text: NSAttributedString
         if state.query.isEmpty {
             text = NSAttributedString(string: placeholder, attributes: [
-                .font: promptFont, .foregroundColor: NSColor.placeholderTextColor,
+                .font: promptFont, .foregroundColor: ink(placeholderInk),
             ])
         } else {
             text = NSAttributedString(string: state.query, attributes: [
-                .font: promptFont, .foregroundColor: NSColor.labelColor,
+                .font: promptFont, .foregroundColor: ink(primaryInk),
             ])
         }
         let size = text.size()
@@ -108,7 +141,7 @@ final class QuickMenuView: NSView {
 
     private func drawNoMatches(at y: CGFloat) {
         let text = NSAttributedString(string: "No matches", attributes: [
-            .font: titleFont, .foregroundColor: NSColor.tertiaryLabelColor,
+            .font: titleFont, .foregroundColor: ink(secondaryInk),
         ])
         text.draw(at: NSPoint(x: QuickMenuGeometry.padding + 4,
                               y: y + (QuickMenuGeometry.rowHeight - text.size().height) / 2))
@@ -158,7 +191,7 @@ final class QuickMenuView: NSView {
             rightEdge -= side
             drawTemplate(chevron,
                          in: NSRect(x: rightEdge, y: rect.midY - side / 2, width: side, height: side),
-                         tint: NSColor.tertiaryLabelColor)
+                         tint: ink(secondaryInk))
             rightEdge -= 6
         }
 
@@ -220,7 +253,7 @@ final class QuickMenuView: NSView {
         paragraph.alignment = .right
         return NSAttributedString(string: detail, attributes: [
             .font: detailFont,
-            .foregroundColor: NSColor.secondaryLabelColor,
+            .foregroundColor: ink(secondaryInk),
             .paragraphStyle: paragraph,
         ])
     }
@@ -228,7 +261,7 @@ final class QuickMenuView: NSView {
     /// `selected` is not consulted: the highlight is a tinted fill behind unchanged text rather
     /// than an inverted row, which is what keeps a themed accent legible in both appearances.
     private func colour(for entry: MenuEntry, selected: Bool) -> NSColor {
-        entry.isSelectable ? .labelColor : .tertiaryLabelColor
+        entry.isSelectable ? ink(primaryInk) : ink(secondaryInk)
     }
 
     /// A template image drawn in a colour, which `NSImage` will not do on its own.
@@ -243,7 +276,7 @@ final class QuickMenuView: NSView {
 
     /// Faint arrows when the list runs past the window, since there is no scroll bar to say so.
     private func drawScrollHint(rows: Int, first: Int, last: Int) {
-        NSColor.tertiaryLabelColor.setFill()
+        ink(hintInk).setFill()
         let x = bounds.width - QuickMenuGeometry.padding - 3
         if first > 0 {
             NSRect(x: x, y: QuickMenuGeometry.promptHeight + 6, width: 3, height: 3).fill()

--- a/Sources/toe/UI/QuickMenuView.swift
+++ b/Sources/toe/UI/QuickMenuView.swift
@@ -1,0 +1,265 @@
+import AppKit
+import ToeCore
+
+/// The prompt line and the rows, drawn by hand.
+///
+/// Not an `NSTableView`, and not because a table would be hard: a table brings a scroll view, cell
+/// reuse and a selection-highlight system that fights a custom accent — and decisively it wants the
+/// arrow keys for itself, so its keys would have to be intercepted anyway. `MenuState` already owns
+/// the scroll offset and the selection, so a table would only duplicate that state.
+///
+/// There is no `NSTextField` either. Characters go straight into `MenuState.query`, which keeps one
+/// source of truth for what is on screen. The cost is no input method: CJK input will not work in
+/// the query. For a fuzzy filter over a built-in Latin list that is the right trade, but it is a
+/// real limitation and the README says so.
+final class QuickMenuView: NSView {
+
+    /// Set by the controller; the view never mutates the menu itself.
+    var state: MenuState?
+    var accent: NSColor = .controlAccentColor
+    var onKey: ((NSEvent) -> Void)?
+
+    private let promptFont = NSFont.systemFont(ofSize: 15, weight: .regular)
+    private let titleFont = NSFont.systemFont(ofSize: 13, weight: .regular)
+    private let matchFont = NSFont.systemFont(ofSize: 13, weight: .semibold)
+    private let detailFont = NSFont.systemFont(ofSize: 12, weight: .regular)
+
+    override var acceptsFirstResponder: Bool { true }
+    override var isFlipped: Bool { true }        // top-down, so row 0 is the first one drawn
+
+    // MARK: - Keys
+
+    override func keyDown(with event: NSEvent) {
+        // Deliberately no `super.keyDown` fallthrough: `NSResponder`'s default path ends in
+        // `NSBeep`, and the menu owns the keyboard outright for as long as it is open. Every
+        // keystroke is either handled or swallowed, never bounced.
+        onKey?(event)
+    }
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        // CTRL+N and friends arrive here rather than in keyDown.
+        guard event.modifierFlags.contains(.control),
+              !event.modifierFlags.contains(.command) else { return false }
+        onKey?(event)
+        return true
+    }
+
+    override func flagsChanged(with event: NSEvent) { /* nothing to do; do not beep */ }
+
+    // MARK: - Drawing
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard let state else { return }
+        let pad = QuickMenuGeometry.padding
+
+        drawPrompt(state, in: NSRect(x: pad, y: 0,
+                                     width: bounds.width - 2 * pad,
+                                     height: QuickMenuGeometry.promptHeight))
+
+        // The hairline between the prompt and the list.
+        NSColor.separatorColor.withAlphaComponent(0.6).setFill()
+        NSRect(x: 0, y: QuickMenuGeometry.promptHeight,
+               width: bounds.width, height: QuickMenuGeometry.separatorHeight).fill()
+
+        let rows = state.rows
+        var y = QuickMenuGeometry.promptHeight + QuickMenuGeometry.separatorHeight + pad
+        if rows.isEmpty {
+            drawNoMatches(at: y)
+            return
+        }
+
+        let first = state.scrollOffset
+        let last = min(rows.count, first + state.visibleRows)
+        for index in first..<last {
+            let rect = NSRect(x: pad, y: y, width: bounds.width - 2 * pad,
+                              height: QuickMenuGeometry.rowHeight)
+            draw(rows[index], in: rect, selected: index == state.selection)
+            y += QuickMenuGeometry.rowHeight
+        }
+        drawScrollHint(rows: rows.count, first: first, last: last)
+    }
+
+    private func drawPrompt(_ state: MenuState, in rect: NSRect) {
+        // Where you are, as a trail — "Go › Style › Theme" — because a filtered list gives no other
+        // clue how deep you have gone.
+        let trail = state.breadcrumb.dropFirst().joined(separator: " › ")
+        let placeholder = trail.isEmpty ? state.prompt : "\(state.breadcrumb[0]) › \(trail)…"
+
+        let text: NSAttributedString
+        if state.query.isEmpty {
+            text = NSAttributedString(string: placeholder, attributes: [
+                .font: promptFont, .foregroundColor: NSColor.placeholderTextColor,
+            ])
+        } else {
+            text = NSAttributedString(string: state.query, attributes: [
+                .font: promptFont, .foregroundColor: NSColor.labelColor,
+            ])
+        }
+        let size = text.size()
+        let y = rect.midY - size.height / 2
+        text.draw(at: NSPoint(x: rect.minX, y: y))
+
+        // A solid caret rather than a blinking one: nothing here is a text field, and a cursor that
+        // blinks on a surface open for a second and a half is just flicker.
+        accent.withAlphaComponent(0.9).setFill()
+        let caretX = rect.minX + (state.query.isEmpty ? 0 : size.width + 2)
+        NSRect(x: caretX, y: y + 2, width: 2, height: size.height - 4).fill()
+    }
+
+    private func drawNoMatches(at y: CGFloat) {
+        let text = NSAttributedString(string: "No matches", attributes: [
+            .font: titleFont, .foregroundColor: NSColor.tertiaryLabelColor,
+        ])
+        text.draw(at: NSPoint(x: QuickMenuGeometry.padding + 4,
+                              y: y + (QuickMenuGeometry.rowHeight - text.size().height) / 2))
+    }
+
+    private func draw(_ row: MenuRow, in rect: NSRect, selected: Bool) {
+        let entry = row.entry
+
+        if selected {
+            accent.withAlphaComponent(0.20).setFill()
+            let path = NSBezierPath(roundedRect: rect, xRadius: 6, yRadius: 6)
+            path.fill()
+        }
+
+        var x = rect.minX + 6
+
+        // The checkmark occupies the same slot whether or not it is there, so rows do not shift
+        // as the ticked one moves.
+        let tickWidth: CGFloat = 14
+        if entry.isOn, let tick = NSImage(systemSymbolName: "checkmark",
+                                          accessibilityDescription: nil) {
+            tick.isTemplate = true
+            let side: CGFloat = 10
+            drawTemplate(tick, in: NSRect(x: x, y: rect.midY - side / 2, width: side, height: side),
+                         tint: accent)
+        }
+        x += tickWidth
+
+        if let image = MenuIconRenderer.image(for: entry.icon) {
+            let side = MenuIconRenderer.side
+            let box = NSRect(x: x, y: rect.midY - side / 2, width: side, height: side)
+            if image.isTemplate {
+                drawTemplate(image, in: box, tint: colour(for: entry, selected: selected))
+            } else {
+                image.draw(in: box)
+            }
+        }
+        x += MenuIconRenderer.side + 8
+
+        // A submenu marker on the right, so a row that drills down looks like one before you
+        // press anything.
+        var rightEdge = rect.maxX - 6
+        if entry.isSubmenu, let chevron = NSImage(systemSymbolName: "chevron.right",
+                                                  accessibilityDescription: nil) {
+            chevron.isTemplate = true
+            let side: CGFloat = 9
+            rightEdge -= side
+            drawTemplate(chevron,
+                         in: NSRect(x: rightEdge, y: rect.midY - side / 2, width: side, height: side),
+                         tint: NSColor.tertiaryLabelColor)
+            rightEdge -= 6
+        }
+
+        // The title gets what it needs and the detail gets what is left. walker is 295pt wide, and
+        // keeping that fidelity means something has to give: a truncated hint beats a truncated name,
+        // so the title is served first and the detail takes the remainder or is dropped.
+        let title = attributedTitle(entry, offsets: row.offsets, selected: selected)
+        let titleSize = title.size()
+        let detail = entry.detail.map { detailText($0) }
+        let detailSize = detail?.size() ?? .zero
+
+        let available = max(0, rightEdge - x)
+        let titleWidth = min(titleSize.width, max(0, available - detailSize.width - 10))
+        title.draw(with: NSRect(x: x, y: rect.midY - titleSize.height / 2,
+                                width: titleWidth, height: titleSize.height),
+                   options: [.usesLineFragmentOrigin, .truncatesLastVisibleLine])
+
+        // A hint narrower than this is unreadable anyway, so it is left off rather than shown as
+        // an ellipsis.
+        if let detail {
+            let width = min(detailSize.width, max(0, available - titleWidth - 10))
+            if width >= 16 {
+                detail.draw(with: NSRect(x: rightEdge - width,
+                                         y: rect.midY - detailSize.height / 2,
+                                         width: width, height: detailSize.height),
+                            options: [.usesLineFragmentOrigin, .truncatesLastVisibleLine])
+            }
+        }
+    }
+
+    /// Bold on the characters the query matched, so you can see *why* a row is in the list.
+    private func attributedTitle(_ entry: MenuEntry, offsets: [Int], selected: Bool)
+        -> NSAttributedString {
+        let colour = self.colour(for: entry, selected: selected)
+        // Without an explicit truncating line-break mode, `truncatesLastVisibleLine` has nothing to
+        // act on and a long title is clipped mid-glyph instead of ellipsised.
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.lineBreakMode = .byTruncatingTail
+        let text = NSMutableAttributedString(string: entry.title, attributes: [
+            .font: titleFont, .foregroundColor: colour, .paragraphStyle: paragraph,
+        ])
+        guard entry.isEnabled else { return text }
+        for offset in offsets where offset < entry.title.count {
+            text.addAttributes([.font: matchFont, .foregroundColor: colour],
+                               range: NSRange(location: offset, length: 1))
+        }
+        return text
+    }
+
+    private func detailText(_ detail: String) -> NSAttributedString {
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.lineBreakMode = .byTruncatingTail
+        paragraph.alignment = .right
+        return NSAttributedString(string: detail, attributes: [
+            .font: detailFont,
+            .foregroundColor: NSColor.secondaryLabelColor,
+            .paragraphStyle: paragraph,
+        ])
+    }
+
+    /// `selected` is not consulted: the highlight is a tinted fill behind unchanged text rather
+    /// than an inverted row, which is what keeps a themed accent legible in both appearances.
+    private func colour(for entry: MenuEntry, selected: Bool) -> NSColor {
+        entry.isSelectable ? .labelColor : .tertiaryLabelColor
+    }
+
+    /// A template image drawn in a colour, which `NSImage` will not do on its own.
+    private func drawTemplate(_ image: NSImage, in rect: NSRect, tint: NSColor) {
+        guard let context = NSGraphicsContext.current else { return }
+        context.saveGraphicsState()
+        image.draw(in: rect)
+        tint.set()
+        rect.fill(using: .sourceAtop)
+        context.restoreGraphicsState()
+    }
+
+    /// Faint arrows when the list runs past the window, since there is no scroll bar to say so.
+    private func drawScrollHint(rows: Int, first: Int, last: Int) {
+        NSColor.tertiaryLabelColor.setFill()
+        let x = bounds.width - QuickMenuGeometry.padding - 3
+        if first > 0 {
+            NSRect(x: x, y: QuickMenuGeometry.promptHeight + 6, width: 3, height: 3).fill()
+        }
+        if last < rows {
+            NSRect(x: x, y: bounds.height - 9, width: 3, height: 3).fill()
+        }
+    }
+
+    // MARK: - Accessibility
+
+    // A hand-drawn list is invisible to VoiceOver without help. This is the minimum: the panel
+    // says what it is and announces the row the selection lands on. Exposing each row as an
+    // `NSAccessibilityElement` would be better and is not done yet.
+    override func accessibilityRole() -> NSAccessibility.Role? { .list }
+    override func accessibilityLabel() -> String? { state?.prompt }
+    override func accessibilityValue() -> Any? { state?.selectedRow?.entry.title }
+
+    func announceSelection() {
+        guard let title = state?.selectedRow?.entry.title else { return }
+        NSAccessibility.post(element: self, notification: .selectedChildrenChanged)
+        NSAccessibility.post(element: self, notification: .announcementRequested,
+                             userInfo: [.announcement: title, .priority: NSAccessibilityPriorityLevel.medium.rawValue])
+    }
+}

--- a/Sources/toe/UI/StatusItem.swift
+++ b/Sources/toe/UI/StatusItem.swift
@@ -1,31 +1,6 @@
 import AppKit
 import ToeCore
 
-/// One application's presence on a workspace.
-struct AppSummary {
-    let name: String
-    let windowCount: Int
-    let icon: NSImage?
-    /// Selecting the row focuses this window.
-    let representativeWindow: WindowID
-}
-
-struct WorkspaceSummary {
-    let index: Int
-    /// Shown on the monitor that currently has focus.
-    let isFocused: Bool
-    /// Shown on some monitor — with several displays, more than one workspace is visible.
-    let isVisible: Bool
-    let monitorName: String?
-    let apps: [AppSummary]
-
-    var isEmpty: Bool { apps.isEmpty }
-
-    var stripState: WorkspaceStrip.State {
-        .init(index: index, isFocused: isFocused, isVisible: isVisible, isEmpty: isEmpty)
-    }
-}
-
 /// The menu bar item. toe is an `LSUIElement`, so this is its only visible surface.
 ///
 /// The title is the workspace strip in Omarchy's waybar styling — the focused workspace is
@@ -46,6 +21,9 @@ final class StatusItem: NSObject, NSMenuDelegate {
     var onOpenConfig: (() -> Void)?
     var onOpenAccessibility: (() -> Void)?
     var onQuit: (() -> Void)?
+    /// The quick menu owns the keyboard while it is up, and `popUpMenu` blocks the run loop —
+    /// so it has to be told before this menu starts tracking.
+    var onMenuWillOpen: (() -> Void)?
 
     private var warnings: [String] = []
     private var accessibilityGranted = false
@@ -218,6 +196,10 @@ final class StatusItem: NSObject, NSMenuDelegate {
 
     // MARK: - The menu
 
+    func menuWillOpen(_ menu: NSMenu) {
+        onMenuWillOpen?()
+    }
+
     func menuNeedsUpdate(_ menu: NSMenu) {
         menu.removeAllItems()
 
@@ -260,11 +242,7 @@ final class StatusItem: NSObject, NSMenuDelegate {
                 entry.target = self
                 entry.indentationLevel = 1
                 entry.representedObject = app.representativeWindow
-                if let icon = app.icon {
-                    let sized = icon.copy() as! NSImage
-                    sized.size = NSSize(width: 16, height: 16)
-                    entry.image = sized
-                }
+                entry.image = MenuIconRenderer.image(for: .runningApp(pid: app.pid))
                 menu.addItem(entry)
             }
         }

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -101,6 +101,12 @@ persistent_workspaces = 5
 "super-j"       = "togglesplit"
 "super-t"       = "togglefloating"
 
+# ── The menu ──────────────────────────────────────────────────────────────────
+# Omarchy binds SUPER+SPACE to `walker`, its launcher and command menu. toe's is built in:
+# type to filter, arrows or CTRL+N/P to move, ENTER to pick, ESC to go back, SUPER+SPACE again
+# to dismiss.
+"super-space" = "menu"
+
 # ── Launch ────────────────────────────────────────────────────────────────────
 # AppleScript's `new window` reuses the running instance, so the window opens on the current
 # workspace without a second app process lingering. `ghostty +new-window` is not supported on


### PR DESCRIPTION
Adds Omarchy's `SUPER`+`SPACE` menu — the `walker --dmenu` panel its `omarchy-menu` script drives — as a built-in, keyboard-driven overlay. It was the last of Omarchy's key bindings toe did not answer.

**Draft:** the model is fully tested and the app builds and runs, but the interactive paths have not been exercised end to end. See *Verification still owed* below.

## Shape

```
┌─────────────────────────────┐
│ Go…                         │
├─────────────────────────────┤
│  Windows                   ›│
│  Workspaces                ›│
│  Layout                    ›│
│  Style                     ›│
│  Setup                     ›│
│  System                    ›│
│  About                      │
└─────────────────────────────┘
```

Type to filter, arrows or `CTRL`+`N`/`P` to move, `ENTER` to pick, `ESC` back a level and again to dismiss. `BACKSPACE` on an empty query goes back a level but never out of the menu — only `ESC` does that.

Seven sections rather than Omarchy's ten: Install, Remove, Update and Learn are pacman, the AUR and Arch's own documentation. `Learn → Keybindings` survives under About, generated from the live config, where each row *runs* the command it describes.

## How it is put together

The whole interaction is a value in `ToeCore` — tree, fuzzy filter, key semantics, selection, scroll window — so all of it is asserted headlessly, and `Sources/toe` only draws it and performs side effects. Every row that maps onto a `Command` dispatches through `Coordinator.dispatch`, so no dispatcher exists twice.

| Layer | Files |
|---|---|
| Model (pure, tested) | `ToeCore/Menu/{MenuEntry,MenuAction,MenuContext,MenuTree,MenuState,MenuKeyMapping,FuzzyMatch,QuickMenuGeometry,BorderTheme,WorkspaceSummary}.swift` |
| Config writing | `ToeCore/Config/TOMLEdit.swift` |
| Shared with the border | `ToeCore/Colour.swift`, `toe/UI/GradientBand.swift` |
| Presentation | `toe/UI/{QuickMenuPanel,QuickMenuView,QuickMenuController,MenuIconRenderer}.swift` |
| Side effects | `toe/SystemActions.swift`, `toe/Coordinator+QuickMenu.swift` |

Commit 1 (`Extract the border gradient and its hex parser`) is a no-behaviour-change refactor and reviewable on its own. Commit 2 is the feature.

## Four things a background app has to get right

Each of these fails *silently*, which is why they are called out rather than left to the code:

- **`canBecomeKey`.** `NSWindow` returns false for a borderless window. Without the override the panel appears, `makeKeyAndOrderFront` quietly does nothing, and every keystroke lands in whatever the user was editing. Worst failure available here; cheapest to prevent.
- **Cooperative activation.** macOS can refuse to activate an app it cannot attribute recent input to. A Carbon hotkey press does count, so this works in practice — but it is not contractual, so toe verifies the panel really became key and **closes rather than swallowing keys**, with a log line.
- **Hotkey gating.** Carbon hotkeys are dispatched ahead of key-window delivery and keep firing while toe is frontmost, so `⌥3` would switch workspaces behind the open menu. Gated in the trigger closure, not by unregistering — that would race `loadConfig` and could cost the user their keyboard outright.
- **`charactersIgnoringModifiers`.** SUPER is Option, so anyone who opens the menu with `⌥Space` and keeps `⌥` held would otherwise type `å ∂ ƒ` into the filter. The mapping lives in ToeCore precisely so the selftest can pin it.

## Decisions worth arguing with

- **A panel, not an `NSMenu`.** A pointer-popped `NSMenu` would be far less code and would get type-select and submenu traversal free. Rejected because walker is a centred panel you type into, and reproducing that feel is the point of this repo. The cost is `QuickMenuView` and the activation dance.
- **SF Symbols, not Nerd Font glyphs.** `StatusItem.marker` draws its workspace square rather than setting a glyph precisely so toe needs no font installed; shipping Omarchy's glyphs would be tofu on a stock Mac. Each symbol records the nerd-font name it stands in for.
- **`Style` writes your config**, as Omarchy's own Style menu does, and then leaves the reload to the watcher. Reloading directly would rewrite every window's frame twice inside the debounce and flicker the whole screen for the sake of a colour. `TOMLEdit` substitutes values in place — `TOML.swift` parses but cannot write, and the file is two-thirds comments that *are* the documentation.
- **No text field.** Characters go straight into the menu's query, keeping one source of truth for what is on screen. The cost is no input method: the query is Latin-only.
- **Restart and shut down ask once, not twice.** A Cancel/Confirm level whose preselected row is the one that does nothing, so `ENTER` twice in a row cannot reboot you. The `NSAlert` I first wrote was dropped — the level had already asked.
- **Gaps are not a theme property.** In Omarchy `looknfeel.conf` is shared across every theme and only the colours change, so they sit beside the themes rather than inside them.

## Verification still owed

`make test` — 423 assertions, green. `make run` — builds, launches, `config loaded: 37 binding(s), 0 warning(s)`.

Two things blocked end-to-end verification on the machine this was written on:

1. **No `toe-dev` certificate**, so `make run` signed ad-hoc and macOS re-asks for Accessibility every rebuild. `make dev-cert` fixes it permanently. Hotkeys are live without the grant (Carbon needs none), but there are no tracked windows, so `Windows` will be empty.
2. **`osascript` is not allowed to send keystrokes** there, so the panel, the activation dance and the theme write are untested by hand.

Checklist in #27.

## Note for existing installs

`"super-space" = "menu"` is a *default*, so a config written by an earlier version will not have it. Add it to `[binds]`, or delete `~/.config/toe/toe.toml` for a fresh one. The README says so.