### PR TITLE
Check the type of Accessibility values before using them

### DIFF
--- a/Sources/toe/AX/AXElement.swift
+++ b/Sources/toe/AX/AXElement.swift
@@ -55,6 +55,34 @@ extension AXUIElement {
     func string(_ attribute: String) -> String? { value(attribute) as? String }
     func bool(_ attribute: String) -> Bool? { value(attribute) as? Bool }
 
+    /// An attribute value, checked against the CoreFoundation type it is supposed to hold.
+    ///
+    /// Every one of these values crosses a process boundary from an application toe does not
+    /// control, and nothing obliges that application to answer `kAXFocusedWindowAttribute`
+    /// with a window, or `kAXPositionAttribute` with a point. `as?` cannot do the checking:
+    /// AX types are CoreFoundation types, Swift's conditional cast to one is unchecked, and
+    /// the compiler rejects it outright as always succeeding. `CFGetTypeID` is the real test,
+    /// so the two casts below are reached only once the type is established — which is what
+    /// keeps a misbehaving application from taking toe down with it.
+    private func checked(_ attribute: String, is typeID: CFTypeID) -> CFTypeRef? {
+        guard let raw = value(attribute), CFGetTypeID(raw) == typeID else { return nil }
+        return raw
+    }
+
+    /// An attribute that is supposed to hold another element.
+    func elementValue(_ attribute: String) -> AXUIElement? {
+        guard let raw = checked(attribute, is: AXUIElementGetTypeID()) else { return nil }
+        // swiftlint:disable:next force_cast
+        return (raw as! AXUIElement)
+    }
+
+    /// An attribute that is supposed to hold a packed `AXValue` — a point, a size, a range.
+    func axValue(_ attribute: String) -> AXValue? {
+        guard let raw = checked(attribute, is: AXValueGetTypeID()) else { return nil }
+        // swiftlint:disable:next force_cast
+        return (raw as! AXValue)
+    }
+
     @discardableResult
     func set(_ attribute: String, _ newValue: CFTypeRef) -> Bool {
         AXUIElementSetAttributeValue(self, attribute as CFString, newValue) == .success
@@ -89,18 +117,18 @@ extension AXUIElement {
     }
 
     var position: CGPoint? {
-        guard let raw = value(kAXPositionAttribute) else { return nil }
+        // AXValueGetValue answers false for an AXValue packing something other than a point,
+        // so the pair of checks covers both a wrong CFType and a wrong payload inside it.
+        guard let raw = axValue(kAXPositionAttribute) else { return nil }
         var point = CGPoint.zero
-        // swiftlint:disable:next force_cast
-        guard AXValueGetValue(raw as! AXValue, .cgPoint, &point) else { return nil }
+        guard AXValueGetValue(raw, .cgPoint, &point) else { return nil }
         return point
     }
 
     var size: CGSize? {
-        guard let raw = value(kAXSizeAttribute) else { return nil }
+        guard let raw = axValue(kAXSizeAttribute) else { return nil }
         var s = CGSize.zero
-        // swiftlint:disable:next force_cast
-        guard AXValueGetValue(raw as! AXValue, .cgSize, &s) else { return nil }
+        guard AXValueGetValue(raw, .cgSize, &s) else { return nil }
         return s
     }
 

--- a/Sources/toe/AX/WindowMover.swift
+++ b/Sources/toe/AX/WindowMover.swift
@@ -46,9 +46,8 @@ enum WindowMover {
     }
 
     static func close(_ window: ManagedWindow) {
-        guard let button = window.element.value(kAXCloseButtonAttribute) else { return }
-        // swiftlint:disable:next force_cast
-        AXUIElementPerformAction(button as! AXUIElement, kAXPressAction as CFString)
+        guard let button = window.element.elementValue(kAXCloseButtonAttribute) else { return }
+        AXUIElementPerformAction(button, kAXPressAction as CFString)
     }
 }
 

--- a/Sources/toe/AX/WindowTracker.swift
+++ b/Sources/toe/AX/WindowTracker.swift
@@ -91,9 +91,8 @@ final class WindowTracker {
         guard let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
               app.processIdentifier != ownPID else { return }
         let element = AX.application(app.processIdentifier)
-        if let focused = element.value(kAXFocusedWindowAttribute) {
-            // swiftlint:disable:next force_cast
-            if let id = (focused as! AXUIElement).windowID, windows[id] != nil {
+        if let focused = element.elementValue(kAXFocusedWindowAttribute) {
+            if let id = focused.windowID, windows[id] != nil {
                 delegate?.windowFocused(id)
             }
         }
@@ -223,9 +222,7 @@ final class WindowTracker {
 
         case kAXApplicationActivatedNotification:
             let app = AX.application(element.pid)
-            if let focused = app.value(kAXFocusedWindowAttribute) {
-                // swiftlint:disable:next force_cast
-                let focusedElement = focused as! AXUIElement
+            if let focusedElement = app.elementValue(kAXFocusedWindowAttribute) {
                 let window = adopt(focusedElement, pid: element.pid)
                 if let id = window?.id ?? focusedElement.windowID, windows[id] != nil {
                     delegate?.windowFocused(id)


### PR DESCRIPTION
Closes #22.

Five attribute values arriving from other applications were force cast on receipt — `kAXFocusedWindowAttribute` and `kAXCloseButtonAttribute` to `AXUIElement`, `kAXPositionAttribute` and `kAXSizeAttribute` to `AXValue`. Nothing obliges an application to answer those with the type they name, and a wrong one is an unconditional trap: toe dies because some other app misbehaved.

### Not the fix the issue proposed

The issue suggested changing all five to `as?`. That does not compile, and would not have been safe if it did:

```
error: conditional downcast to CoreFoundation type 'AXUIElement' will always succeed
```

Swift's conditional cast to a CoreFoundation type is unchecked — it is a no-op the compiler rejects outright. `CFGetTypeID` is the only real test.

### What is here

Two accessors on `AXUIElement`, sitting alongside the existing `string(_:)` and `bool(_:)` and returning nil the same way:

- `elementValue(_:)` — checked against `AXUIElementGetTypeID()`
- `axValue(_:)` — checked against `AXValueGetTypeID()`

All five call sites go through them, and every one already had a nil-return path to fall into, so no new error handling was needed. That leaves two casts instead of five, both inside those accessors and both reached only once the type is established.

For `position` and `size` the `CFGetTypeID` check also pairs with `AXValueGetValue`, which answers false when the `AXValue` packs something other than the point or size asked for — so a wrong CFType and a wrong payload inside the right one are both covered.

### Testing

`swift build -c release` is clean and `swift run -c debug toe-selftest` passes (357 assertions). The change is in `Sources/toe`, which the headless suite does not reach — it needs Accessibility and a window server — so the coverage here is the compiler plus the fact that every path already handled nil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184PPAns5xQzE1hTKwcGN1L