### PR TITLE
Bind the ways out in code, not only in the shipped config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,12 @@ bundle: test
 ## Build and launch in place, replacing any running copy.
 run: bundle
 	@pkill -x toe 2>/dev/null || true
+	@# SIGTERM is asynchronous, and toe handles it rather than dying on the spot: it unstashes
+	@# every hidden workspace and takes down the event tap first. Opening the new copy while the
+	@# old one is still on its way out makes LaunchServices refuse the launch with -600, so wait
+	@# for the process to actually be gone. Bounded, so a wedged toe cannot hang the build.
+	@for _ in $$(seq 50); do pgrep -x toe >/dev/null || break; sleep 0.1; done
+	@pgrep -x toe >/dev/null && { echo "a previous toe will not exit — kill -9 it and retry"; exit 1; } || true
 	@open $(APP)
 	@echo "toe running — look for it in the menu bar"
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,15 @@ menu bar item's tooltip — a typo can never leave you without a keyboard. See
 Binding specs parse in both spellings, so you can paste from an AeroSpace config or an Omarchy
 one: `"alt-shift-1"`, `"super+shift+1"` and `"SUPER SHIFT, 1"` are the same binding.
 
+`editconfig`, `reload` and `quit` are bound in code as well as in the file — `SUPER`+`,`,
+`SUPER`+`SHIFT`+`R` and `SUPER`+`SHIFT`+`Q` — so the ways out exist whether or not your config
+mentions them. Your config is never rewritten once it is there, so a binding introduced after you
+first ran toe would otherwise never reach you: that is how the menu bar item losing its menu left
+anyone upgrading with no way to quit but `pkill`. A fallback applies only when the command is
+bound nowhere, so rebinding `quit` keeps your key and does not also collect the default, and a
+fallback whose own combination you have already used for something else is dropped rather than
+registered on top of yours.
+
 Commands: `movefocus`, `swapwindow`, `movewindow`, `workspace`, `movetoworkspace`,
 `movetoworkspacesilent`, `killactive`, `togglefloating`, `togglesplit`, `swapsplit`, `exec`,
 `reload`, `editconfig`, `quit`.

--- a/Sources/ToeCore/Config/Config.swift
+++ b/Sources/ToeCore/Config/Config.swift
@@ -106,6 +106,23 @@ public struct Config: Equatable {
 
     public init() {}
 
+    /// The ways out, bound in code so that they exist whether or not the config file mentions
+    /// them. Every other setting already works this way — `gaps`, `border`, `dwindle` and the
+    /// rest all default here and let the file override — and bindings were the one exception,
+    /// living only in the template written on first run. That gap strands anyone who installed
+    /// before a binding was introduced: their config is never rewritten, so the menu bar item
+    /// losing its menu left them with no way to quit toe but `pkill`.
+    ///
+    /// Deliberately only the escape hatches. A fallback that covered every binding would be a
+    /// second config competing with yours; these three exist so that a config which forgot them
+    /// cannot leave you stuck, in the same spirit as keeping the last good config when a new one
+    /// will not parse.
+    public static let fallbackBindings: [(spec: String, command: Command)] = [
+        ("super-comma", .editConfig),
+        ("super-shift-r", .reload),
+        ("super-shift-q", .quit),
+    ]
+
     public static let defaultFloatRules: [FloatRule] = [
         FloatRule(app: "com.apple.systempreferences"),
         FloatRule(app: "com.apple.finder", title: "Copy"),
@@ -230,6 +247,22 @@ public struct Config: Equatable {
                     config.warnings.append("binds.\(spec): \(error)")
                 }
             }
+        }
+
+        // Fill in any escape hatch the config did not bind. Only a command that is bound nowhere
+        // gets one, so rebinding `quit` to something else keeps your key and does not also get
+        // the default — the fallback is for the command being absent, not for the key being free.
+        // A fallback whose own combination you have already used for something else is dropped
+        // rather than registered twice: your binding wins, and the alternative is a duplicate the
+        // system would refuse anyway.
+        for fallback in Config.fallbackBindings
+        where !config.bindings.contains(where: { $0.command == fallback.command }) {
+            guard let (mods, code, keyName) = try? BindingParser.parse(fallback.spec,
+                                                                       superKey: config.superKey),
+                  !config.bindings.contains(where: { $0.modifiers == mods && $0.keyCode == code })
+            else { continue }
+            config.bindings.append(Binding(modifiers: mods, keyCode: code, keyName: keyName,
+                                           command: fallback.command, source: fallback.spec))
         }
 
         if let floats = root["float"]?.arrayValue {

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -698,6 +698,39 @@ h.test("the macOS behaviours toe takes over are configurable") { t in
             "and says so in the menu bar")
 }
 
