### PR TITLE
Make SUPER+T a cycle through two floating sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ as the defaults.
 | `SUPER` + `SHIFT` + `ENTER` | New browser window |
 | `SUPER` + `W` | Close window |
 | `SUPER` + `J` | Toggle split orientation |
-| `SUPER` + `T` | Toggle floating |
+| `SUPER` + `T` | Cycle floating: 70×80% of the display, 80×90%, back to tiling |
 | `SUPER` + `,` | Edit the config — nano, in a terminal window |
 | `SUPER` + `SHIFT` + `R` / `Q` | Reload the config / quit toe |
 | Drag a tiled window | Swap it with the tile you drag it over |
@@ -224,10 +224,15 @@ visible all the way round the window; only what is really in front of it covers 
 
 **Floating windows.** `togglefloating` lifts a window out of the tree and centres it, at a
 consistent fraction of the display — 70% wide by 80% tall by default — so every floating window
-is the same shape whichever window it came from. No floating window is ever wider than 1.6 times
-its own height, which is what stops 70% of a 32:9 ultrawide from being a letterbox; on a laptop
-that cap never comes into play. All three are `[floating]` keys in the config. Sizing happens
-when you float the window, not on every frame, so dragging it afterwards sticks: toe writes a
+is the same shape whichever window it came from. It is a cycle rather than a toggle: press it
+again and the window is re-centred at the larger size, 80% by 90%, and only the third press puts
+it back in the tree. A window toe floated on its own — a dialog, anything that will not take a
+size — has no place in that cycle, and the first press tiles it. No floating window is ever wider
+than 1.6 times its own height, which is what stops 70% of a 32:9 ultrawide from being a
+letterbox; on a laptop that cap never comes into play. All of it is `[floating]` keys in the
+config, and setting `large_width`/`large_height` to the same values as `width`/`height` gives
+back the plain two-state toggle. Sizing happens when you float the window, not on every frame,
+so dragging it afterwards sticks: toe writes a
 floating frame only when it actually changes and never re-asserts it, so a floating window is
 never fought the way a tile is. If the display it was last on has been unplugged, it is centred
 on the display that remains rather than clamped against an edge. It is raised when you float it

