### PR TITLE
Cap TOML nesting depth and take AXObserver sources off the run loop

### DIFF
--- a/Sources/ToeCore/Config/TOML.swift
+++ b/Sources/ToeCore/Config/TOML.swift
@@ -41,6 +41,11 @@ public struct TOMLError: Error, CustomStringConvertible {
 /// Not supported: multi-line strings, dates, and dotted keys on the left of `=`.
 public enum TOML {
 
+    /// Arrays and inline tables nest, and every level costs a stack frame. toe's own config
+    /// never nests more than two deep, so a low cap turns a stack overflow on a pathological
+    /// file into an ordinary parse error.
+    static let maxNestingDepth = 64
+
     public static func parse(_ text: String) throws -> [String: TOMLValue] {
         var parser = Parser(text)
         return try parser.parseDocument()
@@ -63,6 +68,7 @@ public enum TOML {
         let chars: [Character]
         var i = 0
         var line = 1
+        var depth = 0
 
         init(_ text: String) { chars = Array(text) }
 
@@ -204,6 +210,14 @@ public enum TOML {
             }
         }
 
+        mutating func enterNesting() throws {
+            depth += 1
+            guard depth <= TOML.maxNestingDepth else {
+                throw TOMLError(line: line,
+                                message: "nested more than \(TOML.maxNestingDepth) levels deep")
+            }
+        }
+
         mutating func parseValue() throws -> TOMLValue {
             guard let c = peek else { throw TOMLError(line: line, message: "expected a value") }
 
@@ -212,6 +226,8 @@ public enum TOML {
                 return .string(try parseString())
             case "[":
                 i += 1
+                try enterNesting()
+                defer { depth -= 1 }
                 var items: [TOMLValue] = []
                 while true {
                     skipInsignificant()
@@ -227,6 +243,8 @@ public enum TOML {
                 return .array(items)
             case "{":
                 i += 1
+                try enterNesting()
+                defer { depth -= 1 }
                 var table: [String: TOMLValue] = [:]
                 while true {
                     skipInsignificant(stopAtNewline: true)

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -717,6 +717,26 @@ h.test("TOML errors carry a line number") { t in
     }
 }
 
+h.test("deeply nested values are capped instead of overflowing the stack") { t in
+    let deep = 60
+    let nested = try TOML.parse("a = " + String(repeating: "[", count: deep) + String(repeating: "]", count: deep))
+    t.equal(nested["a"] != nil, true, "\(deep) levels still parse")
+
+    do {
+        _ = try TOML.parse("a = " + String(repeating: "[", count: 100_000))
+        t.expect(false, "should have thrown")
+    } catch let e as TOMLError {
+        t.equal(e.message.contains("nested more than"), true, "arrays report the depth limit")
+    }
+
+    do {
+        _ = try TOML.parse("a = " + String(repeating: "{ b = ", count: 100_000))
+        t.expect(false, "should have thrown")
+    } catch let e as TOMLError {
+        t.equal(e.message.contains("nested more than"), true, "inline tables report it too")
+    }
+}
+
 h.test("float rules match by bundle id and title") { t in
     t.equal(FloatRule(app: "com.apple.systempreferences").matches(bundleID: "com.apple.systempreferences", title: "General"), true, "exact bundle id")
     t.equal(FloatRule(app: "com.apple.*").matches(bundleID: "com.apple.finder", title: nil), true, "wildcard suffix")

--- a/Sources/toe/AX/WindowTracker.swift
+++ b/Sources/toe/AX/WindowTracker.swift
@@ -78,7 +78,7 @@ final class WindowTracker {
         guard let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
         else { return }
         let pid = app.processIdentifier
-        observers.removeValue(forKey: pid)
+        stopObserving(pid)
         for (id, window) in windows where window.pid == pid {
             windows.removeValue(forKey: id)
             delegate?.windowDisappeared(id)
@@ -123,6 +123,13 @@ final class WindowTracker {
                 self?.adoptWindows(of: pid)
             }
         }
+    }
+
+    /// The run-loop source has to come off the run loop as well as out of `observers`, or
+    /// every launched-and-quit application leaves one behind for the life of the session.
+    private func stopObserving(_ pid: pid_t) {
+        guard let observer = observers.removeValue(forKey: pid) else { return }
+        CFRunLoopRemoveSource(CFRunLoopGetMain(), AXObserverGetRunLoopSource(observer), .defaultMode)
     }
 
     private func adoptWindows(of pid: pid_t) {


### PR DESCRIPTION
Fixes #24. Two unrelated small leaks, both a few lines, grouped as they were reported.

### Unbounded parser recursion

`parseValue` recursed on every `[` and `{` with nothing to stop it, so a config file deep enough to exhaust the stack segfaulted instead of reporting an error. Only reachable from the user's own config file, so the practical risk is nil — but a segfault is a bad way to learn a config is malformed.

`Parser` now carries a depth counter that both nesting cases raise on entry and lower on the way out, and a depth past `TOML.maxNestingDepth` throws an ordinary `TOMLError` with a line number, like every other parse failure. 64 is far above anything toe's own config reaches — the deepest thing in `toe.example.toml` is an array of inline tables, at two — and far below where recursion becomes a problem.

The `{` case needed the guard as much as `[`: an inline table's value is another `parseValue`, so `a = { b = { b = ...` recurses just as freely. Both are covered.

### AXObserver run-loop sources

`observe()` adds each `AXObserver`'s run-loop source to the main run loop, but `appTerminated` only dropped the observer from the dictionary — releasing the observer does not detach the source, so it stayed attached for the life of the process. Small per app, but it accrues over exactly toe's usage pattern.

`stopObserving` now pairs the `CFRunLoopAddSource` with a `CFRunLoopRemoveSource`, so the two calls sit in matching places and neither can be done without the other.

### Testing

The selftest suite gains a parser case: 60 levels still parse, and 100,000 of each bracket now throw with the depth message where they previously crashed the process — the regression test the issue's probe was doing by hand.

`swift build` is clean for both targets; the suite passes at 241 assertions (was 238). The run-loop change is by inspection, as the leak itself was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXegVoiDyxveMuuyPF2N1d