### PR TITLE
Keep macOS's own window management out of the layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,46 @@ frames on return — the same approach AeroSpace takes. The trade-off is that st
 remain visible to Cmd-Tab and Mission Control, and Cmd-Tabbing to one can pull it back onto the
 current workspace.
 
-**Hotkeys** use Carbon's `RegisterEventHotKey`, deliberately not a `CGEventTap`. A tap would
-receive every keystroke you type; Carbon hotkeys only ever deliver the exact combinations toe
-registers.
+**Dock swipes.** A four-finger swipe up opens Mission Control, which puts that off-screen stash on
+display; a sideways swipe changes the macOS Space out from under toe, leaving its model of the
+screen describing windows that are no longer on it. So toe swallows the Dock's swipe gestures —
+up, down, left and right — with a session-level `CGEventTap` inserted ahead of the Dock. It keys
+off the gesture's event type rather than a finger count, so it covers the three-finger setting
+too. `CGEvent.tapCreate` is public API and this needs no entitlement and no private symbol, but
+the mask — two gesture event types — and the fields the callback reads are undocumented, so
+anything that does not positively identify itself as a dock swipe is passed straight through. The
+worst a wrong guess there can do is drop a gesture: no keystroke, click or scroll can reach a tap
+masked this way. `gestures.swallow_dock_swipes = false` turns it off.
+
+The cost is that swiping between Spaces is gone, including swiping out of a natively-fullscreen
+app's Space — and natively-fullscreen windows are one of the things toe leaves alone. `Ctrl`+`←`/`→`
+still switches Spaces and `⌃⌘F` still leaves fullscreen; the config key is there for anyone who
+would rather have the swipe.
+
+The swipe is not the only way in: `Ctrl`+`↑` and `Ctrl`+`↓` open the same two views. Those are
+*symbolic hotkeys*, resolved inside the window server well before any event tap sees a key, so the
+tap cannot help — toe switches them off with `CGSSetSymbolicHotKeyEnabled` while it runs. Unlike
+the tap, that state outlives the process: the window server keeps it, so a toe that died without
+restoring would leave `Ctrl`+`↑` dead with nothing to say why. Every change is journalled to
+`~/.local/state/toe/symbolic-hotkeys` *before* it is made, and a journal found at startup is
+replayed in reverse, which is what repairs a crash, a `kill -9` or a logout. Show Desktop is left
+alone, because its gesture is a thumb-and-three-finger spread rather than a dock swipe — the key
+and the gesture stay consistent. `misc.disable_expose_shortcuts = false` leaves all of them alone.
+
+**Hiding.** `⌘H` and `⌘⌥H` take an application's windows out of the layout without closing them:
+the tree reflows around the gap, and `SUPER`+arrows cannot reach them again because they are no
+longer on any workspace. Omarchy has no equivalent, so toe puts a hidden application straight
+back. Deliberately done by watching `NSWorkspace.didHideApplicationNotification` rather than by
+swallowing the keystroke — hiding is observable, so it can be undone without a keyboard tap, and
+the notification also catches the routes a shortcut tap would miss: the Dock's Hide menu item, an
+app hiding itself, and `⌘⌥H` hiding everything else at once. The window is gone for a frame, since
+the notification arrives after the fact rather than instead of it.
+`misc.prevent_hiding = false` turns it off.
+
+**Hotkeys** use Carbon's `RegisterEventHotKey`, deliberately not a keyboard `CGEventTap`. A tap
+masked to key events would receive every keystroke you type; Carbon hotkeys only ever deliver the
+exact combinations toe registers. The one tap toe does run — see **Dock swipes** — has a mask
+covering two gesture event types and nothing else, so it cannot see a keystroke even in principle.
 
 **Electron and Chromium apps** (Chrome, VS Code, Slack) and the JetBrains IDEs ignore or
 animate programmatic resizes while `AXEnhancedUserInterface` is set. toe clears it around each
@@ -170,7 +207,8 @@ and again whenever it is focused, but the Accessibility API offers no persistent
 activate a tiled window afterwards and it can cover the floating one. Floating windows stay
 reachable with `SUPER`+arrows.
 
-**Windows toe leaves alone**: dialogs, sheets, palettes, minimized and natively-fullscreen
+**Windows toe leaves alone**: dialogs, sheets, palettes, minimized and natively-fullscreen (see
+**Dock swipes** for the one thing that changes about living in one)
 windows, and anything that refuses a position or size. Add your own exceptions with `[[float]]`
 rules.
 

--- a/Sources/ToeCore/Config/Config.swift
+++ b/Sources/ToeCore/Config/Config.swift
@@ -33,6 +33,26 @@ public struct FloatingSize: Equatable {
     public init() {}
 }
 
