### PR TITLE
Keep app icons off the status refresh path

### DIFF
--- a/Sources/ToeCore/Layout/WorkspaceManager.swift
+++ b/Sources/ToeCore/Layout/WorkspaceManager.swift
@@ -479,6 +479,12 @@ public extension WorkspaceManager {
         return ws.layout.windowIDs + ws.floating.sorted()
     }
 
+    /// Whether a workspace holds no windows — without building the window list, so the menu
+    /// bar can ask it on every status refresh.
+    func isEmpty(workspace index: Int) -> Bool {
+        workspaces[index]?.isEmpty ?? true
+    }
+
     /// Which monitor, if any, is currently showing this workspace.
     func monitorShowing(workspace index: Int) -> UInt32? {
         activeWorkspace.first { $0.value == index }?.key

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -755,6 +755,10 @@ h.test("windows are listed in tree order, floating last") { t in
     t.equal(wm.orderedWindows(inWorkspace: 1), [1, 2, 3, 7, 9],
             "tiled left-to-right depth-first, then floating")
     t.equal(wm.orderedWindows(inWorkspace: 4), [], "an untouched workspace is empty")
+
+    // What the menu bar strip asks on every refresh, and why it does not ask for the list.
+    t.equal(wm.isEmpty(workspace: 1), false, "tiled and floating windows both count")
+    t.equal(wm.isEmpty(workspace: 4), true, "an untouched workspace holds nothing")
 }
 
 h.test("windows group by application in first-appearance order") { t in

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -175,14 +175,29 @@ final class Coordinator: WindowTrackerDelegate {
     }
 
     private func refreshStatus() {
-        status.update(workspaces: workspaceSummaries(),
+        status.update(workspaces: workspaceStates(),
                       warnings: warnings,
                       accessibilityGranted: AXIsProcessTrusted(),
                       showMonitorNames: workspaces.monitors.count > 1)
     }
 
-    /// What the menu bar shows: every workspace, the applications on it, and which display
-    /// (if any) is currently showing it.
+    /// What the strip in the menu bar title draws. This runs on every focus change and every
+    /// adopted window, so it stays to what the strip actually reads — no window lists, no app
+    /// names, and above all no icons. Those belong to `workspaceSummaries()`, which the menu
+    /// asks for only when it opens.
+    private func workspaceStates() -> [WorkspaceStrip.State] {
+        let focusedIndex = workspaces.focusedWorkspaceIndex
+
+        return (1...WorkspaceManager.workspaceCount).map { index in
+            WorkspaceStrip.State(index: index,
+                                 isFocused: index == focusedIndex,
+                                 isVisible: workspaces.monitorShowing(workspace: index) != nil,
+                                 isEmpty: workspaces.isEmpty(workspace: index))
+        }
+    }
+
+    /// What the menu shows: every workspace, the applications on it, and which display
+    /// (if any) is currently showing it. Only built while the menu is opening.
     private func workspaceSummaries() -> [WorkspaceSummary] {
         let focusedIndex = workspaces.focusedWorkspaceIndex
 

--- a/Sources/toe/UI/StatusItem.swift
+++ b/Sources/toe/UI/StatusItem.swift
@@ -20,10 +20,6 @@ struct WorkspaceSummary {
     let apps: [AppSummary]
 
     var isEmpty: Bool { apps.isEmpty }
-
-    var stripState: WorkspaceStrip.State {
-        .init(index: index, isFocused: isFocused, isVisible: isVisible, isEmpty: isEmpty)
-    }
 }
 
 /// The menu bar item. toe is an `LSUIElement`, so this is its only visible surface.
@@ -87,9 +83,10 @@ final class StatusItem: NSObject, NSMenuDelegate {
         item.button?.sendAction(on: [.leftMouseUp, .rightMouseUp])
     }
 
-    /// Cheap: only the title strip is recomputed. The menu rebuilds itself when opened.
-    func update(workspaces: [WorkspaceSummary], warnings: [String], accessibilityGranted: Bool,
-                showMonitorNames: Bool) {
+    /// Cheap: only the title strip is recomputed, from the little the strip reads. The menu
+    /// rebuilds itself from `workspaceProvider` when opened.
+    func update(workspaces: [WorkspaceStrip.State], warnings: [String],
+                accessibilityGranted: Bool, showMonitorNames: Bool) {
         self.warnings = warnings
         self.accessibilityGranted = accessibilityGranted
         self.showMonitorNames = showMonitorNames
@@ -106,7 +103,7 @@ final class StatusItem: NSObject, NSMenuDelegate {
 
     // MARK: - The workspace strip
 
-    private func title(for workspaces: [WorkspaceSummary]) -> NSAttributedString {
+    private func title(for workspaces: [WorkspaceStrip.State]) -> NSAttributedString {
         stripItems = []
         stripWidths = []
 
@@ -116,8 +113,7 @@ final class StatusItem: NSObject, NSMenuDelegate {
             ])
         }
 
-        let items = WorkspaceStrip.items(for: workspaces.map(\.stripState),
-                                         persistent: persistentWorkspaces)
+        let items = WorkspaceStrip.items(for: workspaces, persistent: persistentWorkspaces)
         guard !items.isEmpty else {
             return NSAttributedString(string: "toe", attributes: [.font: font])
         }


### PR DESCRIPTION
Closes #19.

`refreshStatus()` built the full menu model — every workspace's windows grouped by application, with `NSRunningApplication(processIdentifier:)?.icon` fetched for each group — and handed it to `StatusItem.update()`, which reads four fields per workspace and throws the rest away. The menu never saw that model either: it calls `workspaceProvider` lazily in `menuNeedsUpdate`, exactly as its own comment says.

The icons are what cost. Per the issue's benchmark, fetching them for a machine's worth of running apps is roughly fifty times the price of looking the applications up, and `refreshStatus()` runs from `apply()`, from every focus change, and twice per adopted window — so the bill scales with how many apps are running, not with how many windows toe manages.

## What changed

- `Coordinator.workspaceStates()` is the new cheap path behind `refreshStatus()`: it returns the `WorkspaceStrip.State` the title strip actually draws — index, focused, visible, empty — and nothing else.
- `Coordinator.workspaceSummaries()` keeps the app grouping and the icons, and is now reached only through `status.workspaceProvider`, on the menu's existing lazy path.
- `StatusItem.update(workspaces:…)` takes `[WorkspaceStrip.State]` directly, so `WorkspaceSummary.stripState` is gone — the strip's own type was already exactly the four fields it read.
- `WorkspaceManager.isEmpty(workspace:)` answers emptiness from `layout.isEmpty && floating.isEmpty` instead of materializing `orderedWindows`, so even the cheap path builds no arrays.

## Testing

`make test` — 240 assertions pass, including two new ones covering `isEmpty(workspace:)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vZ647hVSDGYWxF5B6WnWD