### PR TITLE
Ask the window server for each window's own corner radius

### DIFF
--- a/Sources/ToeCore/Config/Config.swift
+++ b/Sources/ToeCore/Config/Config.swift
@@ -7,8 +7,9 @@ public struct BorderConfig: Equatable {
     public var activeStart: String = "#33ccffee"
     public var activeEnd: String = "#00ff99ee"
     public var angle: Double = 45
-    /// Negative follows the system window corner radius, 0 is square, positive is an
-    /// explicit value in points.
+    /// Negative follows the window's own corner radius — the window server is asked per
+    /// window, falling back to the system value — 0 is square, positive is an explicit value
+    /// in points.
     public var radius: Double = -1
     public init() {}
 }

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -42,7 +42,9 @@ width        = 2
 active_start = "#33ccffee"
 active_end   = "#00ff99ee"
 angle        = 45
-# -1 follows the system window corner radius, 0 is square, or set an explicit value.
+# -1 follows each window's own corner radius, asking the window server for it and falling
+# back to the system value for windows that do not report one. 0 is square, or set an
+# explicit value.
 radius       = -1
 
 [floating]

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -657,7 +657,7 @@ h.test("the shipped default config parses cleanly") { t in
     t.equal(c.dwindle.preserveSplit, true, "preserve_split")
     t.equal(c.dwindle.forceSplit, 2, "force_split")
     t.equal(c.border.activeStart, "#33ccffee", "Omarchy active border gradient start")
-    t.equal(c.border.radius, -1, "radius follows the system window corner radius")
+    t.equal(c.border.radius, -1, "radius follows the window's own corner radius")
     t.equal(c.floatRules.count, 5, "float rules")
     t.equal(c.floating.width, 0.70, "floating width fraction")
     t.equal(c.floating.height, 0.80, "floating height fraction")

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -460,7 +460,7 @@ final class Coordinator: WindowTrackerDelegate {
             // Behind the window being dragged, and above every other one — where Hyprland puts
             // it, since it draws each border with its own window and the focused window last.
             if let tile = desired[focused] {
-                border.show(around: tile, depth: .behindFrontmost)
+                border.show(around: tile, of: focused, depth: .behindFrontmost)
             } else {
                 border.hide()
             }
@@ -469,7 +469,7 @@ final class Coordinator: WindowTrackerDelegate {
 
         // Prefer the frame we wrote; fall back to asking the window for floating ones.
         if let box = window.element.frame ?? desired[focused] {
-            border.show(around: box, depth: borderDepth(around: box, of: focused))
+            border.show(around: box, of: focused, depth: borderDepth(around: box, of: focused))
         } else {
             border.hide()
         }

--- a/Sources/toe/UI/BorderOverlay.swift
+++ b/Sources/toe/UI/BorderOverlay.swift
@@ -68,8 +68,11 @@ final class BorderOverlay {
         band.cornerCurve = .continuous              // macOS's squircle, not a circular arc
         panel.contentView = view
 
-        // Resolves the system corner radius here, on the main thread, and records it once.
-        Log.info("system window corner radius: \(SystemCornerRadius.points) pt (\(SystemCornerRadius.source))")
+        // Resolves the fallback corner radius here, on the main thread, and records it once,
+        // along with whether the window server can be asked for per-window radii at all.
+        Log.info("window corner radius: per-window query "
+            + (WindowCornerRadius.isAvailable ? "available" : "unavailable")
+            + ", falling back to \(SystemCornerRadius.points) pt (\(SystemCornerRadius.source))")
     }
 
     func apply(_ newConfig: BorderConfig) {
@@ -86,10 +89,11 @@ final class BorderOverlay {
     }
 
     /// `box` is the window's own frame in AX coordinates; the border is drawn just outside it.
+    /// `id` is the window the border belongs to, which is what the corner radius is asked about.
     ///
     /// `depth` has no default on purpose: both call sites decide it, and a default is how a
     /// future one would silently go back to drawing over whatever is in front of it.
-    func show(around box: Box, depth: Depth) {
+    func show(around box: Box, of id: WindowID, depth: Depth) {
         guard config.enabled, config.width > 0 else { hide(); return }
 
         let w = config.width
@@ -99,8 +103,12 @@ final class BorderOverlay {
         let rect = Coordinates.toCocoa(outer)
         guard rect.width > 0, rect.height > 0 else { hide(); return }
 
+        // The window's own radius, not one number for every window: macOS 26 rounds Safari at
+        // 26 pt and Ghostty at 16, so a system-wide value is wrong for most windows. The system
+        // value is the fallback for the ones that do not report one.
+        let radius = WindowCornerRadius.points(for: id) ?? SystemCornerRadius.points
         let windowRadius = BorderGeometry.effectiveRadius(configured: config.radius,
-                                                          system: Double(SystemCornerRadius.points),
+                                                          system: Double(radius),
                                                           box: box)
 
         CATransaction.begin()

--- a/Sources/toe/UI/SystemCornerRadius.swift
+++ b/Sources/toe/UI/SystemCornerRadius.swift
@@ -1,8 +1,13 @@
 import AppKit
 import ObjectiveC
 
-/// The corner radius macOS rounds a window to. No public API reports it, and on macOS 26 no
-/// private one does either, so this is part measurement, part lookup.
+/// The corner radius macOS rounds a window to, system-wide. No public API reports it, and on
+/// macOS 26 no private one does either, so this is part measurement, part lookup.
+///
+/// This is the *fallback*, not the answer. macOS 26 gives every window its own radius, and
+/// `WindowCornerRadius` asks the window server for the one that belongs to the window being
+/// outlined; this value is what the border falls back on when that query has nothing to say —
+/// below macOS 26, where the per-window symbols do not exist, and for windows that report 0.
 ///
 /// On macOS 26 the window server rounds every window itself, and AppKit's own accessors have
 /// not followed: `NSWindow._cornerRadius`, `_effectiveCornerRadius`, `NSThemeFrame._cornerRadius`

--- a/Sources/toe/UI/WindowCornerRadius.swift
+++ b/Sources/toe/UI/WindowCornerRadius.swift
@@ -1,0 +1,101 @@
+import CoreGraphics
+import Foundation
+import ToeCore
+
+/// The corner radius of *one particular window*, straight from the window server.
+///
+/// macOS 26 rounds windows itself, and it does not round them all the same: Safari's windows
+/// come back at 26 pt, Ghostty's at 16. A single system-wide number — which is all
+/// `SystemCornerRadius` can offer — is therefore wrong for most windows, by up to 8 pt in the
+/// cases measured here, and that is what makes the band overshoot one app's corner while
+/// cutting the next one's.
+///
+/// `SLSWindowIteratorGetCornerRadii` is how JankyBorders answers the same question. It is
+/// undocumented, and new in macOS 26 — nothing below that has it, and the lookup simply fails
+/// there, which is the right outcome: `SystemCornerRadius` is still the best available answer
+/// on those releases.
+///
+/// Note what this buys and what it does not. It is the *radius*, not the curve: JankyBorders
+/// takes the same number and draws a circular arc with it, which is not the shape a macOS
+/// corner is. toe keeps drawing through `CALayer.cornerCurve = .continuous`, so with the right
+/// radius in hand the band follows both.
+enum WindowCornerRadius {
+
+    /// The window's own corner radius, or nil to fall back on `SystemCornerRadius.points`.
+    ///
+    /// Nil covers three cases that all want the same answer: the symbols are missing (below
+    /// macOS 26), the query came back empty, or the window reported 0.
+    ///
+    /// **Zero is "unknown", not "square".** toe's own borderless panel reports 0 and really is
+    /// square — but Electron windows report 0 while rendering rounded, and nothing in the reply
+    /// tells the two apart. Falling back keeps those looking exactly as they do today; treating
+    /// 0 as square would put a sharp ring around Slack's rounded corners. A window that is
+    /// genuinely square is served by `radius = 0` in the config.
+    static func points(for id: WindowID) -> CGFloat? {
+        guard let mainConnectionID, let queryWindows, let copyWindows,
+              let advance, let getCornerRadii
+        else { return nil }
+
+        // A one-element array asks about this window alone, rather than walking every window
+        // on the system to find it.
+        var window = id
+        guard let number = CFNumberCreate(nil, .sInt32Type, &window) else { return nil }
+        let ids = [number] as CFArray
+
+        // Despite the names, all three of these come back +1. Retained, not unretained: an
+        // unretained take here would over-release, and no take at all would leak one query,
+        // one iterator and one array on every focus change.
+        guard let query = queryWindows(mainConnectionID(), ids, 1)?.takeRetainedValue(),
+              let iterator = copyWindows(query)?.takeRetainedValue(),
+              advance(iterator)
+        else { return nil }
+
+        guard let radii = getCornerRadii(iterator)?.takeRetainedValue() as? [Int32],
+              let first = radii.first, first > 0
+        else { return nil }
+
+        // One radius for four corners. The reply carries all four, and every window measured
+        // has them equal; CALayer has a single `cornerRadius` anyway, so an asymmetric window
+        // would need a hand-built path and would lose the system rasteriser that makes these
+        // corners the right shape to begin with.
+        return CGFloat(first)
+    }
+
+    /// Whether the window server can be asked at all, for the line toe logs at startup.
+    static var isAvailable: Bool {
+        mainConnectionID != nil && queryWindows != nil && copyWindows != nil
+            && advance != nil && getCornerRadii != nil
+    }
+}
+
+// MARK: - SkyLight
+
+/// PRIVATE API. Resolved with dlsym on `RTLD_NEXT`, the same way `_AXUIElementGetWindow` and
+/// `CGSSetSymbolicHotKeyEnabled` are, so a missing symbol degrades instead of failing to launch.
+///
+/// `RTLD_NEXT` rather than a `dlopen` of SkyLight's path on purpose: AppKit has already loaded
+/// the framework, so the lookup resolves inside a library that is in the process anyway — which
+/// is what lets library validation stay on. See `Resources/toe.entitlements`.
+private func skyLight<T>(_ name: String, as type: T.Type) -> T? {
+    guard let sym = dlsym(UnsafeMutableRawPointer(bitPattern: -2), name) else { return nil }
+    return unsafeBitCast(sym, to: type)
+}
+
+private let mainConnectionID: (@convention(c) () -> Int32)? =
+    skyLight("SLSMainConnectionID", as: (@convention(c) () -> Int32).self)
+
+private let queryWindows: (@convention(c) (Int32, CFArray, Int32) -> Unmanaged<CFTypeRef>?)? =
+    skyLight("SLSWindowQueryWindows",
+             as: (@convention(c) (Int32, CFArray, Int32) -> Unmanaged<CFTypeRef>?).self)
+
+private let copyWindows: (@convention(c) (CFTypeRef) -> Unmanaged<CFTypeRef>?)? =
+    skyLight("SLSWindowQueryResultCopyWindows",
+             as: (@convention(c) (CFTypeRef) -> Unmanaged<CFTypeRef>?).self)
+
+private let advance: (@convention(c) (CFTypeRef) -> Bool)? =
+    skyLight("SLSWindowIteratorAdvance", as: (@convention(c) (CFTypeRef) -> Bool).self)
+
+/// macOS 26 and later only.
+private let getCornerRadii: (@convention(c) (CFTypeRef) -> Unmanaged<CFArray>?)? =
+    skyLight("SLSWindowIteratorGetCornerRadii",
+             as: (@convention(c) (CFTypeRef) -> Unmanaged<CFArray>?).self)

--- a/Sources/toe/main.swift
+++ b/Sources/toe/main.swift
@@ -28,8 +28,31 @@ let app = NSApplication.shared
 app.setActivationPolicy(.accessory)
 // `toe --print-corner-radius` reports what macOS rounds windows to, so the border can be
 // checked without granting Accessibility or launching the agent. Needs NSApp to exist.
+//
+// The fallback first, then what the window server says about each window on screen — which is
+// the interesting half, since that is the number the border actually draws with, and the two
+// disagree for most windows.
 if CommandLine.arguments.contains("--print-corner-radius") {
-    print(SystemCornerRadius.points)
+    print("fallback: \(SystemCornerRadius.points) pt (\(SystemCornerRadius.source))")
+    guard WindowCornerRadius.isAvailable else {
+        print("per-window query unavailable; every window uses the fallback")
+        exit(0)
+    }
+    let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+    let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] ?? []
+    // `%@` ignores a width specifier for a Swift string, so the columns are padded by hand.
+    func row(_ id: String, _ radius: String, _ owner: String) {
+        print(id.padding(toLength: 8, withPad: " ", startingAt: 0)
+            + radius.padding(toLength: 14, withPad: " ", startingAt: 0) + owner)
+    }
+    row("wid", "radius", "owner")
+    for info in windows {
+        guard let id = info[kCGWindowNumber as String] as? WindowID else { continue }
+        let owner = info[kCGWindowOwnerName as String] as? String ?? "?"
+        let radius = WindowCornerRadius.points(for: id)
+            .map { "\($0) pt" } ?? "- (fallback)"
+        row("\(id)", radius, owner)
+    }
     exit(0)
 }
 

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -35,7 +35,9 @@ width        = 2
 active_start = "#33ccffee"
 active_end   = "#00ff99ee"
 angle        = 45
-# -1 follows the system window corner radius, 0 is square, or set an explicit value.
+# -1 follows each window's own corner radius, asking the window server for it and falling
+# back to the system value for windows that do not report one. 0 is square, or set an
+# explicit value.
 radius       = -1
 
 [floating]


### PR DESCRIPTION
The border drew every window with one corner radius: `SystemCornerRadius`, part measurement and part lookup, is a single system-wide number. macOS 26 does not round windows that way — Safari's windows come back at 26 pt, Ghostty's at 16 — so the band overshot one app's corner and cut into the next one's, off by up to 8 pt in the cases measured here.

## What changed

`WindowCornerRadius` (new) asks the window server about the window being outlined, through `SLSWindowIteratorGetCornerRadii` — the call JankyBorders answers the same question with. The symbols are resolved with `dlsym` on `RTLD_NEXT`, the way `_AXUIElementGetWindow` and `CGSSetSymbolicHotKeyEnabled` already are, so they resolve inside a framework AppKit has loaded anyway and library validation stays on.

They are new in macOS 26. Below that the lookup fails and `SystemCornerRadius` remains the best answer available — which is why it stays, now documented as the fallback rather than the answer.

`BorderOverlay.show(around:of:depth:)` takes the window id so it can ask; `Coordinator` passes it at both call sites.

## Windows that report 0

A window reporting 0 falls back rather than being drawn square. toe's own borderless panel reports 0 and really is square, but Electron windows report 0 while rendering rounded, and nothing in the reply tells the two apart. Falling back leaves those looking exactly as they do today; trusting the 0 would put a sharp ring around Slack's rounded corners. A window that genuinely is square is served by `radius = 0` in the config.

## Radius, not curve

This changes the number, not the shape. The band still draws through `CALayer.cornerCurve = .continuous`, so with the right radius in hand it follows macOS's squircle — where JankyBorders takes the same number and draws a circular arc.

## Checking it

`toe --print-corner-radius` now prints the fallback and then a table of every window on screen with the radius the border would draw it at, so a corner that looks wrong can be inspected without granting Accessibility or launching the agent.

Suite passes (339 assertions); the config text for `radius = -1` is updated in `DefaultConfig.swift`, `toe.example.toml` and the assertion that reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)