--- a/Sources/ToeCore/Config/Config.swift
+++ b/Sources/ToeCore/Config/Config.swift
@@ -23,14 +23,28 @@ public struct BarConfig: Equatable {
 
 /// How big a window is when it leaves the tiling tree.
 public struct FloatingSize: Equatable {
-    /// Fraction of the monitor's usable width and height.
+    /// Fraction of the monitor's usable width and height, at the first stop of the cycle.
     public var width: Double = 0.70
     public var height: Double = 0.80
+    /// The second stop: pressing `togglefloating` again on a window that already floats grows
+    /// it to this instead of tiling it, and only the press after that puts it back in the tree.
+    public var largeWidth: Double = 0.80
+    public var largeHeight: Double = 0.90
     /// Widest the window may be relative to its own height. On an ultrawide, 70% of the
     /// width is a letterbox; capping the ratio keeps a floating window a shape you would
     /// have picked by hand, on any display.
     public var maxAspectRatio: Double = 1.6
     public init() {}
+
+    /// How many floating sizes `togglefloating` walks through before it tiles the window.
+    public static let stages = 2
+
+    /// The fractions stage 1 and stage 2 use. Anything outside that range is the nearest end,
+    /// so a stage that has drifted — a snapshot from a build with more of them — still lands
+    /// on a real size.
+    public func fractions(stage: Int) -> (width: Double, height: Double) {
+        stage >= 2 ? (largeWidth, largeHeight) : (width, height)
+    }
 }
 
 /// Trackpad gestures toe takes off macOS's hands.
@@ -199,6 +213,16 @@ public struct Config: Equatable {
             if let v = f["height"]?.doubleValue {
                 if v > 0, v <= 1 { config.floating.height = v } else {
                     config.warnings.append("floating.height: must be over 0 and at most 1, using \(config.floating.height)")
+                }
+            }
+            if let v = f["large_width"]?.doubleValue {
+                if v > 0, v <= 1 { config.floating.largeWidth = v } else {
+                    config.warnings.append("floating.large_width: must be over 0 and at most 1, using \(config.floating.largeWidth)")
+                }
+            }
+            if let v = f["large_height"]?.doubleValue {
+                if v > 0, v <= 1 { config.floating.largeHeight = v } else {
+                    config.warnings.append("floating.large_height: must be over 0 and at most 1, using \(config.floating.largeHeight)")
                 }
             }
             if let v = f["max_aspect_ratio"]?.doubleValue {

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -50,6 +50,10 @@ radius       = -1
 # this fraction of the display, so every floating window is the same shape.
 width  = 0.70
 height = 0.80
+# SUPER+T again grows it to this instead of tiling it; the third press puts it back in the
+# tree. Set these to width/height above for a plain two-state toggle.
+large_width  = 0.80
+large_height = 0.90
 # ...except that no floating window is ever wider than this many times its own height. On a
 # 32:9 ultrawide a plain 70% would be a letterbox; on a laptop this never comes into play.
 max_aspect_ratio = 1.6

--- a/Sources/ToeCore/Layout/WorkspaceManager.swift
+++ b/Sources/ToeCore/Layout/WorkspaceManager.swift
@@ -55,6 +55,11 @@ public final class WorkspaceManager {
     /// Frames of floating windows, supplied by the app layer so directional search has an
     /// origin box for them.
     public var floatingFrames: [WindowID: Box] = [:]
+    /// Where each window is on `togglefloating`'s cycle: 1 is the first floating size, 2 the
+    /// larger one, and a window with no entry is either tiled or floating because the app
+    /// layer adopted it that way — the next press tiles that one rather than resizing a
+    /// window toe never sized itself.
+    public private(set) var floatingStage: [WindowID: Int] = [:]
     /// The pointer, in AX coordinates, supplied by the app layer so ToeCore stays free of
     /// AppKit. Hyprland splits the window under the cursor when there is no focused tiled
     /// window to split — see `onWindowCreatedTiling`'s `use_active_for_splits` branch.
@@ -185,26 +190,37 @@ public final class WorkspaceManager {
             ws.layout.remove(id)
             ws.floating.remove(id)
         }
+        floatingStage.removeValue(forKey: id)
         focusHistory.removeAll { $0 == id }
     }
 
-    /// Toggle a window between the dwindle tree and floating.
+    /// Walk a window one step around `togglefloating`'s cycle: tiled, floating at the first
+    /// size, floating at the larger one, tiled again.
+    ///
+    /// A window the app layer floated on its own — a dialog, anything that will not take a
+    /// size — has no stage, and the first press tiles it. Resizing a window that arrived at a
+    /// size of its own choosing would be toe overriding a decision it never made.
     public func toggleFloating(_ id: WindowID) {
         guard let index = workspaceIndex(of: id) else { return }
         let ws = workspace(index)
-        if ws.floating.contains(id) {
+        let next = ws.floating.contains(id) ? (floatingStage[id] ?? FloatingSize.stages) + 1 : 1
+
+        guard next <= FloatingSize.stages else {
             ws.floating.remove(id)
+            floatingStage.removeValue(forKey: id)
             ws.layout.insert(id, anchor: anchor(on: ws, excluding: id), focalPoint: focalPoint(on: ws))
-        } else {
-            ws.layout.remove(id)
-            ws.floating.insert(id)
-            // A window leaving the tree is centred, at the size it remembers. This is set here
-            // rather than derived in `floatingBox` so that it happens once, when you float the
-            // window — deriving it every render would drag the window back to the middle of
-            // the screen the moment you tried to move it.
-            if let m = monitor(id: ws.monitorID) {
-                floatingFrames[id] = centredFloatingBox(on: m)
-            }
+            return
+        }
+
+        ws.layout.remove(id)
+        ws.floating.insert(id)
+        floatingStage[id] = next
+        // A window leaving the tree, or growing to the next size, is centred. This is set here
+        // rather than derived in `floatingBox` so that it happens once, on the keypress —
+        // deriving it every render would drag the window back to the middle of the screen the
+        // moment you tried to move it.
+        if let m = monitor(id: ws.monitorID) {
+            floatingFrames[id] = centredFloatingBox(on: m, stage: next)
         }
     }
 
@@ -417,8 +433,9 @@ public final class WorkspaceManager {
     /// captured from a parked window overlaps by 1×1pt, and handing that back would make the
     /// window vanish.
     private func floatingBox(for id: WindowID, on monitor: Monitor) -> Box {
+        let stage = floatingStage[id] ?? 1
         guard let remembered = floatingFrames[id] else {
-            return centredFloatingBox(on: monitor)
+            return centredFloatingBox(on: monitor, stage: stage)
         }
 
         let onScreen = remembered.intersection(monitor.usable)
@@ -431,16 +448,17 @@ public final class WorkspaceManager {
         // unplugged, or a window left parked in the stash corner. Centring rather than
         // clamping matters here — an edge-clamped window lands wherever the old geometry
         // happened to point, which on a display that is gone is arbitrary.
-        return centredFloatingBox(on: monitor)
+        return centredFloatingBox(on: monitor, stage: stage)
     }
 
     /// Centred on the monitor at a consistent fraction of it, so a floating window is the
     /// same shape whichever window it came from. The aspect cap is what keeps that honest on
     /// a wide display, where a plain width fraction would produce a letterbox.
-    private func centredFloatingBox(on monitor: Monitor) -> Box {
+    private func centredFloatingBox(on monitor: Monitor, stage: Int) -> Box {
         let usable = monitor.usable
-        let h = min(usable.h * floatingSize.height, usable.h)
-        let w = min(usable.w * floatingSize.width, usable.w, h * floatingSize.maxAspectRatio)
+        let fraction = floatingSize.fractions(stage: stage)
+        let h = min(usable.h * fraction.height, usable.h)
+        let w = min(usable.w * fraction.width, usable.w, h * floatingSize.maxAspectRatio)
         return Box(x: usable.minX + (usable.w - w) / 2.0,
                    y: usable.minY + (usable.h - h) / 2.0,
                    w: w, h: h).rounded()
@@ -498,7 +516,7 @@ public final class WorkspaceManager {
         out.focusedMonitor = monitorKey(focusedMonitorID)
         out.focusHistory = focusHistory
         out.floatingFrames = floatingFrames.keys.sorted().map {
-            FloatingFrame(window: $0, frame: floatingFrames[$0]!)
+            FloatingFrame(window: $0, frame: floatingFrames[$0]!, stage: floatingStage[$0])
         }
         return out
     }
@@ -576,9 +594,11 @@ public final class WorkspaceManager {
         // in the dictionary for the life of the process, since `reap` only knows about
         // windows it can find on a workspace.
         let placed = seen
-        floatingFrames = Dictionary(
-            snapshot.floatingFrames.filter { placed.contains($0.window) }.map { ($0.window, $0.frame) },
-            uniquingKeysWith: { first, _ in first })
+        let frames = snapshot.floatingFrames.filter { placed.contains($0.window) }
+        floatingFrames = Dictionary(frames.map { ($0.window, $0.frame) },
+                                    uniquingKeysWith: { first, _ in first })
+        floatingStage = Dictionary(frames.compactMap { f in f.stage.map { (f.window, $0) } },
+                                   uniquingKeysWith: { first, _ in first })
         focusHistory = snapshot.focusHistory.filter { placed.contains($0) }
 
         for ws in workspaces.values {
@@ -600,7 +620,7 @@ public final class WorkspaceManager {
         guard !stale.isEmpty else { return false }
 
         for id in stale {
-            removeWindow(id)
+            removeWindow(id)          // clears the floating stage too
             floatingFrames.removeValue(forKey: id)
         }
         return true

--- a/Sources/ToeCore/Session.swift
+++ b/Sources/ToeCore/Session.swift
@@ -63,10 +63,16 @@ public struct SessionSnapshot: Codable, Equatable {
 public struct FloatingFrame: Codable, Equatable {
     public var window: WindowID
     public var frame: Box
+    /// Where the window is on `togglefloating`'s cycle, so the next press after a restart
+    /// carries on round it rather than starting over. Absent for a window the app layer
+    /// floated on its own, and for files written before the cycle existed — both of which
+    /// mean the same thing, that the next press tiles the window.
+    public var stage: Int?
 
-    public init(window: WindowID, frame: Box) {
+    public init(window: WindowID, frame: Box, stage: Int? = nil) {
         self.window = window
         self.frame = frame
+        self.stage = stage
     }
 }
 

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -352,10 +352,46 @@ h.test("toggling a window out of the tree and back") { t in
                "a drag is not pulled back to the centre on the next render")
 
     wm.toggleFloating(2)
-    t.equal(wm.isFloating(2), false, "w2 is tiled again")
+    t.equal(wm.isFloating(2), true, "the second press keeps w2 floating")
+    t.equalBox(wm.render().floating[2], box(151, 49, 1210, 884),
+               "re-centred at the larger size, 80% wide by 90% tall")
+
+    wm.toggleFloating(2)
+    t.equal(wm.isFloating(2), false, "and the third press tiles it again")
     t.equalBox(wm.workspaces[1]?.layout.idealBox(of: 1), box(0, 0, 756, 982), "w1 back to the left half")
     t.equalBox(wm.workspaces[1]?.layout.idealBox(of: 2), box(756, 0, 756, 982), "w2 back to the right half")
     t.equal(wm.render().floating.isEmpty, true, "nothing floats any more")
+}
+
+h.test("togglefloating cycles through both floating sizes before it tiles") { t in
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
+    wm.addWindow(1); wm.addWindow(2)
+    wm.noteFocus(2)
+
+    wm.toggleFloating(2)
+    t.equalBox(wm.render().floating[2], box(227, 98, 1058, 786), "first press: 70% by 80%")
+    wm.toggleFloating(2)
+    t.equalBox(wm.render().floating[2], box(151, 49, 1210, 884), "second press: 80% by 90%")
+    wm.toggleFloating(2)
+    t.equal(wm.isFloating(2), false, "third press: back in the tree")
+    wm.toggleFloating(2)
+    t.equalBox(wm.render().floating[2], box(227, 98, 1058, 786),
+               "and round again from the first size")
+
+    // Both sizes are the config's, and setting them the same is the old two-state toggle.
+    wm.floatingSize.largeWidth = 0.70
+    wm.floatingSize.largeHeight = 0.80
+    wm.toggleFloating(2)
+    t.equalBox(wm.render().floating[2], box(227, 98, 1058, 786), "the second size can be the first")
+
+    // A window the app layer floated of its own accord never had a size from toe, so the
+    // first press tiles it rather than resizing it.
+    wm.addWindow(3, floating: true)
+    wm.floatingFrames[3] = box(200, 150, 640, 400)
+    wm.noteFocus(3)
+    wm.toggleFloating(3)
+    t.equal(wm.isFloating(3), false, "an adopted floating window tiles on the first press")
 }
 
 h.test("a floating frame is left alone unless it is stranded") { t in
@@ -414,7 +450,8 @@ h.test("a floating window is not a letterbox on an ultrawide") { t in
 
     wm.floatingSize.maxAspectRatio = 100                 // effectively uncapped
     wm.noteFocus(2)
-    wm.toggleFloating(2); wm.toggleFloating(2)           // re-float to re-centre
+    // Right round the cycle — larger, tiled, floating again — to re-centre at the first size.
+    wm.toggleFloating(2); wm.toggleFloating(2); wm.toggleFloating(2)
     t.equalBox(wm.render().floating[2], box(768, 141, 3584, 1128), "uncapped, it is the full 70%")
 }
 
@@ -600,6 +637,17 @@ h.test("only tiled windows are dragged, and only onto tiles") { t in
 
 // MARK: - Config
 
+h.test("the second floating size is configurable, and a bad one warns") { t in
+    let c = try Config.parse("[floating]\nlarge_width = 0.5\nlarge_height = 0.6\n")
+    t.equal(c.floating.largeWidth, 0.5, "large_width is read")
+    t.equal(c.floating.largeHeight, 0.6, "large_height is read")
+    t.equal(c.warnings, [], "no warnings for a fraction in range")
+
+    let bad = try Config.parse("[floating]\nlarge_height = 1.4\n")
+    t.equal(bad.floating.largeHeight, 0.90, "out of range keeps the default")
+    t.equal(bad.warnings.contains { $0.contains("floating.large_height") }, true, "and says so")
+}
+
 h.test("the shipped default config parses cleanly") { t in
     let c = try Config.parse(Config.defaultTOML)
     t.equal(c.warnings, [], "no warnings")
@@ -613,6 +661,8 @@ h.test("the shipped default config parses cleanly") { t in
     t.equal(c.floatRules.count, 5, "float rules")
     t.equal(c.floating.width, 0.70, "floating width fraction")
     t.equal(c.floating.height, 0.80, "floating height fraction")
+    t.equal(c.floating.largeWidth, 0.80, "the cycle's second width fraction")
+    t.equal(c.floating.largeHeight, 0.90, "the cycle's second height fraction")
     t.equal(c.floating.maxAspectRatio, 1.6, "floating max aspect ratio")
     t.equal(c.gestures.swallowDockSwipes, true, "dock swipes are swallowed by default")
     t.equal(c.misc.disableExposeShortcuts, true, "Ctrl+Up and Ctrl+Down are disabled by default")
@@ -984,6 +1034,9 @@ h.test("a restart keeps windows on their own workspaces and monitors") { t in
     t.equal(restored.workspaceIndex(of: 3), 7, "w3 is back on the workspace nothing is showing")
     t.equal(restored.isFloating(2), true, "w2 is still floating")
     t.equalBox(restored.render().floating[2], box(100, 100, 400, 300), "at the frame it was left at")
+    restored.toggleFloating(2)
+    t.equal(restored.isFloating(2), true,
+            "and at the first stage of the cycle, so the next press grows it rather than tiling it")
     t.equal(restored.render().stashed, [3], "and the hidden workspace is still hidden")
     t.equal(restored.activeWorkspace, wm.activeWorkspace, "each monitor shows what it showed")
     t.equal(restored.focusedMonitorID, wm.focusedMonitorID, "on the monitor that had focus")

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -43,6 +43,10 @@ radius       = -1
 # this fraction of the display, so every floating window is the same shape.
 width  = 0.70
 height = 0.80
+# SUPER+T again grows it to this instead of tiling it; the third press puts it back in the
+# tree. Set these to width/height above for a plain two-state toggle.
+large_width  = 0.80
+large_height = 0.90
 # ...except that no floating window is ever wider than this many times its own height. On a
 # 32:9 ultrawide a plain 70% would be a letterbox; on a laptop this never comes into play.
 max_aspect_ratio = 1.6


### PR DESCRIPTION
`togglefloating` had one floating size and toggled against it. It now walks **tiled → 70%×80% → 80%×90% → tiled**, re-centring on each floating step, so the same key gets a window out of the tree and then gives it room without reaching for the mouse.

- The second size is `large_width` / `large_height` under `[floating]`, defaulting to 0.80 / 0.90 and validated like the existing fractions. Set them equal to `width` / `height` for the old two-state toggle.
- The aspect cap applies to both stops, so neither is a letterbox on an ultrawide.
- Where a window is on the cycle is per-window state kept beside `floatingFrames` and persisted with them, so a restart carries on round the cycle. The snapshot field is optional — older session files still decode.
- A window the app layer floated on its own (a dialog, anything that will not take a size) has no stage and tiles on the first press: toe never chose that window's size, so it does not resize it out from under you.

README, the shipped default config and `toe.example.toml` (regenerated from the default, verified identical) are updated.

## Testing

`make test` — 339 assertions pass, including a new test for the full cycle, one for adopted floating windows, config parsing for the new keys, and the stage surviving a session round trip. Also ran it in place with `make run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qpb9Xzy7ziL44QcJ9Vt3TZ