### PR TITLE
Cap Accessibility messaging at 250ms so a hung app cannot freeze toe

### DIFF
--- a/Sources/toe/AX/AXElement.swift
+++ b/Sources/toe/AX/AXElement.swift
@@ -12,6 +12,38 @@ private let axGetWindow: (@convention(c) (AXUIElement, UnsafeMutablePointer<CGWi
     return unsafeBitCast(sym, to: (@convention(c) (AXUIElement, UnsafeMutablePointer<CGWindowID>) -> AXError).self)
 }()
 
+/// How long toe will wait for an application to answer a single Accessibility call.
+///
+/// Every AX call toe makes is synchronous and on the main thread, and they are not rare:
+/// `isManageable` alone makes six cross-process round trips per candidate window, on every
+/// window creation and focus change, and `WindowMover.setFrame` five more per tile. The macOS
+/// default timeout is measured in seconds, so one unresponsive application — an Electron app
+/// mid-startup, a process stopped in a debugger — would stall hotkeys, the menu bar strip and
+/// the layout for every other app along with it. yabai and AeroSpace cap it for this reason.
+///
+/// A quarter of a second is far more than a healthy app needs to answer, and short enough that
+/// a hung one costs a frame rather than a freeze.
+private let axMessagingTimeout: Float = 0.25
+
+enum AX {
+
+    /// The application element for `pid`, with toe's messaging timeout applied. Always use
+    /// this rather than `AXUIElementCreateApplication`: the timeout is a property of the
+    /// element, and setting it on an application element covers every message to that app.
+    static func application(_ pid: pid_t) -> AXUIElement {
+        let element = AXUIElementCreateApplication(pid)
+        AXUIElementSetMessagingTimeout(element, axMessagingTimeout)
+        return element
+    }
+
+    /// Applies the timeout to every element that does not carry one of its own. The window
+    /// elements the observer callbacks hand to toe are what this is for: they arrive from the
+    /// AX API rather than from an application element toe created, so nothing else caps them.
+    static func setGlobalMessagingTimeout() {
+        AXUIElementSetMessagingTimeout(AXUIElementCreateSystemWide(), axMessagingTimeout)
+    }
+}
+
 extension AXUIElement {
 
     func value(_ attribute: String) -> CFTypeRef? {

--- a/Sources/toe/AX/WindowMover.swift
+++ b/Sources/toe/AX/WindowMover.swift
@@ -16,7 +16,7 @@ enum WindowMover {
     ///    silently ignore programmatic resizes. Turning it off around the write and restoring
     ///    it afterwards is what makes those apps tile at all.
     static func setFrame(_ frame: Box, element: AXUIElement, pid: pid_t) {
-        let app = AXUIElementCreateApplication(pid)
+        let app = AX.application(pid)
         let enhanced = app.bool(kAXEnhancedUserInterface) ?? false
         if enhanced { app.set(kAXEnhancedUserInterface, kCFBooleanFalse) }
         defer { if enhanced { app.set(kAXEnhancedUserInterface, kCFBooleanTrue) } }
@@ -31,7 +31,7 @@ enum WindowMover {
 
     /// Moves a window without touching its size, used for stashing and un-stashing.
     static func setPosition(_ point: CGPoint, element: AXUIElement, pid: pid_t) {
-        let app = AXUIElementCreateApplication(pid)
+        let app = AX.application(pid)
         let enhanced = app.bool(kAXEnhancedUserInterface) ?? false
         if enhanced { app.set(kAXEnhancedUserInterface, kCFBooleanFalse) }
         defer { if enhanced { app.set(kAXEnhancedUserInterface, kCFBooleanTrue) } }

--- a/Sources/toe/AX/WindowTracker.swift
+++ b/Sources/toe/AX/WindowTracker.swift
@@ -92,7 +92,7 @@ final class WindowTracker {
     @objc private func appActivated(_ note: Notification) {
         guard let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
               app.processIdentifier != ownPID else { return }
-        let element = AXUIElementCreateApplication(app.processIdentifier)
+        let element = AX.application(app.processIdentifier)
         if let focused = element.value(kAXFocusedWindowAttribute) {
             // swiftlint:disable:next force_cast
             if let id = (focused as! AXUIElement).windowID, windows[id] != nil {
@@ -129,7 +129,7 @@ final class WindowTracker {
         guard AXObserverCreate(pid, axCallback, &observer) == .success, let observer else { return }
         observers[pid] = observer
 
-        let element = AXUIElementCreateApplication(pid)
+        let element = AX.application(pid)
         let refcon = Unmanaged.passUnretained(self).toOpaque()
         for notification in [kAXWindowCreatedNotification,
                              kAXFocusedWindowChangedNotification,
@@ -155,7 +155,7 @@ final class WindowTracker {
     }
 
     private func adoptWindows(of pid: pid_t) {
-        let element = AXUIElementCreateApplication(pid)
+        let element = AX.application(pid)
         for window in element.windows { adopt(window, pid: pid) }
     }
 
@@ -225,7 +225,7 @@ final class WindowTracker {
             }
 
         case kAXApplicationActivatedNotification:
-            let app = AXUIElementCreateApplication(element.pid)
+            let app = AX.application(element.pid)
             if let focused = app.value(kAXFocusedWindowAttribute) {
                 // swiftlint:disable:next force_cast
                 let focusedElement = focused as! AXUIElement

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -116,6 +116,8 @@ final class Coordinator: WindowTrackerDelegate {
     }
 
     private func beginManaging() {
+        // Before the first AX call: caps how long any single one can block the main thread.
+        AX.setGlobalMessagingTimeout()
         tracker.delegate = self
         tracker.floatRules = config.floatRules
         refreshMonitors()


### PR DESCRIPTION
Every AX call toe makes is synchronous and on the main thread, and nothing
set a messaging timeout, so the macOS default — seconds — applied. The calls
are not rare: isManageable makes six cross-process round trips per candidate
window on every kAXWindowCreated and kAXFocusedWindowChanged plus the four
timed sweeps per app launch, and WindowMover.setFrame five more per tile. One
unresponsive application therefore blocked the main thread for the duration
of the timeout, stalling hotkeys, the menu bar strip and the layout for every
healthy app along with it.

AX.application(_:) now stamps the timeout on every application element in
place of AXUIElementCreateApplication, which covers messages to that app.
Window elements arriving through the observer callbacks are never created
from an application element toe made, so beginManaging also sets the timeout
on the system-wide element, which is the default for anything without one of
its own.

Closes #16

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011xqvVmFSxb9CsvEd99VN81