### PR TITLE
Drop the focus border under windows stacked over the focused one

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,16 @@ with a read-only global event monitor rather than an event tap. For as long as y
 a window toe writes nothing to it, which is what stops it being yanked out from under the cursor;
 its frame is written once, into whatever tile it now owns, when you release.
 
+**The focus border** is a panel above every ordinary window, which is right until something is
+genuinely stacked over the focused one — a settings panel, a dialog — because a floating-level
+panel is composited above every ordinary window whatever the real z-order says, and the ring
+gets drawn straight through it. Accessibility does not expose stacking order at all, so toe asks
+the window server what is above the focused window and drops the border to the ordinary level
+when any of it covers the band. That is a read of `CGWindowListCopyWindowInfo` for geometry
+only — never `kCGWindowName`, which would need Screen Recording, so Accessibility stays the one
+permission toe asks for. The border still sits above every inactive application, so it stays
+visible all the way round the window; only what is really in front of it covers it.
+
 **Floating windows.** `togglefloating` lifts a window out of the tree and centres it, at a
 consistent fraction of the display — 70% wide by 80% tall by default — so every floating window
 is the same shape whichever window it came from. No floating window is ever wider than 1.6 times

--- a/Sources/ToeCore/BorderGeometry.swift
+++ b/Sources/ToeCore/BorderGeometry.swift
@@ -20,4 +20,36 @@ public enum BorderGeometry {
     public static func outerRadius(inner: Double, width: Double) -> Double {
         max(0, inner) + max(0, width)
     }
+
+    /// The rectangle the band is drawn in: the window grown by the band's width on every side.
+    /// The band is the ring between this and `box`, so it never covers the window itself.
+    public static func outset(_ box: Box, by width: Double) -> Box {
+        let w = max(0, width)
+        return Box(x: box.x - w, y: box.y - w, w: box.w + 2 * w, h: box.h + 2 * w)
+    }
+
+    /// Whether anything in `others` covers part of the *band*, rather than merely sitting over
+    /// the window's own interior — which the border never draws on anyway, so a dialog centred
+    /// on the window hides none of it.
+    ///
+    /// `epsilon` decides how much overlap counts, and leans towards "not covered": a window
+    /// clipping the band by a fraction of a point is rounding noise between Accessibility's
+    /// idea of a frame and the window server's, not something anyone can see.
+    public static func bandIsCovered(window: Box, width: Double,
+                                     by others: [Box], epsilon: Double = 0.5) -> Bool {
+        guard width > 0 else { return false }
+        let outer = outset(window, by: width)
+        return others.contains { other in
+            let clipped = outer.intersection(other)
+            // This guard has to come first. `Box.intersection` clamps the *size* to zero for
+            // boxes that miss each other, but leaves the origin at `max(minX, other.minX)` —
+            // which for a disjoint box sits outside the window, and would read below as the
+            // band being covered.
+            guard clipped.w > 0, clipped.h > 0 else { return false }
+            // Inside the hole covers nothing. Sticking out of it on any side covers the band.
+            let out = max(window.minX - clipped.minX, clipped.maxX - window.maxX,
+                          window.minY - clipped.minY, clipped.maxY - window.maxY)
+            return out > epsilon
+        }
+    }
 }

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -681,6 +681,57 @@ h.test("border corner radius") { t in
     t.equal(BorderGeometry.outerRadius(inner: 0, width: 2), 2, "square window, offset band")
 }
 