+/// Trackpad gestures toe takes off macOS's hands.
+public struct GestureConfig: Equatable {
+    /// Swallow the Dock's swipe gestures — Mission Control, App Exposé and the sideways Spaces
+    /// switch — before the window server acts on them. Keyed off the gesture's event type rather
+    /// than a finger count, so it covers the three-finger setting as well as the four-finger one.
+    public var swallowDockSwipes: Bool = true
+    public init() {}
+}
+
+/// macOS behaviours that pull windows out from under the layout. Hyprland's catch-all table.
+public struct MiscConfig: Equatable {
+    /// `Ctrl`+`↑` and `Ctrl`+`↓` open the same Mission Control and App Exposé the vertical swipe
+    /// does, and a symbolic hotkey is resolved inside the window server, so the tap cannot reach
+    /// them.
+    public var disableExposeShortcuts: Bool = true
+    /// `⌘H` takes an application's windows out of the layout with no way to reach them again.
+    public var preventHiding: Bool = true
+    public init() {}
+}
+
 /// A window that should float instead of joining the dwindle tree.
 public struct FloatRule: Equatable {
     /// Bundle identifier. `*` matches any run of characters.
@@ -76,6 +96,8 @@ public struct Config: Equatable {
     public var border: BorderConfig = BorderConfig()
     public var bar: BarConfig = BarConfig()
     public var floating: FloatingSize = FloatingSize()
+    public var gestures: GestureConfig = GestureConfig()
+    public var misc: MiscConfig = MiscConfig()
     public var bindings: [Binding] = []
     public var floatRules: [FloatRule] = Config.defaultFloatRules
     /// Non-fatal problems (a binding that would not parse, an unknown key). Surfaced in the
@@ -161,6 +183,33 @@ public struct Config: Equatable {
             if let v = f["max_aspect_ratio"]?.doubleValue {
                 if v > 0 { config.floating.maxAspectRatio = v } else {
                     config.warnings.append("floating.max_aspect_ratio: must be over 0, using \(config.floating.maxAspectRatio)")
+                }
+            }
+        }
+
+        if let g = root["gestures"]?.tableValue, let raw = g["swallow_dock_swipes"] {
+            // Warned about rather than silently ignored: a mistyped boolean here quietly hands
+            // Mission Control back the gesture that puts the off-screen stash on display.
+            if let v = raw.boolValue {
+                config.gestures.swallowDockSwipes = v
+            } else {
+                config.warnings.append("gestures.swallow_dock_swipes: must be true or false, using \(config.gestures.swallowDockSwipes)")
+            }
+        }
+
+        if let m = root["misc"]?.tableValue {
+            if let raw = m["disable_expose_shortcuts"] {
+                if let v = raw.boolValue {
+                    config.misc.disableExposeShortcuts = v
+                } else {
+                    config.warnings.append("misc.disable_expose_shortcuts: must be true or false, using \(config.misc.disableExposeShortcuts)")
+                }
+            }
+            if let raw = m["prevent_hiding"] {
+                if let v = raw.boolValue {
+                    config.misc.preventHiding = v
+                } else {
+                    config.warnings.append("misc.prevent_hiding: must be true or false, using \(config.misc.preventHiding)")
                 }
             }
         }

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -54,6 +54,26 @@ height = 0.80
 # 32:9 ultrawide a plain 70% would be a letterbox; on a laptop this never comes into play.
 max_aspect_ratio = 1.6
 
+[gestures]
+# Swallow the Dock's swipe gestures before macOS acts on them. A swipe up would open Mission
+# Control, which puts the windows on hidden workspaces — parked off-screen, since macOS has no
+# public API for virtual desktops — back on display; a sideways swipe would change the macOS
+# Space out from under toe. Ctrl+←/→ still switches Spaces, which is also the way out of a
+# fullscreen app now that swiping is not.
+swallow_dock_swipes = true
+
+[misc]
+# Ctrl+↑ and Ctrl+↓ open the same Mission Control and App Exposé the vertical swipe does. These
+# are symbolic hotkeys, resolved inside the window server, so nothing an event tap can do reaches
+# them — toe switches them off while it runs and gives them back when it quits. Ctrl+←/→ is left
+# alone: it is the way out of a fullscreen app now that swiping is not.
+disable_expose_shortcuts = true
+
+# ⌘H and ⌘⌥H take an application's windows out of the layout without closing them — the tree
+# reflows around the gap and SUPER+arrows cannot reach them again, because they are no longer on
+# any workspace. toe puts a hidden application straight back.
+prevent_hiding = true
+
 [bar]
 # waybar's persistent-workspaces: Omarchy keeps slots 1-5 on the bar even when they are
 # empty, dimmed. 0 shows only the workspaces in use; 10 always shows all ten.

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -614,6 +614,9 @@ h.test("the shipped default config parses cleanly") { t in
     t.equal(c.floating.width, 0.70, "floating width fraction")
     t.equal(c.floating.height, 0.80, "floating height fraction")
     t.equal(c.floating.maxAspectRatio, 1.6, "floating max aspect ratio")
+    t.equal(c.gestures.swallowDockSwipes, true, "dock swipes are swallowed by default")
+    t.equal(c.misc.disableExposeShortcuts, true, "Ctrl+Up and Ctrl+Down are disabled by default")
+    t.equal(c.misc.preventHiding, true, "hiding is undone by default")
 
     func binding(_ spec: String) -> Binding? { c.bindings.first { $0.source == spec } }
 
@@ -662,6 +665,36 @@ h.test("persistent_workspaces is configurable and range-checked") { t in
     let bad = try Config.parse("[bar]\npersistent_workspaces = 99\n")
     t.equal(bad.bar.persistentWorkspaces, 5, "an out-of-range value keeps the default")
     t.equal(bad.warnings.contains { $0.contains("bar.persistent_workspaces") }, true,
+            "and says so in the menu bar")
+}
+
+h.test("dock swipe swallowing is configurable") { t in
+    let off = try Config.parse("[gestures]\nswallow_dock_swipes = false\n")
+    t.equal(off.gestures.swallowDockSwipes, false, "false hands the gestures back to macOS")
+    t.equal(off.warnings, [], "no warnings")
+
+    let absent = try Config.parse("[general]\ngaps_in = 5\n")
+    t.equal(absent.gestures.swallowDockSwipes, true, "omitting the table keeps the default")
+
+    let bad = try Config.parse("[gestures]\nswallow_dock_swipes = \"yes\"\n")
+    t.equal(bad.gestures.swallowDockSwipes, true, "a non-boolean keeps the default")
+    t.equal(bad.warnings.contains { $0.contains("gestures.swallow_dock_swipes") }, true,
+            "and says so in the menu bar")
+}
+
+h.test("the macOS behaviours toe takes over are configurable") { t in
+    let off = try Config.parse("[misc]\ndisable_expose_shortcuts = false\nprevent_hiding = false\n")
+    t.equal(off.misc.disableExposeShortcuts, false, "the Exposé shortcuts can be handed back")
+    t.equal(off.misc.preventHiding, false, "hiding can be allowed")
+    t.equal(off.warnings, [], "no warnings")
+
+    let absent = try Config.parse("[general]\ngaps_in = 5\n")
+    t.equal(absent.misc.disableExposeShortcuts, true, "omitting the table keeps the defaults")
+    t.equal(absent.misc.preventHiding, true, "omitting the table keeps the defaults")
+
+    let bad = try Config.parse("[misc]\nprevent_hiding = 1\n")
+    t.equal(bad.misc.preventHiding, true, "a non-boolean keeps the default")
+    t.equal(bad.warnings.contains { $0.contains("misc.prevent_hiding") }, true,
             "and says so in the menu bar")
 }
 

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -13,11 +13,19 @@ final class Coordinator: WindowTrackerDelegate {
     private let hotkeys = HotkeyManager()
     private let border = BorderOverlay()
     private let drag = DragMonitor()
+    private let dockSwipes = DockSwipeTap()
+    private let hideBlocker = HideBlocker()
     private let status = StatusItem()
     private var watcher: ConfigWatcher?
 
     private var config = Config.makeDefault()
     private var warnings: [String] = []
+    /// Problems that are not the config's fault and so must survive a reload — a tap that would
+    /// not create, for instance. `warnings` is replaced wholesale on every load.
+    private var runtimeWarnings: [String] = []
+    /// False until Accessibility has landed and `beginManaging()` has run. A config reload before
+    /// that must not try to create the event tap: it would be refused and never retried.
+    private var isManaging = false
     /// The frame each window is supposed to occupy, so a re-render does not churn every window.
     private var desired: [WindowID: Box] = [:]
     /// How many times we have re-asserted a frame an app pushed back on. Bounded, so a window
@@ -41,6 +49,10 @@ final class Coordinator: WindowTrackerDelegate {
         status.onOpenAccessibility = { Self.openAccessibilitySettings() }
 
         installSignalHandlers()
+        // Symbolic hotkey state outlives the process, so a previous toe that was killed rather
+        // than quit may have left Mission Control's shortcut switched off. Give it back before
+        // anything else, so the config below decides from a known-good baseline.
+        SymbolicHotkeys.repairAfterUncleanExit()
         writeDefaultConfigIfMissing()
         loadConfig()
 
@@ -56,6 +68,7 @@ final class Coordinator: WindowTrackerDelegate {
             self.apply(refocus: false)
         }
         drag.onEnd = { [weak self] id in self?.endDrag(id) }
+        hideBlocker.onRestored = { [weak self] pid in self?.relayoutAfterUnhide(pid) }
 
         guard waitForAccessibility() else {
             Log.error("no Accessibility permission — hotkeys are live but windows cannot be moved. "
@@ -75,7 +88,7 @@ final class Coordinator: WindowTrackerDelegate {
             signal(number, SIG_IGN)
             let source = DispatchSource.makeSignalSource(signal: number, queue: .main)
             source.setEventHandler { [weak self] in
-                self?.unstashEverything()
+                self?.shutDown()
                 exit(0)
             }
             source.resume()
@@ -102,10 +115,17 @@ final class Coordinator: WindowTrackerDelegate {
     private func beginManaging() {
         // Before the first AX call: caps how long any single one can block the main thread.
         AX.setGlobalMessagingTimeout()
+        isManaging = true
         tracker.delegate = self
         tracker.floatRules = config.floatRules
         refreshMonitors()
         tracker.start()
+        // Deliberately here and not in `start()`: a filtering event tap needs the Accessibility
+        // grant, and it is refused outright — never retried — without one. This is the first
+        // point at which the grant is known to exist, whether it was already there or has just
+        // been given, so a first run picks the tap up without a relaunch.
+        applyDockSwipeSetting()
+        applyMiscSettings()
         refreshStatus()
         apply(refocus: false)
         Log.info("managing \(tracker.windows.count) window(s) across \(workspaces.monitors.count) monitor(s)")
@@ -151,6 +171,8 @@ final class Coordinator: WindowTrackerDelegate {
         tracker.floatRules = newConfig.floatRules
         border.apply(newConfig.border)
         status.persistentWorkspaces = newConfig.bar.persistentWorkspaces
+        applyDockSwipeSetting()
+        applyMiscSettings()
 
         refreshStatus()
         Log.info("config loaded: \(newConfig.bindings.count) binding(s), \(warnings.count) warning(s)")
@@ -160,9 +182,68 @@ final class Coordinator: WindowTrackerDelegate {
         apply(refocus: false)
     }
 
+    /// Starts and stops the dock swipe tap as the config flips, on every reload as well as at
+    /// startup. A no-op until Accessibility has landed; `beginManaging()` calls it again then.
+    private func applyDockSwipeSetting() {
+        guard isManaging else { return }
+        runtimeWarnings.removeAll()
+
+        guard config.gestures.swallowDockSwipes else {
+            dockSwipes.stop()
+            return
+        }
+        if !dockSwipes.isRunning, !dockSwipes.start() {
+            runtimeWarnings = ["dock swipe tap could not be created — swipes are not swallowed"]
+        }
+    }
+
+    /// The two macOS behaviours toe takes over, applied at startup and on every reload. Neither
+    /// needs Accessibility, but both are gated on `isManaging` so they arrive together with the
+    /// tap rather than flickering on before toe can actually manage anything.
+    private func applyMiscSettings() {
+        guard isManaging else { return }
+
+        if config.misc.disableExposeShortcuts {
+            SymbolicHotkeys.disable(SymbolicHotkeys.expose)
+        } else {
+            SymbolicHotkeys.restoreAll()
+        }
+
+        if config.misc.preventHiding {
+            hideBlocker.start()
+        } else {
+            hideBlocker.stop()
+        }
+    }
+
+    /// Puts the layout and the focus back after an application toe unhid has returned.
+    ///
+    /// A hidden window keeps the frame it had, so `desired` still matches it and `apply` would
+    /// write nothing — which is what leaves the windows looking wrong once they are back. Dropping
+    /// this application's bookkeeping forces its tiles to be written again, and the correction
+    /// budget goes with it, because coming back from a hide is not an app fighting for its own
+    /// geometry.
+    private func relayoutAfterUnhide(_ pid: pid_t) {
+        for (id, window) in tracker.windows where window.pid == pid {
+            desired.removeValue(forKey: id)
+            corrections.removeValue(forKey: id)
+        }
+        apply(refocus: false)
+
+        // `activate()` gave the application back the foreground; this gives the focus back to the
+        // window that had it. Deliberately not `focusApplied`: hiding an application makes macOS
+        // activate whichever one is behind it, and that activation reaches toe as an ordinary
+        // focus change — often before the hide notification does — so by now `focusApplied` names
+        // a window belonging to some other app. `focusHistory` is most-recent-first and survives
+        // that, so asking it for this application's own last-focused window is race-free.
+        if let id = workspaces.focusHistory.first(where: { tracker.window($0)?.pid == pid }) {
+            focus(id)
+        }
+    }
+
     private func refreshStatus() {
         status.update(workspaces: workspaceStates(),
-                      warnings: warnings,
+                      warnings: warnings + runtimeWarnings,
                       accessibilityGranted: AXIsProcessTrusted())
     }
 
@@ -399,6 +480,21 @@ final class Coordinator: WindowTrackerDelegate {
         apply(refocus: false)
     }
 
+    /// Everything that must happen before toe goes away, whichever way it is going: the Quit menu
+    /// item, or SIGTERM, which is how `make run` replaces a running copy. There is no
+    /// `applicationWillTerminate` — `NSApp.terminate` and `exit(0)` are both reached from here, so
+    /// this is the one teardown path.
+    private func shutDown() {
+        unstashEverything()
+        // A filtering tap left registered against a callback that is about to go away spins
+        // WindowServer, so it is taken down deliberately rather than left to process death.
+        dockSwipes.stop()
+        hideBlocker.stop()
+        // The only one of the three that would otherwise outlive toe: the window server keeps a
+        // symbolic hotkey switched off until something switches it back on.
+        SymbolicHotkeys.restoreAll()
+    }
+
     private func unstashEverything() {
         for window in tracker.windows.values where window.isStashed {
             window.isStashed = false
@@ -485,7 +581,7 @@ final class Coordinator: WindowTrackerDelegate {
             openConfigInTerminal()
 
         case .quit:
-            unstashEverything()
+            shutDown()
             NSApp.terminate(nil)
         }
     }

--- a/Sources/toe/HideBlocker.swift
+++ b/Sources/toe/HideBlocker.swift
@@ -1,0 +1,77 @@
+import AppKit
+
+/// Puts back any application that gets hidden.
+///
+/// `⌘H` and `⌘⌥H` take an application's windows out of the layout without closing them: the tree
+/// reflows around the gap, and there is nothing on screen to say where they went or how to get
+/// them back — `SUPER`+arrows cannot reach a hidden window, because it is not on any workspace any
+/// more. Omarchy has no equivalent, so the honest behaviour is for hiding not to happen.
+///
+/// Deliberately a notification rather than a keyboard event tap: hiding is *observable*, so toe
+/// can undo it without watching a single keystroke. That also catches the routes a shortcut tap
+/// would miss — the Dock's Hide menu item, an app hiding itself, and `⌘⌥H` hiding everything else
+/// at once, which arrives as one notification per application.
+///
+/// Undoing a hide is not just `unhide()`. macOS drops the frontmost application on the way in and
+/// does not give it back on the way out, so the app returns with nothing focused; and because its
+/// windows kept the frames they had, toe's own bookkeeping still believes they are placed
+/// correctly and writes nothing. Both have to be put right once the app is actually back, which is
+/// what `onRestored` is for.
+final class HideBlocker {
+
+    /// Fires when an application toe unhid is back on screen, having already been re-activated.
+    var onRestored: ((pid_t) -> Void)?
+
+    private var observers: [any NSObjectProtocol] = []
+    /// The applications toe is in the middle of putting back. An unhide toe did not ask for — the
+    /// user picking the app out of the Dock — must be left entirely alone.
+    private var pending: Set<pid_t> = []
+    private var unhidden = 0
+
+    var isRunning: Bool { !observers.isEmpty }
+
+    deinit { stop() }
+
+    func start() {
+        guard observers.isEmpty else { return }
+
+        observe(NSWorkspace.didHideApplicationNotification) { [weak self] app in
+            guard let self else { return }
+            self.pending.insert(app.processIdentifier)
+            // The notification arrives after the hide, so this is an undo rather than a veto: the
+            // windows are gone for a frame before they come back.
+            app.unhide()
+            if self.unhidden == 0 { Log.info("hide blocker: unhiding applications as they are hidden") }
+            self.unhidden &+= 1
+        }
+
+        observe(NSWorkspace.didUnhideApplicationNotification) { [weak self] app in
+            guard let self, self.pending.remove(app.processIdentifier) != nil else { return }
+            // Hiding took the frontmost application away; unhiding does not hand it back.
+            app.activate()
+            self.onRestored?(app.processIdentifier)
+        }
+
+        Log.info("hide blocker: active")
+    }
+
+    func stop() {
+        guard !observers.isEmpty else { return }
+        for observer in observers { NSWorkspace.shared.notificationCenter.removeObserver(observer) }
+        observers.removeAll()
+        pending.removeAll()
+        unhidden = 0
+        Log.info("hide blocker: stopped")
+    }
+
+    private func observe(_ name: Notification.Name, _ handler: @escaping (NSRunningApplication) -> Void) {
+        let observer = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: name, object: nil, queue: .main
+        ) { note in
+            guard let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
+            else { return }
+            handler(app)
+        }
+        observers.append(observer)
+    }
+}

--- a/Sources/toe/Input/DockSwipeTap.swift
+++ b/Sources/toe/Input/DockSwipeTap.swift
@@ -1,0 +1,155 @@
+import CoreGraphics
+import Foundation
+
+/// Swallows the Dock's swipe gestures before the window server acts on them.
+///
+/// toe keeps its own ten workspaces, and a hidden one's windows are parked off-screen rather
+/// than on a macOS Space — see `Stash`. A four-finger swipe up opens Mission Control, which puts
+/// that stash on display; a sideways swipe changes the Space out from under toe, leaving its
+/// model describing windows that are no longer on screen. Both are better prevented than
+/// recovered from.
+///
+/// The two event types in the mask and the fields the callback reads are private and
+/// version-sensitive. `CGEvent.tapCreate` itself is public API, so this needs no entitlement, no
+/// `dlsym` and no private symbol — but everything here is written to fail open: an event that
+/// does not positively identify itself as a dock swipe is passed through untouched. The blast
+/// radius of a wrong guess is bounded by the mask, which admits two gesture event types and
+/// nothing else — no keystroke, click or scroll can reach this tap even in principle.
+final class DockSwipeTap {
+
+    private var tap: CFMachPort?
+    private var source: CFRunLoopSource?
+    private var swallowed = 0
+    /// Read once here rather than per event: the hot path does no dictionary lookups.
+    private let verbose = ProcessInfo.processInfo.environment["TOE_VERBOSE"] != nil
+
+    var isRunning: Bool { tap != nil }
+
+    deinit { stop() }
+
+    // MARK: - Private constants
+
+    /// `kCGSEventGesture` (29) and `kCGSEventDockControl` (30). `CGEventMaskBit` only covers the
+    /// public types, so the mask is built by hand.
+    private static let gestureType: UInt32 = 29
+    private static let dockControlType: UInt32 = 30
+    private static let mask: CGEventMask = (1 << 29) | (1 << 30)
+
+    /// `kIOHIDEventTypeDockSwipe`. Every phase of a swipe — began, changed, ended, cancelled —
+    /// answers this, which is what lets the whole gesture be swallowed as a unit without any
+    /// per-gesture state: the Dock is never left half-way into an animation.
+    private static let dockSwipeHIDType: Int64 = 23
+
+    /// `CGEventField` is a `CF_ENUM(uint32_t)`, so its `init?(rawValue:)` answers nil for every
+    /// index Apple has not declared — which is all of these. The enum's layout is its raw value,
+    /// so a bit cast is the way in. Resolved once, at type initialisation, never per event.
+    private static let hidTypeField = field(110)     // kCGEventGestureHIDType
+    private static let swipeMaskField = field(115)   // up 1, down 2, left 4, right 8 — diagnostics
+    private static let motionField = field(123)      // 0 none, 1 horizontal, 2 vertical — diagnostics
+    private static let phaseField = field(132)       // 1 began, 2 changed, 4 ended, 8 cancelled
+    private static let subtypeField = field(55)      // kCGSEventTypeField — diagnostics
+
+    private static func field(_ raw: UInt32) -> CGEventField {
+        unsafeBitCast(raw, to: CGEventField.self)
+    }
+
+    // MARK: - Lifecycle
+
+    /// Returns false when the tap could not be created, which in practice means the Accessibility
+    /// grant is missing: a filtering tap requires it, and `tapCreate` neither prompts nor retries.
+    /// Call this only once `AXIsProcessTrusted()` is true.
+    @discardableResult
+    func start() -> Bool {
+        guard tap == nil else { return true }
+
+        guard let port = CGEvent.tapCreate(tap: .cgSessionEventTap,       // no root needed
+                                           place: .headInsertEventTap,    // ahead of the Dock
+                                           options: .defaultTap,          // filtering, not listen-only
+                                           eventsOfInterest: Self.mask,
+                                           callback: dockSwipeTapCallback,
+                                           userInfo: Unmanaged.passUnretained(self).toOpaque())
+        else {
+            Log.error("dock swipe tap: could not be created — swipes are not being swallowed")
+            return false
+        }
+
+        // `.commonModes`, not `.defaultMode`: the run loop switches to event-tracking mode while a
+        // menu is open or a window is being dragged, and a filtering tap whose callback is not
+        // being serviced stalls the input stream until the system times it out.
+        let loopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, port, 0)
+        CFRunLoopAddSource(CFRunLoopGetMain(), loopSource, .commonModes)
+        CGEvent.tapEnable(tap: port, enable: true)
+
+        tap = port
+        source = loopSource
+        Log.info("dock swipe tap: active")
+        return true
+    }
+
+    /// Torn down explicitly rather than left to process death: a filtering tap still registered
+    /// against a callback that has gone away is what spins WindowServer.
+    func stop() {
+        guard let port = tap else { return }
+        CGEvent.tapEnable(tap: port, enable: false)
+        if let source { CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes) }
+        CFMachPortInvalidate(port)
+        tap = nil
+        source = nil
+        swallowed = 0
+        Log.info("dock swipe tap: stopped")
+    }
+
+    // MARK: - The hot path
+
+    fileprivate func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        // The system switches a tap off if its callback is slow, or if the user takes the input
+        // stream over. Re-arm and pass the notification on, or the tap is dead for the session.
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            if let port = tap { CGEvent.tapEnable(tap: port, enable: true) }
+            Log.error("dock swipe tap: re-armed after "
+                      + (type == .tapDisabledByTimeout ? "timeout" : "user input"))
+            return Unmanaged.passUnretained(event)
+        }
+
+        if verbose { dump(type: type, event: event) }
+
+        // Positive identification, and nothing else. Compared on the raw value rather than
+        // switched: 29 and 30 are not declared cases of `CGEventType`, and matching an undeclared
+        // case is not something to rely on. Anything unrecognised falls through untouched, so a
+        // renumbered field degrades to "swipes stop being swallowed", never to "the wrong thing is".
+        let raw = type.rawValue
+        guard raw == Self.gestureType || raw == Self.dockControlType,
+              event.getIntegerValueField(Self.hidTypeField) == Self.dockSwipeHIDType
+        else { return Unmanaged.passUnretained(event) }
+
+        if swallowed == 0 { Log.info("dock swipe tap: swallowing dock swipes") }
+        swallowed &+= 1
+        return nil                      // the event never reaches the Dock
+    }
+
+    /// `TOE_VERBOSE=1` only. The bring-up tool for the day a macOS release renumbers a field:
+    /// swipe, watch the numbers, compare them with the constants above.
+    private func dump(type: CGEventType, event: CGEvent) {
+        Log.info("gesture event: type=\(type.rawValue)"
+                 + " subtype=\(event.getIntegerValueField(Self.subtypeField))"
+                 + " hid=\(event.getIntegerValueField(Self.hidTypeField))"
+                 + " swipe=\(event.getIntegerValueField(Self.swipeMaskField))"
+                 + " motion=\(event.getIntegerValueField(Self.motionField))"
+                 + " phase=\(event.getIntegerValueField(Self.phaseField))")
+    }
+}
+
+/// A `CGEventTapCallBack` is a C function pointer and captures nothing, so `self` travels through
+/// the tap's refcon. Unretained rather than retained: there is no `CFMachPort` context callback to
+/// balance a retain, so a missed `stop()` would leak for the life of the process. Safety comes
+/// from ownership instead — `Coordinator` holds the only `DockSwipeTap` for the whole process, and
+/// `deinit` invalidates the port before the object can be freed.
+private func dockSwipeTapCallback(proxy: CGEventTapProxy,
+                                  type: CGEventType,
+                                  event: CGEvent,
+                                  refcon: UnsafeMutableRawPointer?) -> Unmanaged<CGEvent>? {
+    guard let refcon else { return Unmanaged.passUnretained(event) }
+    return Unmanaged<DockSwipeTap>.fromOpaque(refcon)
+        .takeUnretainedValue()
+        .handle(type: type, event: event)
+}

--- a/Sources/toe/Input/DragMonitor.swift
+++ b/Sources/toe/Input/DragMonitor.swift
@@ -38,8 +38,9 @@ final class DragMonitor {
         isDragging = true
         window = id
         // toe never sees the drag itself: the events all belong to the window's own application.
-        // Global monitors are read-only and consume nothing, so this stays clear of the event
-        // tap toe deliberately does without.
+        // Global monitors are read-only and consume nothing, which keeps the pointer readable
+        // without widening the one tap toe does run — `DockSwipeTap`, whose mask admits gesture
+        // events only and could not carry a mouse event if it wanted to.
         add([.leftMouseUp, .rightMouseUp, .otherMouseUp]) { [weak self] _ in self?.end() }
         add([.leftMouseDragged, .rightMouseDragged, .otherMouseDragged]) { [weak self] _ in
             guard let self, let window = self.window else { return }

--- a/Sources/toe/Input/HotkeyManager.swift
+++ b/Sources/toe/Input/HotkeyManager.swift
@@ -4,10 +4,14 @@ import ToeCore
 
 /// Global hotkeys via Carbon's `RegisterEventHotKey`.
 ///
-/// Deliberately not a `CGEventTap`: a tap would receive every keystroke you type, which is
-/// far more access than a window manager needs. Carbon hotkeys only ever deliver the exact
-/// combinations toe registers, and they need no permission beyond the Accessibility grant
-/// that moving windows already requires.
+/// Deliberately not a keyboard `CGEventTap`: a tap masked to key events would receive every
+/// keystroke you type, which is far more access than a window manager needs. Carbon hotkeys only
+/// ever deliver the exact combinations toe registers, and they need no permission beyond the
+/// Accessibility grant that moving windows already requires.
+///
+/// toe does run one event tap — `DockSwipeTap` — but its mask covers two gesture event types and
+/// nothing else, so no keystroke can reach it even in principle. The objection above is to the
+/// mask a hotkey tap would need, not to taps as a mechanism.
 final class HotkeyManager {
 
     var onTrigger: ((Binding) -> Void)?

--- a/Sources/toe/Input/SymbolicHotkeys.swift
+++ b/Sources/toe/Input/SymbolicHotkeys.swift
@@ -1,0 +1,106 @@
+import CoreGraphics
+import Foundation
+
+/// `CGSSetSymbolicHotKeyEnabled` is private, but it is how System Settings' own Mission Control
+/// pane turns these shortcuts on and off, and it is re-exported from CoreGraphics on every macOS
+/// toe supports. Resolved with dlsym so a missing symbol degrades instead of failing to launch,
+/// the same way `_AXUIElementGetWindow` is.
+private let setSymbolicHotKeyEnabled: (@convention(c) (Int32, Bool) -> Int32)? = {
+    guard let sym = dlsym(UnsafeMutableRawPointer(bitPattern: -2), "CGSSetSymbolicHotKeyEnabled") else {
+        return nil
+    }
+    return unsafeBitCast(sym, to: (@convention(c) (Int32, Bool) -> Int32).self)
+}()
+
+private let isSymbolicHotKeyEnabled: (@convention(c) (Int32) -> Bool)? = {
+    guard let sym = dlsym(UnsafeMutableRawPointer(bitPattern: -2), "CGSIsSymbolicHotKeyEnabled") else {
+        return nil
+    }
+    return unsafeBitCast(sym, to: (@convention(c) (Int32) -> Bool).self)
+}()
+
+/// Mission Control's keyboard shortcut, switched off for as long as toe runs.
+///
+/// The swipe is only one way in: `Ctrl`+`↑` opens the same view, and it puts the same off-screen
+/// stash on display. `DockSwipeTap` cannot help here — a symbolic hotkey is resolved inside the
+/// window server, well before any event tap sees a key.
+///
+/// Unlike the tap, **this state outlives the process**. The window server keeps it, so a toe that
+/// exits without restoring leaves the user's `Ctrl`+`↑` dead with nothing to explain why. Every
+/// change is therefore journalled to disk *before* it is made, and a journal found at startup is
+/// replayed in reverse — which is what repairs a crash, a force-quit or a logout.
+enum SymbolicHotkeys {
+
+    /// Mission Control (`Ctrl`+`↑`) and App Exposé (`Ctrl`+`↓`), each with its slow-motion twin
+    /// (`+Shift`) — the keyboard routes into the two views the vertical dock swipe opens, taken
+    /// and given back together because they are the same two views.
+    ///
+    /// Deliberately not here: the Spaces keys (79/81), because `Ctrl`+`←`/`→` is the documented
+    /// way out of a fullscreen app now that swiping is not; and Show Desktop (36/37), whose
+    /// gesture is a thumb-and-three-finger spread rather than a dock swipe, so leaving the key
+    /// alone matches leaving the gesture alone.
+    static let expose: [Int32] = [32, 34, 33, 35]
+
+    private static let journalURL = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".local/state/toe/symbolic-hotkeys")
+
+    private static var disabled: [Int32] = []
+
+    // MARK: - Applying
+
+    /// Turns the keys off, remembering which were on so only those are given back. Idempotent.
+    static func disable(_ keys: [Int32]) {
+        guard let set = setSymbolicHotKeyEnabled, let isEnabled = isSymbolicHotKeyEnabled else {
+            Log.error("symbolic hotkeys: CGS symbols unavailable — Mission Control's shortcut is not disabled")
+            return
+        }
+        let toDisable = keys.filter { !disabled.contains($0) && isEnabled($0) }
+        guard !toDisable.isEmpty else { return }
+
+        // Journalled before the change, not after: a crash between the two must leave a record
+        // that says too much, never one that says too little.
+        disabled += toDisable
+        writeJournal()
+        for key in toDisable { _ = set(key, false) }
+        Log.info("symbolic hotkeys: disabled \(toDisable.map(String.init).joined(separator: ", "))")
+    }
+
+    /// Gives back exactly what `disable` took, and clears the journal. Safe to call twice.
+    static func restoreAll() {
+        guard !disabled.isEmpty else {
+            clearJournal()
+            return
+        }
+        if let set = setSymbolicHotKeyEnabled {
+            for key in disabled { _ = set(key, true) }
+            Log.info("symbolic hotkeys: restored \(disabled.map(String.init).joined(separator: ", "))")
+        }
+        disabled.removeAll()
+        clearJournal()
+    }
+
+    /// Replays a journal left behind by a toe that did not get to restore — a crash, a `kill -9`,
+    /// a logout. Call once at startup, before `disable`.
+    static func repairAfterUncleanExit() {
+        guard let text = try? String(contentsOf: journalURL, encoding: .utf8) else { return }
+        let keys = text.split(whereSeparator: \.isNewline).compactMap { Int32($0) }
+        if let set = setSymbolicHotKeyEnabled, !keys.isEmpty {
+            for key in keys { _ = set(key, true) }
+            Log.info("symbolic hotkeys: repaired \(keys.map(String.init).joined(separator: ", ")) after an unclean exit")
+        }
+        clearJournal()
+    }
+
+    // MARK: - The journal
+
+    private static func writeJournal() {
+        let text = disabled.map(String.init).joined(separator: "\n")
+        try? FileManager.default.createDirectory(at: journalURL.deletingLastPathComponent(),
+                                                 withIntermediateDirectories: true)
+        try? text.write(to: journalURL, atomically: true, encoding: .utf8)
+    }
+
+    private static func clearJournal() {
+        try? FileManager.default.removeItem(at: journalURL)
+    }
+}

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -47,6 +47,26 @@ height = 0.80
 # 32:9 ultrawide a plain 70% would be a letterbox; on a laptop this never comes into play.
 max_aspect_ratio = 1.6
 
+[gestures]
+# Swallow the Dock's swipe gestures before macOS acts on them. A swipe up would open Mission
+# Control, which puts the windows on hidden workspaces — parked off-screen, since macOS has no
+# public API for virtual desktops — back on display; a sideways swipe would change the macOS
+# Space out from under toe. Ctrl+←/→ still switches Spaces, which is also the way out of a
+# fullscreen app now that swiping is not.
+swallow_dock_swipes = true
+
+[misc]
+# Ctrl+↑ and Ctrl+↓ open the same Mission Control and App Exposé the vertical swipe does. These
+# are symbolic hotkeys, resolved inside the window server, so nothing an event tap can do reaches
+# them — toe switches them off while it runs and gives them back when it quits. Ctrl+←/→ is left
+# alone: it is the way out of a fullscreen app now that swiping is not.
+disable_expose_shortcuts = true
+
+# ⌘H and ⌘⌥H take an application's windows out of the layout without closing them — the tree
+# reflows around the gap and SUPER+arrows cannot reach them again, because they are no longer on
+# any workspace. toe puts a hidden application straight back.
+prevent_hiding = true
+
 [bar]
 # waybar's persistent-workspaces: Omarchy keeps slots 1-5 on the bar even when they are
 # empty, dimmed. 0 shows only the workspaces in use; 10 always shows all ten.


### PR DESCRIPTION
toe parks a hidden workspace's windows off-screen, because macOS has no public API for putting a window on a virtual desktop. Three macOS behaviours cut straight across that. All three are now toe's, on by default, each with a config key.

## Dock swipes — `gestures.swallow_dock_swipes`

A four-finger swipe up opens Mission Control, which puts the off-screen stash on display; a sideways swipe changes the macOS Space out from under toe, leaving its model describing windows that are no longer on screen. `DockSwipeTap` swallows all four directions with a session-level `CGEventTap` inserted ahead of the Dock, keyed off the gesture's **event type** rather than a finger count — so it covers the three-finger setting too.

**This is the first event tap in the codebase**, and `HotkeyManager` and `DragMonitor` both carried comments rejecting taps outright. The real objection was always to the *mask* a hotkey tap would need: this one admits two gesture event types and cannot carry a keystroke, click or scroll even in principle. Both comments and the README Design note now say that, rather than contradicting the code.

`CGEvent.tapCreate` is public API — no entitlement change, no private symbol, so **Accessibility stays the one permission toe asks for**. The event type numbers and field indices *are* private, so the callback fails open: anything that does not positively identify itself as a dock swipe is passed through untouched. A field renumbering on a future macOS degrades to "swipes stop being swallowed", never to "the wrong thing is". `TOE_VERBOSE=1` dumps the fields for exactly that day.

## Exposé shortcuts — `misc.disable_expose_shortcuts`

`Ctrl`+`↑` and `Ctrl`+`↓` open the same two views the vertical swipe does, and a symbolic hotkey is resolved inside the window server well before any tap sees a key. `SymbolicHotkeys` switches them off with `CGSSetSymbolicHotKeyEnabled`.

Unlike the tap, **that state outlives the process** — a toe that died without restoring would leave `Ctrl`+`↑` dead with nothing to say why. So every change is journalled to `~/.local/state/toe/symbolic-hotkeys` *before* it is made, and a journal found at startup is replayed in reverse. Verified against a real `kill -9`.

Deliberately left alone: the Spaces keys (79/81), because `Ctrl`+`←`/`→` is the way out of a fullscreen app now that swiping is not; and Show Desktop (36/37), whose gesture is a thumb-and-three-finger spread rather than a dock swipe.

## Hiding — `misc.prevent_hiding`

`⌘H` takes an application's windows out of the layout without closing them, and `SUPER`+arrows cannot reach them again because they are no longer on any workspace. `HideBlocker` puts the application straight back — by watching for the hide rather than swallowing the keystroke, so it needs no keyboard tap, and it also catches the Dock's Hide menu item and `⌘⌥H`.

Undoing a hide turned out not to be just `unhide()`. Two bugs found in testing:

- **Focus was lost.** macOS drops the frontmost application on the way in and does not give it back, so `activate()` is needed on the way out.
- **Windows came back looking wrong.** A hidden window keeps its frame, so `desired` still matched and `apply` wrote nothing. Coming back now drops that application's `desired`/`corrections` so its tiles are written again.
- **Focus landed on a random window.** Restoring from `focusApplied` was wrong: hiding an application makes macOS activate the one behind it, and that reaches toe as an ordinary focus change — often *before* the hide notification — so by restore time `focusApplied` named a window in the wrong app. Now restored from `focusHistory` filtered to that pid, which is race-free.

## Verification

`make test` — **281 assertions pass** (config surface only; the tap is not reachable from `toe-selftest`, which links `ToeCore` alone).

Verified by hand on macOS 26.6.2:

- tap goes active; late Accessibility grant picked up in 200 ms with no relaunch
- hotkeys 32/34/33/35 disabled, 36/79/81 untouched
- clean quit (SIGTERM) restores hotkeys and clears the journal
- `kill -9` leaves them dead → next launch replays the journal and repairs
- `make run` handover: outgoing instance tears down all three before the new one applies them

Still worth a second pair of hands: the four swipe directions and `⌘⌥H` on a multi-display setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qpb9Xzy7ziL44QcJ9Vt3TZ