### PR TITLE
Drop the status item menu, bind config editing instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ as the defaults.
 | `SUPER` + `W` | Close window |
 | `SUPER` + `J` | Toggle split orientation |
 | `SUPER` + `T` | Toggle floating |
+| `SUPER` + `,` | Edit the config — nano, in a terminal window |
+| `SUPER` + `SHIFT` + `R` / `Q` | Reload the config / quit toe |
 | Drag a tiled window | Swap it with the tile you drag it over |
 
 `SUPER` is **Option (⌥)** — the same physical key position as SUPER on a PC keyboard, and it
@@ -48,23 +50,10 @@ not focused on gets the same square, outlined.
 `[bar] persistent_workspaces` sets how many keep a slot: `0` shows only the ones in use, `10`
 always shows all ten.
 
-Clicking a workspace switches to it, as Omarchy's `on-click: activate` does. Right-click —
-or left-click the padding at either end — to open the menu, which breaks each workspace down
-into the applications living there:
-
-```
-▪ Workspace 1
-      Ghostty  ×2
-      Safari  ×2
-  Workspace 4
-      Google Chrome
-────────────────────
-Config loaded
-```
-
-Rows are live: click a workspace to switch to it, or an application to focus its window —
-including one on a hidden workspace, which brings that workspace forward first. The list is
-built when the menu opens, so nothing is maintained while it is closed.
+Clicking a workspace switches to it, as Omarchy's `on-click: activate` does. That is the
+whole of it — waybar's strip has no menu behind it, and neither has this one. toe's own
+actions are key bindings instead: `SUPER`+`,` edits the config, `SUPER`+`SHIFT`+`R` reloads
+it, `SUPER`+`SHIFT`+`Q` quits. A config that will not parse is named in the item's tooltip.
 
 ## Install
 
@@ -187,16 +176,18 @@ rules.
 
 ## Config
 
-`~/.config/toe/toe.toml` is written on first run and reloaded whenever you save it. If it
-fails to parse, the running config is kept and the error appears in the menu bar item — a typo
-can never leave you without a keyboard. See [`toe.example.toml`](toe.example.toml).
+`~/.config/toe/toe.toml` is written on first run and reloaded whenever you save it. `SUPER`+`,`
+opens it in nano, in a Terminal.app window; bind `exec` with your own terminal instead if you
+would rather. If it fails to parse, the running config is kept and the error is named in the
+menu bar item's tooltip — a typo can never leave you without a keyboard. See
+[`toe.example.toml`](toe.example.toml).
 
 Binding specs parse in both spellings, so you can paste from an AeroSpace config or an Omarchy
 one: `"alt-shift-1"`, `"super+shift+1"` and `"SUPER SHIFT, 1"` are the same binding.
 
 Commands: `movefocus`, `swapwindow`, `movewindow`, `workspace`, `movetoworkspace`,
 `movetoworkspacesilent`, `killactive`, `togglefloating`, `togglesplit`, `swapsplit`, `exec`,
-`reload`.
+`reload`, `editconfig`, `quit`.
 
 The TOML parser is a dependency-free subset: tables, arrays of tables, bare and quoted keys,
 basic and literal strings, numbers, booleans, arrays and inline tables. No multi-line strings

