### PR TITLE
Parse config files saved with CRLF line endings

### DIFF
--- a/Sources/ToeCore/Config/TOML.swift
+++ b/Sources/ToeCore/Config/TOML.swift
@@ -46,8 +46,13 @@ public enum TOML {
     /// file into an ordinary parse error.
     static let maxNestingDepth = 64
 
+    /// The parser walks `Character`s, and in Unicode `"\r\n"` is a single grapheme cluster that
+    /// equals neither `"\n"` nor `"\r"` — so a file saved with Windows line endings would be read
+    /// as one enormous line and fail wholesale. Normalising on the way in is cheaper than teaching
+    /// every newline check about the pair, and safe because this parser has no multi-line strings:
+    /// a `"\r\n"` can only ever appear between tokens.
     public static func parse(_ text: String) throws -> [String: TOMLValue] {
-        var parser = Parser(text)
+        var parser = Parser(text.replacingOccurrences(of: "\r\n", with: "\n"))
         return try parser.parseDocument()
     }
 

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -717,6 +717,26 @@ h.test("TOML errors carry a line number") { t in
     }
 }
 
+h.test("a config saved with CRLF line endings parses like any other") { t in
+    let crlf = "[general]\r\ngaps_in = 5\r\nsuper_key = \"cmd\"\r\n\r\n[dwindle]\r\nsmart_split = true\r\n"
+    let root = try TOML.parse(crlf)
+
+    t.equal(root["general"]?.tableValue?["gaps_in"]?.doubleValue, 5, "an integer stops at the CRLF")
+    t.equal(root["general"]?.tableValue?["super_key"]?.stringValue, "cmd", "a string survives")
+    t.equal(root["dwindle"]?.tableValue?["smart_split"]?.boolValue, true, "a later header is still found")
+
+    let c = try Config.parse(crlf)
+    t.equal(c.gaps.inner, 5, "and the whole config loads rather than falling back")
+    t.equal(c.warnings, [], "with no warnings")
+
+    do {
+        _ = try TOML.parse("[general]\r\ngaps_in = 5\r\ngaps_out\r\n")
+        t.expect(false, "should have thrown")
+    } catch let e as TOMLError {
+        t.equal(e.line, 3, "and errors still point at the real line, not line 1")
+    }
+}
+
 h.test("deeply nested values are capped instead of overflowing the stack") { t in
     let deep = 60
     let nested = try TOML.parse("a = " + String(repeating: "[", count: deep) + String(repeating: "]", count: deep))


### PR DESCRIPTION
Fixes #18.

## The bug

`TOML.Parser` does `chars = Array(text)` and indexes it, so it walks **grapheme clusters** — and in Unicode `"\r\n"` is a single cluster that equals neither `"\n"` nor `"\r"`. Two things follow:

- `skipInsignificant` treats it as significant content rather than whitespace.
- `parseValue`'s terminator set `",]}#\n"` never matches it, so a value greedily swallows every following line.

Nothing survives — headers, strings, integers and booleans all fail. Because `loadConfig()` deliberately keeps the last good config on a parse error, a user who saved `toe.toml` from a Windows-y editor gets a menu-bar warning, none of their settings, and a line number pointing nowhere: `line` only increments on a bare `"\n"`, so every error reports line 1 regardless of where the problem is.

## The fix

Normalise `\r\n` → `\n` in `TOML.parse`. That is cheaper than teaching every newline check about the pair, and it repairs the bogus line numbers for free.

This is safe precisely because the parser has no multi-line strings: an unescaped `"\r\n"` can only ever appear *between* tokens, never inside a string literal, so normalising cannot alter a parsed value.

## Test

New case in the selftest suite covering an integer, a string, a second table header, a full `Config.parse` round trip, and the line number on a genuine error further down a CRLF file.

Verified it actually catches the bug — with the one-line fix reverted:

```
✗ 1 failure(s), 243 passed

  • a config saved with CRLF line endings parses like any other: threw line 1: expected a key, found '
'
```

and with it in place, `make test` reports `✓ 249 assertions passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAeajQcuAVySLrcGgsVwtT