### PR TITLE
Gate the Claude workflow on author association

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,21 @@ on:
 
 jobs:
   claude:
+    # Only trusted authors can spend the Claude quota: every branch pairs the
+    # '@claude' mention with the author_association field for that event type.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Closes #21

`claude.yml` fired on any comment mentioning `@claude`, from anyone at all — the `if:` had no `author_association` gate. Token permissions were already read-only (`contents: read`, `pull-requests: read`, `issues: read`), so this was quota spend, not a write path: every drive-by comment started a job consuming `secrets.CLAUDE_CODE_OAUTH_TOKEN`.

Each branch of the `if:` now pairs its `@claude` check with the `author_association` field that event actually carries, and requires `OWNER`, `MEMBER`, or `COLLABORATOR`:

- `issue_comment` / `pull_request_review_comment` → `github.event.comment.author_association`
- `pull_request_review` → `github.event.review.author_association`
- `issues` → `github.event.issue.author_association`

Per-event rather than one shared guard, precisely because the field lives in a different place for each — a single `github.event.comment.author_association` would be empty (and so fail closed) on the review and issues events.

### Notes

- `issues: [assigned]` is now gated on the **issue author's** association, not the assigner's. If an outside contributor opens an issue mentioning `@claude` and a maintainer assigns it, the job no longer fires. Making assignment-by-a-maintainer the trust signal instead would need `github.event.assignee` logic, which associations don't provide directly.
- `claude-code-review.yml` left alone: it triggers on `pull_request`, not `pull_request_target`, so fork PRs run without secrets. Correct as-is.

### Testing

YAML parses. `actionlint` isn't installed locally, so the expression itself was validated by reading only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAKg43ihxZsuqQ95dhkpyj