+// The decision is tested here; the window-list read that feeds it lives in WindowStack and
+// needs a live window server, so it is not. Geometry from the capture that found the bug:
+// Ghostty focused at 15,48 842x1054 with a 4pt band, Raycast's Settings at 364,215 1000x626.
+h.test("the border only gives way to a window that covers the band") { t in
+    let window = box(15, 48, 842, 1054)
+    let width = 4.0
+    func covered(_ others: [Box]) -> Bool {
+        BorderGeometry.bandIsCovered(window: window, width: width, by: others)
+    }
+
+    t.equalBox(BorderGeometry.outset(window, by: width), box(11, 44, 850, 1062),
+               "the band's outer rectangle is the panel toe actually put on screen")
+
+    t.equal(covered([box(364, 215, 1000, 626)]), true,
+            "a dialog running past the window's right edge covers the band")
+    t.equal(covered([box(300, 300, 200, 150)]), false,
+            "a dialog centred on the window covers the hole, not the ring")
+    t.equal(covered([window]), false,
+            "a window the same size and place covers the hole, not the ring")
+    t.equal(covered([box(600, 300, 257, 150)]), false,
+            "flush against the window's right edge from inside is still the hole")
+    t.equal(covered([box(857, 48, 400, 1054)]), true,
+            "starting on that edge covers the whole band width")
+
+    t.equal(covered([box(861, 44, 400, 1062)]), false,
+            "a neighbouring tile that only abuts the outer rectangle does not count")
+    // Measured by how far the overlap reaches *past* the window's edge, so these two differ
+    // by where they end, not where they start.
+    t.equal(covered([box(600, 300, 257.25, 150)]), false,
+            "a quarter-point past the edge is rounding noise between AX and the window server")
+    t.equal(covered([box(600, 300, 259, 150)]), true,
+            "two points past it is real")
+
+    t.equal(covered([box(15, 900, 842, 300)]), true,
+            "poking past the bottom edge covers the band there")
+    t.equal(covered([box(0, 0, 3456, 2234)]), true, "a full-screen window covers everything")
+    t.equal(covered([box(2000, 48, 800, 1000)]), false,
+            "a window on the next display along cannot cover this band")
+    t.equal(covered([box(-900, 48, 800, 1000)]), false,
+            "nor one on the display to the left, at negative coordinates")
+
+    t.equal(covered([]), false, "nothing above means nothing covering")
+    t.equal(BorderGeometry.bandIsCovered(window: window, width: 0, by: [box(0, 0, 3456, 2234)]),
+            false, "no band, nothing to cover")
+
+    t.equal(covered([box(300, 300, 200, 150), box(364, 215, 1000, 626)]), true,
+            "the second of two is enough")
+    t.equal(covered([box(300, 300, 200, 150), box(400, 400, 100, 100)]), false,
+            "neither of two is still nothing")
+}
+
 h.test("binding specs parse in both spellings") { t in
     func parse(_ s: String) -> String? {
         guard let (m, code, name) = try? BindingParser.parse(s, superKey: .option) else { return nil }

--- a/Sources/toe/AX/WindowStack.swift
+++ b/Sources/toe/AX/WindowStack.swift
@@ -1,0 +1,53 @@
+import CoreGraphics
+import Foundation
+import ToeCore
+
+/// The window server's stacking order, which Accessibility does not expose at all.
+///
+/// Reads `kCGWindowBounds`, `kCGWindowLayer`, `kCGWindowOwnerPID` and `kCGWindowAlpha`, and
+/// nothing else. `kCGWindowName` would need Screen Recording; Accessibility is the one
+/// permission toe asks for, so the window list is read for geometry and never for content.
+enum WindowStack {
+
+    /// The levels worth considering. A window above `.floating` — a menu, the Dock, a system
+    /// alert — already draws over the border correctly, and dropping the border to `.normal`
+    /// would not change that, so counting one would strand the border down there for as long
+    /// as it stayed on screen. This bound is the same fact as `BorderOverlay.Depth`'s
+    /// `.floating`: change one and change the other.
+    private static let levels = 0...Int(CGWindowLevelForKey(.floatingWindow))
+
+    /// Ordinary windows stacked above `id`, in Accessibility coordinates.
+    ///
+    /// Empty when the window is not on screen — a stale id, another Space, a window on its way
+    /// out — which reads as "nothing is covering it". That is the right way to fail: the
+    /// fallback is the behaviour toe has always had, not a new one.
+    static func ordinaryWindowsAbove(_ id: WindowID) -> [Box] {
+        let options: CGWindowListOption = [.optionOnScreenAboveWindow, .excludeDesktopElements]
+        guard let list = CGWindowListCopyWindowInfo(options, id) as? [[String: Any]] else {
+            return []
+        }
+        let ownPID = Int(ProcessInfo.processInfo.processIdentifier)
+
+        return list.compactMap { info in
+            // toe's own border panel is above the focused window by construction, so without
+            // this the border would demote itself every single time, in every case.
+            guard info[kCGWindowOwnerPID as String] as? Int != ownPID else { return nil }
+            guard let layer = info[kCGWindowLayer as String] as? Int,
+                  levels.contains(layer)
+            else { return nil }
+            // Apps keep invisible helper windows around; one of those covering the band is not
+            // something anyone can see.
+            if let alpha = info[kCGWindowAlpha as String] as? Double, alpha < 0.01 { return nil }
+            guard let bounds = info[kCGWindowBounds as String] as? NSDictionary,
+                  let rect = CGRect(dictionaryRepresentation: bounds as CFDictionary),
+                  rect.width > 1, rect.height > 1
+            else { return nil }
+
+            // No conversion. `kCGWindowBounds` and `Box` are already the same space: origin at
+            // the top-left of the primary display, y growing downward. `Coordinates.toCocoa`
+            // sits next door and looks like it belongs here, but it would flip y about the
+            // primary display's height — invisible on one display, badly wrong on two.
+            return Box(x: rect.minX, y: rect.minY, w: rect.width, h: rect.height)
+        }
+    }
+}

--- a/Sources/toe/AX/WindowTracker.swift
+++ b/Sources/toe/AX/WindowTracker.swift
@@ -33,6 +33,10 @@ protocol WindowTrackerDelegate: AnyObject {
     /// geometry, or the user dragging it.
     func windowFrameChangedExternally(_ id: CGWindowID)
     func screensChanged()
+    /// Something moved in the window stack that toe does not manage: another application came
+    /// forward, or one opened a window toe will never tile. Neither changes the layout, but
+    /// both change what is stacked over the focused window.
+    func windowStackChanged()
 }
 
 /// Discovers windows and keeps them in sync with the running applications.
@@ -93,6 +97,24 @@ final class WindowTracker {
             // swiftlint:disable:next force_cast
             if let id = (focused as! AXUIElement).windowID, windows[id] != nil {
                 delegate?.windowFocused(id)
+            }
+        }
+        // Unconditionally, and after the focus forwarding above rather than inside it: the app
+        // coming forward is very often one toe manages nothing for — Raycast opening its
+        // settings panel over the focused tile is the case that prompted this — and that is
+        // exactly when the border needs to be told what is now stacked above it.
+        noteStackChange()
+    }
+
+    /// Fires now and twice more shortly after. The notification arrives before the window
+    /// server has necessarily finished raising and placing the window, and the border's depth
+    /// is decided from stacking that is only true a beat later — the same reason `observe`
+    /// sweeps for windows more than once, and bounded the same way.
+    private func noteStackChange() {
+        delegate?.windowStackChanged()
+        for delay in [0.15, 0.4] {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+                self?.delegate?.windowStackChanged()
             }
         }
     }
@@ -182,7 +204,10 @@ final class WindowTracker {
     fileprivate func handle(notification: String, element: AXUIElement) {
         switch notification {
         case kAXWindowCreatedNotification:
-            adopt(element, pid: element.pid)
+            // A window toe will never manage — a dialog, a sheet, a palette — still changes
+            // what is stacked over the focused one. `adopt` returns the existing window when
+            // it already knows it, so this only fires for windows nothing else reports.
+            if adopt(element, pid: element.pid) == nil { noteStackChange() }
 
         case kAXWindowMovedNotification, kAXWindowResizedNotification:
             guard let id = windows.first(where: { CFEqual($0.value.element, element) })?.key else { return }

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -333,6 +333,12 @@ final class Coordinator: WindowTrackerDelegate {
         apply(refocus: false)
     }
 
+    /// Nothing about the layout has changed — only what is stacked over the focused window,
+    /// which is what decides whether the border can sit above everything.
+    func windowStackChanged() {
+        updateBorder()
+    }
+
     // MARK: - Applying the layout
 
     private func apply(refocus: Bool) {
@@ -411,10 +417,24 @@ final class Coordinator: WindowTrackerDelegate {
 
         // Prefer the frame we wrote; fall back to asking the window for floating ones.
         if let box = window.element.frame ?? desired[focused] {
-            border.show(around: box)
+            border.show(around: box, depth: borderDepth(around: box, of: focused))
         } else {
             border.hide()
         }
+    }
+
+    /// Where the border belongs in the stack.
+    ///
+    /// Above every ordinary window is right almost always — but a `.floating` panel is
+    /// composited above every ordinary window whatever the real z-order says, so a dialog
+    /// opened over the focused window had the ring drawn straight through it. When something
+    /// really is stacked over the band, the ordinary level puts the border back underneath the
+    /// active application, where it belongs: still above every inactive app, so the ring stays
+    /// visible all the way round, with the window in front covering only what it overlaps.
+    private func borderDepth(around box: Box, of id: WindowID) -> BorderOverlay.Depth {
+        let above = WindowStack.ordinaryWindowsAbove(id)
+        return BorderGeometry.bandIsCovered(window: box, width: config.border.width, by: above)
+            ? .behindFrontmost : .aboveEverything
     }
 
     /// The user has let go. The window has been off its tile for the length of the drag, so

--- a/Sources/toe/UI/BorderOverlay.swift
+++ b/Sources/toe/UI/BorderOverlay.swift
@@ -14,10 +14,18 @@ final class BorderOverlay {
     private let band = CALayer()
     private var config = BorderConfig()
 
-    /// Where the border sits in the window stack.
+    /// Where the border sits in the window stack. Chosen per update by
+    /// `Coordinator.borderDepth(around:of:)` rather than fixed.
     enum Depth {
-        /// Above every ordinary window — the focused window's own outline, which nothing
-        /// should cover.
+        /// Above every ordinary window. Where the focused window's outline belongs whenever
+        /// nothing is stacked over it — which is nearly always, and is why it is the starting
+        /// point rather than the exception.
+        ///
+        /// It cannot be the only answer, though. `.floating` is CG layer 3, and the window
+        /// server composites by layer before z-order, so this level draws above every ordinary
+        /// window whether or not it is really in front — which had the ring drawn straight
+        /// through any dialog opened over the focused window. `WindowStack` derives its own
+        /// bound from this level; the two are the same fact.
         case aboveEverything
         /// Just behind the frontmost window, above all the rest.
         ///
@@ -28,6 +36,11 @@ final class BorderOverlay {
         /// window level decides the order regardless — but the ordinary level arrives at the
         /// same place anyway: toe is a background app, so a normal-level panel lands directly
         /// beneath the frontmost application's window, which is the one in the user's hand.
+        ///
+        /// It does the same job for a window stacked over the focused one: at the ordinary
+        /// level the ring still draws above every inactive application, so it stays visible
+        /// all the way round the focused window, while the window in front covers the part of
+        /// it that it genuinely overlaps.
         case behindFrontmost
 
         var level: NSWindow.Level { self == .aboveEverything ? .floating : .normal }
@@ -73,11 +86,16 @@ final class BorderOverlay {
     }
 
     /// `box` is the window's own frame in AX coordinates; the border is drawn just outside it.
-    func show(around box: Box, depth: Depth = .aboveEverything) {
+    ///
+    /// `depth` has no default on purpose: both call sites decide it, and a default is how a
+    /// future one would silently go back to drawing over whatever is in front of it.
+    func show(around box: Box, depth: Depth) {
         guard config.enabled, config.width > 0 else { hide(); return }
 
         let w = config.width
-        let outer = Box(x: box.x - w, y: box.y - w, w: box.w + 2 * w, h: box.h + 2 * w)
+        // The same `outset` the depth decision measures against, so what is drawn and what is
+        // tested for coverage cannot drift apart.
+        let outer = BorderGeometry.outset(box, by: w)
         let rect = Coordinates.toCocoa(outer)
         guard rect.width > 0, rect.height > 0 else { hide(); return }
 


### PR DESCRIPTION
Fixes #38.

The border panel was held at `.floating` unconditionally — CG layer 3, against layer 0 for
ordinary windows. The window server composites by layer before z-order, so the ring was drawn
above every ordinary window whether or not it was genuinely in front.

## Fix

Decide the depth per update: ask the window server what is stacked above the focused window and,
when any of it covers the band, use `Depth.behindFrontmost` (already there for drags). toe is an
accessory app, so at the ordinary level the ring still draws above every *inactive* application
— it stays visible all the way round the focused window, and only the window actually in front
covers the part it overlaps.

| File | |
|---|---|
| `ToeCore/BorderGeometry.swift` | `outset`, `bandIsCovered` — pure, tested |
| `toe/AX/WindowStack.swift` | **new** — the `CGWindowListCopyWindowInfo` read, nothing else |
| `toe/Coordinator.swift` | `borderDepth(around:of:)`, `windowStackChanged()` |
| `toe/AX/WindowTracker.swift` | the two new triggers |
| `toe/UI/BorderOverlay.swift` | `Depth` docs; `show` loses its default argument |

`bandIsCovered` measures the **band** — the ring between the window and the outset rect — so a
dialog centred on the window covers only the hole the border never draws on, and does not count.
`show(around:depth:)` loses its default so a future call site cannot silently reintroduce this,
and both it and the decision now go through the same `BorderGeometry.outset`.

## Verified against live data, not just unit tests

Replaying the real decision path over the running window server, with the bug visible on screen:

```
focused tile (871.0, 48.0, 842.0, 520.0)   (toe pid 18073 filtered out)
windows above, after filtering:
   Ghostty  (15.0, 48.0, 842.0, 1054.0)     <- adjacent tile, correctly does NOT trigger
   Raycast  (428.0, 270.0, 1000.0, 626.0)   <- correctly triggers
bandIsCovered(width: 4) -> true
=> depth would be .behindFrontmost (layer 0)
```

Plus 17 new assertions (243 → 260), including the exact geometry from the capture that found the
bug, the epsilon on both sides, and the adjacent-tile and other-display cases.

## Traps, all commented where they bite

- **toe's own panel is in its own query result** — confirmed empirically, it comes back at layer
  3. Without the pid filter the border demotes itself every time, in every case.
- **No coordinate conversion.** `kCGWindowBounds` and `Box` are already the same space.
  `Coordinates.toCocoa` sits next door and looks like it belongs; it would be a y-flip that
  looks like a no-op on one display and is wrong on two.
- **`Box.intersection` clamps size but not origin**, so the empty check must precede the
  stick-out test or disjoint boxes read as covering the band.

## Not done, deliberately

- **`isManageable` untouched.** Widening it to adopt dialogs would make toe *tile* them. The
  border legitimately stays on the focused tile; it just stops painting over what is in front.
- **No timer.** A stale decision now leaves the border one level too low and still fully drawn,
  rather than absent — not worth polling for.
- **Known limit:** `.normal` is a single position, not per-window interleaving, so a covering
  window belonging to a non-frontmost app is still painted over. Correct interleaving needs
  CGS/SkyLight relative ordering, which toe does without.

## Still to check by hand

The one path not exercised end to end is the panel actually changing level, which needs a
running toe with Accessibility. The dev build (`toe-dev`) has its own TCC entry separate from
the installed Developer ID app, so it needs a one-time grant before `make run` can show it.