+h.test("the escape hatches are bound even when the config forgets them") { t in
+    func binding(_ c: Config, _ command: Command) -> Binding? {
+        c.bindings.first { $0.command == command }
+    }
+
+    // The case that prompted this: a config written before these bindings existed. It is never
+    // rewritten, so without a fallback there is no way to quit toe but `pkill`.
+    let old = try Config.parse("[binds]\n\"super-w\" = \"killactive\"\n")
+    t.equal(binding(old, .quit)?.source, "super-shift-q", "quit is bound")
+    t.equal(binding(old, .editConfig)?.source, "super-comma", "editconfig is bound")
+    t.equal(binding(old, .reload)?.source, "super-shift-r", "reload is bound")
+    t.equal(old.warnings, [], "silently, with no warnings")
+
+    // Your binding wins, and does not also collect the default.
+    let rebound = try Config.parse("[binds]\n\"super-shift-x\" = \"quit\"\n")
+    t.equal(binding(rebound, .quit)?.source, "super-shift-x", "a rebound quit keeps your key")
+    t.equal(rebound.bindings.filter { $0.command == .quit }.count, 1, "and is not bound twice")
+
+    // A fallback whose combination you already used for something else is dropped, not
+    // registered on top of yours — the system would refuse the duplicate anyway.
+    let clash = try Config.parse("[binds]\n\"super-comma\" = \"killactive\"\n")
+    t.equal(binding(clash, .editConfig), nil, "a taken fallback key is left alone")
+    t.equal(binding(clash, .killActive)?.source, "super-comma", "and stays yours")
+    t.equal(binding(clash, .quit)?.source, "super-shift-q", "the others still land")
+
+    // The shipped config binds all three itself, so nothing should be duplicated.
+    let shipped = try Config.parse(Config.defaultTOML)
+    for command in [Command.quit, .editConfig, .reload] {
+        t.equal(shipped.bindings.filter { $0.command == command }.count, 1,
+                "the shipped config binds \(command) exactly once")
+    }
+}
+
 h.test("a negative radius survives the TOML parser") { t in
     let c = try Config.parse("[border]\nradius = -1\n")
     t.equal(c.border.radius, -1, "radius = -1")
@@ -791,7 +824,11 @@ h.test("a bad binding warns instead of failing the whole config") { t in
     "super-h"    = "notacommand"
     "super-j"    = "movefocus sideways"
     """)
-    t.equal(c.bindings.count, 1, "the one good binding survives")
+    // Asserted by source rather than by count: the escape hatches are bound in code when the
+    // config does not bind them, so this config yields its own one good binding plus those.
+    t.equal(c.bindings.contains { $0.source == "super-left" }, true, "the one good binding survives")
+    t.equal(c.bindings.contains { ["super-nope", "super-h", "super-j"].contains($0.source) }, false,
+            "and the three bad ones do not")
     t.equal(c.warnings.count, 3, "each bad binding produces a warning")
     t.equal(c.warnings.contains { $0.contains("unknown key 'nope'") }, true, "names the bad key")
     t.equal(c.warnings.contains { $0.contains("unknown command 'notacommand'") }, true, "names the bad command")


### PR DESCRIPTION
## The bug

#42 dropped the status item menu and moved `editconfig` / `reload` / `quit` onto key bindings, adding them to the config written on first run. But `writeDefaultConfigIfMissing()` only writes when the file is **absent** — so nobody who installed earlier ever got them.

The menu went away, the bindings never arrived, and **the only way to quit toe was `pkill`**. v0.5.0 sharpened it: it disables the Exposé shortcuts, which is precisely when someone reaches for a way out.

Reproduced on a real pre-#42 config: 36 bindings loaded, none of them `quit`.

## Why not merge into the config file

The obvious fix — splice missing defaults into the existing `toe.toml` — is the wrong mechanism here:

- **There is no TOML writer.** `TOML.swift` parses only, so this means textual insertion into a hand-ordered, heavily commented document.
- **It cannot tell "new since your version" from "I deleted this deliberately"** without tracking provenance. Free up `SUPER`+`,` for your own use and it comes back on every launch — the kind of fight toe already refuses elsewhere ("a tile is re-asserted against an app, never against you").
- **The config is yours to edit.** `ConfigWatcher` would also see toe's own write.

## The actual asymmetry

`bindings` was the **one** setting with no code-level default:

```swift
public var gaps: Gaps = Gaps(inner: 5, outer: 10)   // defaults in code
public var border: BorderConfig = BorderConfig()    // defaults in code
public var bindings: [Binding] = []                 // ← only ever from the file
```

Gaps, border, dwindle, floating, bar, gestures and misc all default in `Config` and let the file override. Bindings existed nowhere but the template. `super-comma` was never a *default* — just a line in a file that is written once and never touched again.

So the fix removes the asymmetry rather than starting to rewrite configs.

## The rule

`Config.fallbackBindings` supplies the three escape hatches when the config does not:

| Your config | Result |
|---|---|
| No `quit` binding | fallback `super-shift-q` applies |
| `"super-shift-x" = "quit"` | your key wins, no duplicate |
| `"super-comma" = "killactive"` | your binding stands, that fallback is dropped; the others still land |
| Shipped default | binds all three itself — nothing duplicated |

A fallback applies only when the command is bound **nowhere**, so rebinding keeps your key without also collecting the default. Deliberately only the escape hatches — covering every binding would be a second config competing with yours.

## Also: `make run` LaunchServices -600

`make run` fired `open` straight after `pkill` and was rejected while the previous toe was still exiting. This became common with 0.5.0, because SIGTERM now unstashes workspaces, tears down the event tap and restores four symbolic hotkeys before exiting — widening the window. Now waits for the process to actually go, bounded at 5 s so a wedged toe cannot hang the build.

## Verification

**290 assertions pass.** New test covers config-forgot-them, rebound, key-collision, and no-duplication-in-the-shipped-config.

End-to-end on a real pre-#42 config, unmodified on disk:

- old build → `config loaded: 36 binding(s)`
- new build, **same file** → `config loaded: 39 binding(s), 0 warning(s)`
- `grep -c "editconfig\|super-shift-q" ~/.config/toe/toe.toml` → `0`

One existing test asserted `bindings.count == 1` as shorthand for "only the good binding survived". It now asserts by `source` — the good one present, the three bad ones absent — which is what it meant and won't break if more fallbacks are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qpb9Xzy7ziL44QcJ9Vt3TZ