### PR TITLE
Cycle only through the workspaces in use

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ as the defaults.
 | `SUPER` + `SHIFT` + `←↑↓→` | Swap window with its neighbour |
 | `SUPER` + `1`…`9`, `0` | Switch to workspace 1…10 |
 | `SUPER` + `SHIFT` + `1`…`9`, `0` | Move window to workspace and follow it |
-| `SUPER` + `TAB` / `SHIFT`+`TAB` / `CTRL`+`TAB` | Next / previous / former workspace |
+| `SUPER` + `TAB` / `SHIFT`+`TAB` / `CTRL`+`TAB` | Next / previous workspace in use, former workspace |
 | `SUPER` + `ENTER` | New terminal window |
 | `SUPER` + `SHIFT` + `ENTER` | New browser window |
 | `SUPER` + `W` | Close window |

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -133,6 +133,8 @@ persistent_workspaces = 5
 # Same, without following the window:  "movetoworkspacesilent 3"
 
 # ── Cycling ───────────────────────────────────────────────────────────────────
+# next/prev walk only the workspaces in use — the ones with windows on them, plus whatever the
+# other displays are showing — so a press never lands on a blank slot.
 "super-tab"       = "workspace next"
 "super-shift-tab" = "workspace prev"
 "super-ctrl-tab"  = "workspace previous"

--- a/Sources/ToeCore/Layout/WorkspaceManager.swift
+++ b/Sources/ToeCore/Layout/WorkspaceManager.swift
@@ -400,11 +400,17 @@ public final class WorkspaceManager {
         if let prev = previousWorkspace[focusedMonitorID] { switchTo(workspace: prev) }
     }
 
+    /// `workspace e+1` / `e-1`. Cycles through the workspaces in use — the ones with windows
+    /// on them, plus whatever the monitors are showing — rather than all ten, so a press never
+    /// lands on a blank slot you would have to press past. With nothing else in use it does
+    /// nothing, and the workspace you are on always counts as one of them.
     public func switchToRelativeWorkspace(_ delta: Int) {
         let current = focusedWorkspaceIndex
-        var next = (current - 1 + delta) % Self.workspaceCount
-        if next < 0 { next += Self.workspaceCount }
-        switchTo(workspace: next + 1)
+        let ring = (1...Self.workspaceCount).filter { $0 == current || inUse(workspace: $0) }
+        guard ring.count > 1, let position = ring.firstIndex(of: current) else { return }
+        var next = (position + delta) % ring.count
+        if next < 0 { next += ring.count }
+        switchTo(workspace: ring[next])
     }
 
     /// `movetoworkspace <n>` / `movetoworkspacesilent <n>`.
@@ -669,5 +675,12 @@ public extension WorkspaceManager {
     /// Which monitor, if any, is currently showing this workspace.
     func monitorShowing(workspace index: Int) -> UInt32? {
         activeWorkspace.first { $0.value == index }?.key
+    }
+
+    /// Whether a workspace is one of the ones you are actually using: it holds windows, or a
+    /// monitor is showing it right now. This is what the strip draws as anything but a dim
+    /// digit, and what `workspace e+1` cycles through.
+    func inUse(workspace index: Int) -> Bool {
+        !isEmpty(workspace: index) || monitorShowing(workspace: index) != nil
     }
 }

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -315,6 +315,50 @@ h.test("movetoworkspace follows the window") { t in
     t.equal(wm.workspaceIndex(of: 2), 1, "w2 moved anyway")
 }
 