--- a/Sources/ToeCore/Config/Binding.swift
+++ b/Sources/ToeCore/Config/Binding.swift
@@ -6,7 +6,7 @@ public struct Binding: Equatable {
     public let keyCode: UInt32
     public let keyName: String
     public let command: Command
-    /// The binding string exactly as written in the config, for error messages and the menu.
+    /// The binding string exactly as written in the config, for error messages.
     public let source: String
 
     public var describedShortcut: String {

--- a/Sources/ToeCore/Config/Config.swift
+++ b/Sources/ToeCore/Config/Config.swift
@@ -79,7 +79,7 @@ public struct Config: Equatable {
     public var bindings: [Binding] = []
     public var floatRules: [FloatRule] = Config.defaultFloatRules
     /// Non-fatal problems (a binding that would not parse, an unknown key). Surfaced in the
-    /// menu bar rather than thrown, so one typo never leaves you without a keyboard.
+    /// menu bar item rather than thrown, so one typo never leaves you without a keyboard.
     public var warnings: [String] = []
 
     public init() {}
@@ -166,7 +166,7 @@ public struct Config: Equatable {
         }
 
         if let binds = root["binds"]?.tableValue {
-            // Sorted so the menu and any diagnostics are stable run to run.
+            // Sorted so the tooltip and any diagnostics are stable run to run.
             for spec in binds.keys.sorted() {
                 guard let raw = binds[spec]?.stringValue else {
                     config.warnings.append("binds.\(spec): value must be a string")

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -8,7 +8,8 @@ let defaultConfigText = #"""
 # toe — The Omarchy Experience
 #
 # Reloads automatically when you save. If a line does not parse, the running config is kept
-# and the error is shown in the menu bar item, so a typo can never leave you keyboardless.
+# and the error is named in the menu bar item's tooltip, so a typo can never leave you
+# keyboardless. SUPER+, opens this file in nano.
 
 [general]
 # Omarchy's SUPER maps to Option: same physical key position as SUPER on a PC keyboard, and
@@ -107,6 +108,17 @@ persistent_workspaces = 5
 "super-w"       = "killactive"
 "super-j"       = "togglesplit"
 "super-t"       = "togglefloating"
+
+# ── toe itself ────────────────────────────────────────────────────────────────
+# The menu bar item is only the workspace strip — waybar's has nothing behind it either — so
+# these are the way in to everything toe can do to itself.
+# `editconfig` opens this file in nano, in a Terminal.app window. To use your own terminal,
+# bind exec instead:  "exec open -na Ghostty --args -e nano ~/.config/toe/toe.toml"
+"super-comma"   = "editconfig"
+# Saving this file already reloads it; this is the manual way.
+"super-shift-r" = "reload"
+# Puts every window on a hidden workspace back where it came from on the way out.
+"super-shift-q" = "quit"
 
 # ── Launch ────────────────────────────────────────────────────────────────────
 # AppleScript's `new window` reuses the running instance, so the window opens on the current

--- a/Sources/ToeCore/Dispatch/Command.swift
+++ b/Sources/ToeCore/Dispatch/Command.swift
@@ -20,6 +20,10 @@ public enum Command: Equatable {
     case swapSplit
     case exec(String)
     case reload
+    /// Opens the config file in a terminal, in nano. toe has no settings window and, since
+    /// the menu bar item lost its menu, no other way in.
+    case editConfig
+    case quit
 }
 
 public enum CommandError: Error, CustomStringConvertible {
@@ -72,6 +76,8 @@ public enum CommandParser {
         case "togglesplit":                 return .toggleSplit
         case "swapsplit":                   return .swapSplit
         case "reload":                      return .reload
+        case "editconfig", "config":        return .editConfig
+        case "quit", "exit":                return .quit
 
         case "exec", "exec-and-forget":
             guard !argument.isEmpty else { throw CommandError.missingArgument(name) }

--- a/Sources/ToeCore/Layout/WorkspaceManager.swift
+++ b/Sources/ToeCore/Layout/WorkspaceManager.swift
@@ -472,15 +472,8 @@ public final class WorkspaceManager {
 
 public extension WorkspaceManager {
 
-    /// The windows on a workspace in a stable, meaningful order: tiled windows in tree order
-    /// (left to right, top to bottom), then floating ones.
-    func orderedWindows(inWorkspace index: Int) -> [WindowID] {
-        guard let ws = workspaces[index] else { return [] }
-        return ws.layout.windowIDs + ws.floating.sorted()
-    }
-
-    /// Whether a workspace holds no windows — without building the window list, so the menu
-    /// bar can ask it on every status refresh.
+    /// Whether a workspace holds no windows — cheap enough for the menu bar to ask on every
+    /// status refresh.
     func isEmpty(workspace index: Int) -> Bool {
         workspaces[index]?.isEmpty ?? true
     }
@@ -488,28 +481,5 @@ public extension WorkspaceManager {
     /// Which monitor, if any, is currently showing this workspace.
     func monitorShowing(workspace index: Int) -> UInt32? {
         activeWorkspace.first { $0.value == index }?.key
-    }
-}
-
-/// Collapses a window list into one entry per application, preserving the order the
-/// applications first appear in.
-public enum AppGrouping {
-
-    public struct Group: Equatable {
-        public let name: String
-        public let windows: [WindowID]
-        public var count: Int { windows.count }
-    }
-
-    public static func group(_ windows: [WindowID], name: (WindowID) -> String?) -> [Group] {
-        var order: [String] = []
-        var byName: [String: [WindowID]] = [:]
-
-        for window in windows {
-            guard let appName = name(window) else { continue }
-            if byName[appName] == nil { order.append(appName) }
-            byName[appName, default: []].append(window)
-        }
-        return order.map { Group(name: $0, windows: byName[$0] ?? []) }
     }
 }

--- a/Sources/ToeCore/WorkspaceStrip.swift
+++ b/Sources/ToeCore/WorkspaceStrip.swift
@@ -69,7 +69,7 @@ public enum WorkspaceStrip {
     ///
     /// The strip is centred in `buttonWidth`, its items `gap` apart. Zones reach to the
     /// midpoint between neighbours so the gaps are not dead, but a click beyond either end
-    /// of the strip returns nil — that is the padding, and it opens the menu instead.
+    /// of the strip returns nil — that is the padding, and nothing lives there.
     public static func hit(x: Double, widths: [Double], gap: Double, buttonWidth: Double) -> Int? {
         guard !widths.isEmpty else { return nil }
 

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -631,6 +631,11 @@ h.test("the shipped default config parses cleanly") { t in
     t.equal(binding("super-t")?.keyCode, 0x11, "T key code")
     t.equal(binding("super-shift-v"), nil, "SUPER+SHIFT+V is no longer bound")
 
+    // Everything the menu bar item used to offer, now that it offers nothing.
+    t.equal(binding("super-comma")?.command, .editConfig, "SUPER+, edits the config")
+    t.equal(binding("super-shift-r")?.command, .reload, "SUPER+SHIFT+R reloads it")
+    t.equal(binding("super-shift-q")?.command, .quit, "SUPER+SHIFT+Q quits toe")
+
     let arrows = ["super-left", "super-right", "super-up", "super-down"]
     t.equal(arrows.allSatisfy { binding($0) != nil }, true, "all four focus arrows bound")
     t.equal((1...10).allSatisfy { n in c.bindings.contains { $0.command == .workspace(.index(n)) } },
@@ -834,37 +839,17 @@ h.test("hidden windows park on the monitor's bottom corner") { t in
     t.equal(r, Point(x: 3431, y: 1079), "no neighbour further right")
 }
 
-// MARK: - Menu bar summaries
+// MARK: - Menu bar
 
-h.test("windows are listed in tree order, floating last") { t in
+h.test("a workspace knows whether it holds anything") { t in
     let wm = WorkspaceManager()
     wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
-    wm.addWindow(1); wm.addWindow(2); wm.addWindow(3)
+    wm.addWindow(1); wm.addWindow(2)
     wm.addWindow(9, floating: true)
-    wm.addWindow(7, floating: true)
 
-    t.equal(wm.orderedWindows(inWorkspace: 1), [1, 2, 3, 7, 9],
-            "tiled left-to-right depth-first, then floating")
-    t.equal(wm.orderedWindows(inWorkspace: 4), [], "an untouched workspace is empty")
-
-    // What the menu bar strip asks on every refresh, and why it does not ask for the list.
+    // What the strip asks on every refresh — no window list is ever built for it.
     t.equal(wm.isEmpty(workspace: 1), false, "tiled and floating windows both count")
     t.equal(wm.isEmpty(workspace: 4), true, "an untouched workspace holds nothing")
-}
-
-h.test("windows group by application in first-appearance order") { t in
-    let names: [WindowID: String] = [1: "Ghostty", 2: "Google Chrome", 3: "Ghostty",
-                                     4: "Safari", 5: "Google Chrome"]
-    let groups = AppGrouping.group([1, 2, 3, 4, 5]) { names[$0] }
-
-    t.equal(groups.map(\.name), ["Ghostty", "Google Chrome", "Safari"],
-            "ordered by where each app first appears, not alphabetically")
-    t.equal(groups.map(\.count), [2, 2, 1], "windows per app")
-    t.equal(groups.first?.windows, [1, 3], "selecting the row focuses the first window")
-
-    // A window whose application cannot be named is dropped rather than shown blank.
-    t.equal(AppGrouping.group([1, 99]) { names[$0] }.map(\.name), ["Ghostty"], "unnamed windows skipped")
-    t.equal(AppGrouping.group([]) { names[$0] }.isEmpty, true, "no windows, no groups")
 }
 
 h.test("a workspace knows which monitor is showing it") { t in
@@ -954,8 +939,8 @@ h.test("clicking the strip picks the workspace under the pointer") { t in
     t.equal(hit(21), .some(0), "just past the first item")
     t.equal(hit(24), .some(1), "just before the second")
 
-    t.equal(hit(5), nil, "the padding before the strip opens the menu instead")
-    t.equal(hit(55), nil, "and so does the padding after it")
+    t.equal(hit(5), nil, "the padding before the strip is not a workspace")
+    t.equal(hit(55), nil, "and neither is the padding after it")
     t.equal(WorkspaceStrip.hit(x: 30, widths: [], gap: 7, buttonWidth: 60), nil, "no items, no hit")
 }
 

--- a/Sources/toe/AX/WindowTracker.swift
+++ b/Sources/toe/AX/WindowTracker.swift
@@ -7,7 +7,6 @@ final class ManagedWindow {
     let element: AXUIElement
     let pid: pid_t
     let bundleID: String?
-    let appName: String?
     var title: String?
     /// Where the window sat before it was stashed off-screen, so floating windows come back
     /// to exactly where they were.
@@ -15,12 +14,11 @@ final class ManagedWindow {
     var isStashed = false
 
     init(id: CGWindowID, element: AXUIElement, pid: pid_t,
-         bundleID: String?, appName: String?, title: String?) {
+         bundleID: String?, title: String?) {
         self.id = id
         self.element = element
         self.pid = pid
         self.bundleID = bundleID
-        self.appName = appName
         self.title = title
     }
 }
@@ -167,8 +165,7 @@ final class WindowTracker {
 
         let app = NSRunningApplication(processIdentifier: pid)
         let window = ManagedWindow(id: id, element: element, pid: pid,
-                                   bundleID: app?.bundleIdentifier,
-                                   appName: app?.localizedName, title: element.title)
+                                   bundleID: app?.bundleIdentifier, title: element.title)
         windows[id] = window
 
         if let observer = observers[pid] {

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -35,26 +35,10 @@ final class Coordinator: WindowTrackerDelegate {
 
     func start() {
         workspaces.cursorLocation = { Coordinates.toAX(NSEvent.mouseLocation) }
-        status.workspaceProvider = { [weak self] in self?.workspaceSummaries() ?? [] }
         status.onSelectWorkspace = { [weak self] index in
             self?.dispatch(.workspace(.index(index)))
         }
-        status.onSelectWindow = { [weak self] id in
-            guard let self else { return }
-            // Focusing a window on a hidden workspace should bring that workspace forward.
-            if let index = self.workspaces.workspaceIndex(of: id),
-               index != self.workspaces.focusedWorkspaceIndex {
-                self.dispatch(.workspace(.index(index)))
-            }
-            self.focus(id)
-        }
-        status.onReload = { [weak self] in self?.loadConfig() }
-        status.onOpenConfig = { NSWorkspace.shared.open(Coordinator.configURL) }
         status.onOpenAccessibility = { Self.openAccessibilitySettings() }
-        status.onQuit = { [weak self] in
-            self?.unstashEverything()
-            NSApp.terminate(nil)
-        }
 
         installSignalHandlers()
         writeDefaultConfigIfMissing()
@@ -85,7 +69,7 @@ final class Coordinator: WindowTrackerDelegate {
     /// `make run` restarts toe with `pkill`, and SIGTERM's default action would leave a hidden
     /// workspace's windows parked in the stash corner. The next launch then adopts them there
     /// and records that corner as the frame to float them back to — so a window you floated
-    /// would disappear. Unstash before going away, exactly as the Quit menu item does.
+    /// would disappear. Unstash before going away, exactly as `quit` does.
     private func installSignalHandlers() {
         for number in [SIGTERM, SIGINT] {
             signal(number, SIG_IGN)
@@ -177,14 +161,12 @@ final class Coordinator: WindowTrackerDelegate {
     private func refreshStatus() {
         status.update(workspaces: workspaceStates(),
                       warnings: warnings,
-                      accessibilityGranted: AXIsProcessTrusted(),
-                      showMonitorNames: workspaces.monitors.count > 1)
+                      accessibilityGranted: AXIsProcessTrusted())
     }
 
     /// What the strip in the menu bar title draws. This runs on every focus change and every
     /// adopted window, so it stays to what the strip actually reads — no window lists, no app
-    /// names, and above all no icons. Those belong to `workspaceSummaries()`, which the menu
-    /// asks for only when it opens.
+    /// names, and above all no icons.
     private func workspaceStates() -> [WorkspaceStrip.State] {
         let focusedIndex = workspaces.focusedWorkspaceIndex
 
@@ -194,38 +176,6 @@ final class Coordinator: WindowTrackerDelegate {
                                  isVisible: workspaces.monitorShowing(workspace: index) != nil,
                                  isEmpty: workspaces.isEmpty(workspace: index))
         }
-    }
-
-    /// What the menu shows: every workspace, the applications on it, and which display
-    /// (if any) is currently showing it. Only built while the menu is opening.
-    private func workspaceSummaries() -> [WorkspaceSummary] {
-        let focusedIndex = workspaces.focusedWorkspaceIndex
-
-        return (1...WorkspaceManager.workspaceCount).map { index in
-            let ordered = workspaces.orderedWindows(inWorkspace: index)
-            let groups = AppGrouping.group(ordered) { [weak self] id in
-                self?.tracker.window(id)?.appName
-            }
-            let apps = groups.compactMap { group -> AppSummary? in
-                guard let first = group.windows.first else { return nil }
-                let icon = tracker.window(first)
-                    .flatMap { NSRunningApplication(processIdentifier: $0.pid) }?.icon
-                return AppSummary(name: group.name, windowCount: group.count,
-                                  icon: icon, representativeWindow: first)
-            }
-
-            let showingOn = workspaces.monitorShowing(workspace: index)
-            return WorkspaceSummary(
-                index: index,
-                isFocused: index == focusedIndex,
-                isVisible: showingOn != nil,
-                monitorName: showingOn.map { Self.monitorName(for: $0) },
-                apps: apps)
-        }
-    }
-
-    private static func monitorName(for displayID: UInt32) -> String {
-        NSScreen.screens.first { $0.displayID == displayID }?.localizedName ?? "Display \(displayID)"
     }
 
     // MARK: - Monitors
@@ -528,6 +478,39 @@ final class Coordinator: WindowTrackerDelegate {
 
         case .reload:
             loadConfig()
+
+        case .editConfig:
+            openConfigInTerminal()
+
+        case .quit:
+            unstashEverything()
+            NSApp.terminate(nil)
+        }
+    }
+
+    /// The config has no window of its own and, since the menu bar item lost its menu, no
+    /// menu item either — so `editconfig` opens it the way you would edit it anyway: a
+    /// terminal with nano in it. Terminal.app rather than the terminal you launch with
+    /// SUPER+ENTER, because it is the one that is always installed; bind `exec` instead if
+    /// you want your own (there is a line for it in the default config).
+    private func openConfigInTerminal() {
+        let shell = "nano '" + Coordinator.configURL.path.replacingOccurrences(of: "'", with: "'\\''") + "'"
+        let quoted = shell
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        let script = """
+            tell application "Terminal"
+                activate
+                do script "\(quoted)"
+            end tell
+            """
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = ["-e", script]
+        do {
+            try process.run()
+        } catch {
+            Log.error("editconfig: could not open Terminal: \(error)")
         }
     }
 }

--- a/Sources/toe/UI/StatusItem.swift
+++ b/Sources/toe/UI/StatusItem.swift
@@ -1,51 +1,23 @@
 import AppKit
 import ToeCore
 
-/// One application's presence on a workspace.
-struct AppSummary {
-    let name: String
-    let windowCount: Int
-    let icon: NSImage?
-    /// Selecting the row focuses this window.
-    let representativeWindow: WindowID
-}
-
-struct WorkspaceSummary {
-    let index: Int
-    /// Shown on the monitor that currently has focus.
-    let isFocused: Bool
-    /// Shown on some monitor — with several displays, more than one workspace is visible.
-    let isVisible: Bool
-    let monitorName: String?
-    let apps: [AppSummary]
-
-    var isEmpty: Bool { apps.isEmpty }
-}
-
 /// The menu bar item. toe is an `LSUIElement`, so this is its only visible surface.
 ///
 /// The title is the workspace strip in Omarchy's waybar styling — the focused workspace is
-/// a filled rounded square, every other one its own digit — and the menu breaks each
-/// workspace down into the applications living on it. Clicking a workspace switches to it,
-/// as Omarchy's `on-click: activate` does; anywhere else opens the menu.
-final class StatusItem: NSObject, NSMenuDelegate {
+/// a filled rounded square, every other one its own digit. Clicking a workspace switches to
+/// it, as Omarchy's `on-click: activate` does, and that is the whole of it: waybar's strip
+/// has no menu behind it, so neither has this one. Everything the menu used to offer lives
+/// on a key binding instead — `editconfig`, `reload`, `quit`.
+final class StatusItem: NSObject {
 
     private let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-    private let menu = NSMenu()
 
-    /// Rebuilt on demand when the menu opens, so the app list is never stale and toe does no
-    /// work maintaining it while the menu is closed.
-    var workspaceProvider: (() -> [WorkspaceSummary])?
     var onSelectWorkspace: ((Int) -> Void)?
-    var onSelectWindow: ((WindowID) -> Void)?
-    var onReload: (() -> Void)?
-    var onOpenConfig: (() -> Void)?
+    /// The one thing a click still has to be able to do while toe is not yet running: without
+    /// the permission there is no strip to click, and no menu to offer it from either.
     var onOpenAccessibility: (() -> Void)?
-    var onQuit: (() -> Void)?
 
-    private var warnings: [String] = []
     private var accessibilityGranted = false
-    private var showMonitorNames = false
 
     /// waybar's `persistent-workspaces` — how many workspaces keep a slot when empty.
     var persistentWorkspaces = WorkspaceStrip.defaultPersistent
@@ -76,27 +48,27 @@ final class StatusItem: NSObject, NSMenuDelegate {
 
     override init() {
         super.init()
-        menu.delegate = self
         item.button?.title = "toe"
         item.button?.target = self
         item.button?.action = #selector(buttonClicked(_:))
-        item.button?.sendAction(on: [.leftMouseUp, .rightMouseUp])
+        item.button?.sendAction(on: [.leftMouseUp])
     }
 
-    /// Cheap: only the title strip is recomputed, from the little the strip reads. The menu
-    /// rebuilds itself from `workspaceProvider` when opened.
+    /// Cheap: only the title strip is recomputed, from the little the strip reads.
     func update(workspaces: [WorkspaceStrip.State], warnings: [String],
-                accessibilityGranted: Bool, showMonitorNames: Bool) {
-        self.warnings = warnings
+                accessibilityGranted: Bool) {
         self.accessibilityGranted = accessibilityGranted
-        self.showMonitorNames = showMonitorNames
         item.button?.attributedTitle = title(for: workspaces)
 
         // The focused workspace is drawn as a square rather than a digit, so the title on
-        // its own no longer reads as anything — spell it out for VoiceOver.
-        let described = accessibilityGranted
+        // its own no longer reads as anything — spell it out for VoiceOver. With no menu to
+        // list them in, config problems are named here too.
+        var described = accessibilityGranted
             ? "toe — workspace \(workspaces.first { $0.isFocused }?.index ?? 1)"
-            : "toe needs Accessibility permission"
+            : "toe needs Accessibility permission — click to grant it"
+        if !warnings.isEmpty {
+            described += "\n" + warnings.joined(separator: "\n")
+        }
         item.button?.toolTip = described
         item.button?.setAccessibilityLabel(described)
     }
@@ -143,8 +115,7 @@ final class StatusItem: NSObject, NSMenuDelegate {
             ])
         case .focused, .visible:
             let attachment = NSTextAttachment()
-            attachment.image = marker(filled: item.marker == .focused, dim: item.dim,
-                                      side: markerSide)
+            attachment.image = marker(filled: item.marker == .focused, dim: item.dim)
             // Centre the square on the digits' cap height rather than the baseline.
             attachment.bounds = NSRect(x: 0, y: (font.capHeight - markerSide) / 2,
                                        width: markerSide, height: markerSide)
@@ -161,14 +132,10 @@ final class StatusItem: NSObject, NSMenuDelegate {
     /// `nf-md-square_rounded`, which is what Omarchy marks the active workspace with — drawn
     /// rather than set, so it needs no Nerd Font installed. The drawing handler runs at draw
     /// time, so the colour resolves against whichever appearance the menu bar is in.
-    private func marker(filled: Bool, dim: Bool, side: CGFloat,
-                        canvas: CGFloat? = nil) -> NSImage {
-        let box = canvas ?? side
-        let radius = markerRadius * (side / markerSide)
-        let image = NSImage(size: NSSize(width: box, height: box), flipped: false) { rect in
+    private func marker(filled: Bool, dim: Bool) -> NSImage {
+        let side = markerSide, radius = markerRadius
+        let image = NSImage(size: NSSize(width: side, height: side), flipped: false) { square in
             let colour = dim ? Self.dimLabelColor : NSColor.labelColor
-            let square = NSRect(x: (rect.width - side) / 2, y: (rect.height - side) / 2,
-                                width: side, height: side)
             if filled {
                 colour.setFill()
                 NSBezierPath(roundedRect: square, xRadius: radius, yRadius: radius).fill()
@@ -188,142 +155,19 @@ final class StatusItem: NSObject, NSMenuDelegate {
 
     // MARK: - Clicks
 
-    /// The menu is attached only while it is up, so the rest of the time this action runs and
-    /// the strip stays clickable.
+    /// A click on a workspace switches to it. A click anywhere else — the padding at either
+    /// end, or a strip that has nothing in it — does nothing, exactly as waybar's does.
     @objc private func buttonClicked(_ sender: NSStatusBarButton) {
-        guard let event = NSApp.currentEvent,
-              event.type == .leftMouseUp,
-              !event.modifierFlags.contains(.control)
-        else { return popUpMenu() }
+        guard accessibilityGranted else {
+            onOpenAccessibility?()
+            return
+        }
 
+        guard let event = NSApp.currentEvent else { return }
         let x = sender.convert(event.locationInWindow, from: nil).x
-        if let hit = WorkspaceStrip.hit(x: Double(x), widths: stripWidths,
-                                        gap: Double(gap), buttonWidth: Double(sender.bounds.width)) {
-            onSelectWorkspace?(stripItems[hit].index)
-        } else {
-            // The padding at either end, or a strip with no workspaces in it.
-            popUpMenu()
-        }
-    }
-
-    private func popUpMenu() {
-        item.menu = menu                 // menuNeedsUpdate fires here
-        item.button?.performClick(nil)   // blocks until the menu closes
-        item.menu = nil
-    }
-
-    // MARK: - The menu
-
-    func menuNeedsUpdate(_ menu: NSMenu) {
-        menu.removeAllItems()
-
-        if !accessibilityGranted {
-            add(to: menu, "Grant Accessibility permission…", #selector(openAccessibility))
-            menu.addItem(.separator())
-        }
-
-        let workspaces = (workspaceProvider?() ?? []).filter { !$0.isEmpty || $0.isVisible }
-        if workspaces.isEmpty {
-            menu.addItem(disabled("No windows"))
-        }
-
-        for workspace in workspaces {
-            let heading = NSMenuItem(title: headingTitle(workspace),
-                                     action: #selector(selectWorkspace(_:)), keyEquivalent: "")
-            heading.target = self
-            heading.tag = workspace.index
-            // The same square the strip uses, so the two surfaces read as one thing.
-            if workspace.isVisible {
-                heading.image = marker(filled: workspace.isFocused, dim: workspace.isEmpty,
-                                       side: 9, canvas: 12)
-            }
-            heading.attributedTitle = NSAttributedString(
-                string: headingTitle(workspace),
-                attributes: [.font: NSFont.menuFont(ofSize: 13).bold])
-            menu.addItem(heading)
-
-            if workspace.isEmpty {
-                let empty = disabled("empty")
-                empty.indentationLevel = 1
-                menu.addItem(empty)
-                continue
-            }
-
-            for app in workspace.apps {
-                let label = app.windowCount > 1 ? "\(app.name)  ×\(app.windowCount)" : app.name
-                let entry = NSMenuItem(title: label, action: #selector(selectWindow(_:)),
-                                       keyEquivalent: "")
-                entry.target = self
-                entry.indentationLevel = 1
-                entry.representedObject = app.representativeWindow
-                if let icon = app.icon {
-                    let sized = icon.copy() as! NSImage
-                    sized.size = NSSize(width: 16, height: 16)
-                    entry.image = sized
-                }
-                menu.addItem(entry)
-            }
-        }
-
-        menu.addItem(.separator())
-
-        if warnings.isEmpty {
-            menu.addItem(disabled("Config loaded"))
-        } else {
-            let header = NSMenuItem(title: "\(warnings.count) config problem(s)",
-                                    action: nil, keyEquivalent: "")
-            let submenu = NSMenu()
-            for warning in warnings {
-                submenu.addItem(NSMenuItem(title: warning, action: nil, keyEquivalent: ""))
-            }
-            menu.setSubmenu(submenu, for: header)
-            menu.addItem(header)
-        }
-
-        menu.addItem(.separator())
-        add(to: menu, "Reload config", #selector(reload), key: "r")
-        add(to: menu, "Open config…", #selector(openConfig), key: "o")
-        menu.addItem(.separator())
-        add(to: menu, "Quit toe", #selector(quit), key: "q")
-    }
-
-    private func headingTitle(_ workspace: WorkspaceSummary) -> String {
-        var title = "Workspace \(workspace.index)"
-        if showMonitorNames, workspace.isVisible, let monitor = workspace.monitorName {
-            title += " — \(monitor)"
-        }
-        return title
-    }
-
-    private func disabled(_ title: String) -> NSMenuItem {
-        let entry = NSMenuItem(title: title, action: nil, keyEquivalent: "")
-        entry.isEnabled = false
-        return entry
-    }
-
-    @discardableResult
-    private func add(to menu: NSMenu, _ title: String, _ action: Selector, key: String = "") -> NSMenuItem {
-        let entry = NSMenuItem(title: title, action: action, keyEquivalent: key)
-        entry.target = self
-        menu.addItem(entry)
-        return entry
-    }
-
-    // MARK: - Actions
-
-    @objc private func selectWorkspace(_ sender: NSMenuItem) { onSelectWorkspace?(sender.tag) }
-    @objc private func selectWindow(_ sender: NSMenuItem) {
-        guard let id = sender.representedObject as? WindowID else { return }
-        onSelectWindow?(id)
-    }
-    @objc private func reload() { onReload?() }
-    @objc private func openConfig() { onOpenConfig?() }
-    @objc private func openAccessibility() { onOpenAccessibility?() }
-    @objc private func quit() { onQuit?() }
-}
-
-private extension NSFont {
-    var bold: NSFont {
-        NSFontManager.shared.convert(self, toHaveTrait: .boldFontMask)
+        guard let hit = WorkspaceStrip.hit(x: Double(x), widths: stripWidths, gap: Double(gap),
+                                           buttonWidth: Double(sender.bounds.width))
+        else { return }
+        onSelectWorkspace?(stripItems[hit].index)
     }
 }

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -1,7 +1,8 @@
 # toe — The Omarchy Experience
 #
 # Reloads automatically when you save. If a line does not parse, the running config is kept
-# and the error is shown in the menu bar item, so a typo can never leave you keyboardless.
+# and the error is named in the menu bar item's tooltip, so a typo can never leave you
+# keyboardless. SUPER+, opens this file in nano.
 
 [general]
 # Omarchy's SUPER maps to Option: same physical key position as SUPER on a PC keyboard, and
@@ -100,6 +101,17 @@ persistent_workspaces = 5
 "super-w"       = "killactive"
 "super-j"       = "togglesplit"
 "super-t"       = "togglefloating"
+
+# ── toe itself ────────────────────────────────────────────────────────────────
+# The menu bar item is only the workspace strip — waybar's has nothing behind it either — so
+# these are the way in to everything toe can do to itself.
+# `editconfig` opens this file in nano, in a Terminal.app window. To use your own terminal,
+# bind exec instead:  "exec open -na Ghostty --args -e nano ~/.config/toe/toe.toml"
+"super-comma"   = "editconfig"
+# Saving this file already reloads it; this is the manual way.
+"super-shift-r" = "reload"
+# Puts every window on a hidden workspace back where it came from on the way out.
+"super-shift-q" = "quit"
 
 # ── Launch ────────────────────────────────────────────────────────────────────
 # AppleScript's `new window` reuses the running instance, so the window opens on the current


### PR DESCRIPTION
Omarchy's waybar has nothing behind its workspace strip: clicking a
workspace activates it, and that is all. toe's status item grew a menu
with the workspace/application breakdown and its own actions on it, which
is a surface Omarchy does not have — so it goes.

Everything the menu offered is a key binding now, since the item can no
longer offer it:

  SUPER+,        editconfig — the config in nano, in a Terminal.app
                 window, which is the one terminal always installed.
                 Bind exec with your own if you prefer; the default
                 config carries the line for it.
  SUPER+SHIFT+R  reload (saving the file already reloads it)
  SUPER+SHIFT+Q  quit, unstashing hidden workspaces on the way out

Config problems used to be listed in the menu; they are named in the
item's tooltip instead, and a click while Accessibility is ungranted
opens the settings pane directly rather than a menu with one item on it.

Falls out of that: the application summaries the menu was built from —
AppGrouping, orderedWindows, ManagedWindow.appName — and their tests.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012M9PgKZrR6VC35qTb2VEhD