+h.test("workspace next skips the workspaces nothing is on") { t in
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
+
+    wm.addWindow(1)                                   // workspace 1
+    wm.switchTo(workspace: 4); wm.addWindow(2)
+    wm.switchTo(workspace: 9); wm.addWindow(3)
+    wm.switchTo(workspace: 1)
+
+    wm.switchToRelativeWorkspace(1)
+    t.equal(wm.focusedWorkspaceIndex, 4, "next is 4, not 2 — 2 and 3 are empty")
+    wm.switchToRelativeWorkspace(1)
+    t.equal(wm.focusedWorkspaceIndex, 9, "then 9")
+    wm.switchToRelativeWorkspace(1)
+    t.equal(wm.focusedWorkspaceIndex, 1, "and round to 1")
+    wm.switchToRelativeWorkspace(-1)
+    t.equal(wm.focusedWorkspaceIndex, 9, "prev walks the same ring backwards")
+}
+
+h.test("workspace next stays put when nothing else is in use") { t in
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
+    wm.addWindow(1)
+
+    wm.switchToRelativeWorkspace(1)
+    t.equal(wm.focusedWorkspaceIndex, 1, "one workspace in use, so the press does nothing")
+}
+
+h.test("workspace next reaches a workspace another monitor is showing") { t in
+    let left = box(0, 0, 1512, 982)
+    let right = box(1512, 0, 1920, 1080)
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: left, usable: left),
+                    Monitor(id: 2, frame: right, usable: right)])
+
+    let leftWS = wm.activeWorkspace[1]!
+    let rightWS = wm.activeWorkspace[2]!
+    wm.switchTo(workspace: leftWS)
+    wm.addWindow(1)
+
+    wm.switchToRelativeWorkspace(1)
+    t.equal(wm.focusedWorkspaceIndex, rightWS, "the other display's workspace counts, empty or not")
+}
+
 h.test("a floating focus falls back to the window under the pointer") { t in
     let wm = WorkspaceManager()
     wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])

--- a/Sources/toe/UI/StatusItem.swift
+++ b/Sources/toe/UI/StatusItem.swift
@@ -34,16 +34,16 @@ final class StatusItem: NSObject {
     private let markerSide: CGFloat = 8
     private let markerRadius: CGFloat = 2.5
 
-    /// Omarchy dims empty workspaces with `opacity: 0.5`. The menu bar is translucent over
-    /// whatever wallpaper is behind it, and half opacity there is too faint to read, so toe
-    /// dims less far.
+    /// Omarchy dims empty workspaces with `opacity: 0.5`, and so does toe: the ones you are
+    /// using should be the ones your eye lands on, and the rest are there to be counted past
+    /// rather than read.
     ///
     /// Built from a dynamic provider rather than `secondaryLabelColor` so it resolves when it
     /// is drawn, against the menu bar's own appearance — which is not always the app's, since
     /// macOS darkens the menu bar to suit the desktop picture.
     private static let dimLabelColor = NSColor(name: "toeDimLabel") { appearance in
         let dark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
-        return (dark ? NSColor.white : NSColor.black).withAlphaComponent(0.7)
+        return (dark ? NSColor.white : NSColor.black).withAlphaComponent(0.5)
     }
 
     override init() {

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -126,6 +126,8 @@ persistent_workspaces = 5
 # Same, without following the window:  "movetoworkspacesilent 3"
 
 # ── Cycling ───────────────────────────────────────────────────────────────────
+# next/prev walk only the workspaces in use — the ones with windows on them, plus whatever the
+# other displays are showing — so a press never lands on a blank slot.
 "super-tab"       = "workspace next"
 "super-shift-tab" = "workspace prev"
 "super-ctrl-tab"  = "workspace previous"


### PR DESCRIPTION
SUPER+TAB / SUPER+SHIFT+TAB walked all ten workspaces, so reaching the one other thing you had open meant pressing past seven blank slots.

`switchToRelativeWorkspace` now builds a ring of the workspaces in use — the ones with windows on them, plus whatever the monitors are showing — and steps along that. The workspace you are on always counts as one of them, and with nothing else in use the press does nothing. `inUse(workspace:)` joins `isEmpty`/`monitorShowing` in the same extension, and is the same "anything but a dim digit" test the menu bar strip uses.

Three selftests cover it: skipping the blanks and wrapping both ways, staying put when only one workspace is in use, and reaching an empty workspace another display is showing.

Also: empty workspaces in the strip drop from 0.7 to 0.5 alpha, which is Omarchy's own `opacity: 0.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184PPAns5xQzE1hTKwcGN1L