### PR TITLE
Refuse config numbers that are not finite, or not sensible

### DIFF
--- a/Sources/ToeCore/Config/Config.swift
+++ b/Sources/ToeCore/Config/Config.swift
@@ -159,6 +159,37 @@ public struct Config: Equatable {
         (try? Config.parse(defaultTOML)) ?? Config()
     }
 
+    /// One number from the config, or nil — with a warning appended — when it is not a finite
+    /// value inside `range`.
+    ///
+    /// TOML spells `nan` and `inf`, and Swift's `Double(_: String)` accepts them as readily as
+    /// it accepts `0x1p10`, so without a check here a single `gaps_in = nan` reaches the
+    /// layout and three things go wrong at once. `Box` is `Equatable`, so every comparison
+    /// against a NaN coordinate is false: toe decides the window is in the wrong place and
+    /// re-writes its frame on every render, forever. The correction budget that notices a
+    /// window fighting the layout compares the same way, so it never resets either. And the
+    /// NaN geometry is written into other applications over Accessibility, where reading it
+    /// back into an `NSWindow.setFrame` — which the border overlay does — traps.
+    ///
+    /// `[bar]` and `[floating]` were already range-checked. This is the same treatment for
+    /// `[general]`, `[border]` and `[dwindle]`, and it catches the merely absurd (`0x1p10` is
+    /// a gap of 1024 points) along with the non-finite.
+    static func number(_ raw: TOMLValue?, _ path: String, in range: ClosedRange<Double>,
+                       keeping current: Double, warnings: inout [String]) -> Double? {
+        guard let value = raw?.doubleValue else { return nil }
+        guard value.isFinite, range.contains(value) else {
+            warnings.append("\(path): must be a number from \(brief(range.lowerBound)) to "
+                            + "\(brief(range.upperBound)), using \(brief(current))")
+            return nil
+        }
+        return value
+    }
+
+    /// `5` rather than `5.0`, so the warnings read the way the config file is written.
+    private static func brief(_ value: Double) -> String {
+        value == value.rounded() && abs(value) < 1e15 ? String(Int(value)) : String(value)
+    }
+
     public static func parse(_ text: String) throws -> Config {
         let root = try TOML.parse(text)
         var config = Config()
@@ -172,26 +203,52 @@ public struct Config: Equatable {
                 default: config.warnings.append("general.super_key: unknown value '\(s)', using alt")
                 }
             }
-            if let v = general["gaps_in"]?.doubleValue { config.gaps.inner = v }
-            if let v = general["gaps_out"]?.doubleValue { config.gaps.outer = v }
+            if let v = number(general["gaps_in"], "general.gaps_in", in: 0...500,
+                              keeping: config.gaps.inner, warnings: &config.warnings) {
+                config.gaps.inner = v
+            }
+            if let v = number(general["gaps_out"], "general.gaps_out", in: 0...500,
+                              keeping: config.gaps.outer, warnings: &config.warnings) {
+                config.gaps.outer = v
+            }
         }
 
         if let d = root["dwindle"]?.tableValue {
             if let v = d["preserve_split"]?.boolValue { config.dwindle.preserveSplit = v }
             if let v = d["force_split"]?.intValue { config.dwindle.forceSplit = v }
             if let v = d["smart_split"]?.boolValue { config.dwindle.smartSplit = v }
-            if let v = d["split_width_multiplier"]?.doubleValue { config.dwindle.splitWidthMultiplier = v }
-            if let v = d["default_split_ratio"]?.doubleValue { config.dwindle.defaultSplitRatio = v }
+            if let v = number(d["split_width_multiplier"], "dwindle.split_width_multiplier", in: 0.1...10,
+                              keeping: config.dwindle.splitWidthMultiplier, warnings: &config.warnings) {
+                config.dwindle.splitWidthMultiplier = v
+            }
+            // The same range the layout clamps to on use, so a value outside it is named here
+            // rather than silently becoming a different one later.
+            if let v = number(d["default_split_ratio"], "dwindle.default_split_ratio", in: 0.1...1.9,
+                              keeping: config.dwindle.defaultSplitRatio, warnings: &config.warnings) {
+                config.dwindle.defaultSplitRatio = v
+            }
             if let v = d["split_bias"]?.intValue { config.dwindle.splitBias = v }
         }
 
         if let b = root["border"]?.tableValue {
             if let v = b["enabled"]?.boolValue { config.border.enabled = v }
-            if let v = b["width"]?.doubleValue { config.border.width = v }
+            if let v = number(b["width"], "border.width", in: 0...100,
+                              keeping: config.border.width, warnings: &config.warnings) {
+                config.border.width = v
+            }
             if let v = b["active_start"]?.stringValue { config.border.activeStart = v }
             if let v = b["active_end"]?.stringValue { config.border.activeEnd = v }
-            if let v = b["angle"]?.doubleValue { config.border.angle = v }
-            if let v = b["radius"]?.doubleValue { config.border.radius = v }
+            if let v = number(b["angle"], "border.angle", in: 0...360,
+                              keeping: config.border.angle, warnings: &config.warnings) {
+                config.border.angle = v
+            }
+            // -1 is the documented "follow the window's own corner radius", and is the only
+            // negative the range admits: every other one means the same thing, and accepting
+            // them all would make a typo indistinguishable from a choice.
+            if let v = number(b["radius"], "border.radius", in: -1...100,
+                              keeping: config.border.radius, warnings: &config.warnings) {
+                config.border.radius = v
+            }
         }
 
         if let b = root["bar"]?.tableValue {

--- a/Sources/ToeCore/Config/TOML.swift
+++ b/Sources/ToeCore/Config/TOML.swift
@@ -13,7 +13,11 @@ public enum TOMLValue: Equatable {
     public var intValue: Int? {
         switch self {
         case .int(let i): return i
-        case .double(let d): return Int(d)
+        // A float where an integer was wanted, truncated toward zero — but guarded, because
+        // `Int(_: Double)` traps on a NaN, on an infinity and on anything past Int's range,
+        // and TOML spells all three (`nan`, `inf`, `1e400`). An unguarded conversion here is
+        // a crash any config file can cause.
+        case .double(let d): return d.isFinite ? Int(exactly: d.rounded(.towardZero)) : nil
         default: return nil
         }
     }

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -892,6 +892,88 @@ h.test("the escape hatches are bound even when the config forgets them") { t in
     }
 }
 
+h.test("nan and infinity are refused rather than reaching the layout") { t in
+    // TOML spells both, and Double("nan") accepts them. A NaN gap defeats every == in the
+    // coordinator: the window is re-written on every render forever, the correction budget
+    // never resets, and the NaN is passed to other applications over Accessibility.
+    for spelling in ["nan", "inf", "-inf", "+inf"] {
+        let c = try Config.parse("[general]\ngaps_in = \(spelling)\n")
+        t.equal(c.gaps.inner, 5, "gaps_in = \(spelling) keeps the default")
+        t.equal(c.gaps.inner.isFinite, true, "gaps_in = \(spelling) leaves a finite gap")
+        t.equal(c.warnings.contains { $0.contains("general.gaps_in") }, true,
+                "gaps_in = \(spelling) warns")
+    }
+
+    let out = try Config.parse("[general]\ngaps_out = nan\n")
+    t.equal(out.gaps.outer, 10, "gaps_out = nan keeps the default")
+    t.equal(out.warnings.contains { $0.contains("general.gaps_out") }, true, "and says so")
+
+    let border = try Config.parse("[border]\nwidth = nan\nangle = inf\nradius = nan\n")
+    t.equal(border.border.width, 2, "border.width = nan keeps the default")
+    t.equal(border.border.angle, 45, "border.angle = inf keeps the default")
+    t.equal(border.border.radius, -1, "border.radius = nan keeps the default")
+    t.equal(border.warnings.count, 3, "one warning each")
+
+    let dwindle = try Config.parse("[dwindle]\nsplit_width_multiplier = nan\ndefault_split_ratio = inf\n")
+    t.equal(dwindle.dwindle.splitWidthMultiplier, 1.0, "split_width_multiplier = nan keeps the default")
+    t.equal(dwindle.dwindle.defaultSplitRatio, 1.0, "default_split_ratio = inf keeps the default")
+    t.equal(dwindle.warnings.count, 2, "one warning each")
+}
+
+h.test("numbers outside a sensible range are refused too") { t in
+    // Swift's Double(_: String) takes hex floats, which TOML has no notion of, so this used
+    // to parse as a 1024 point gap with no warning at all.
+    let hex = try Config.parse("[general]\ngaps_in = 0x1p10\n")
+    t.equal(hex.gaps.inner, 5, "a 1024 point gap keeps the default")
+    t.equal(hex.warnings.contains { $0.contains("general.gaps_in") }, true, "and says so")
+
+    let negative = try Config.parse("[border]\nwidth = -5\n")
+    t.equal(negative.border.width, 2, "a negative border width keeps the default")
+    t.equal(negative.warnings.contains { $0.contains("border.width") }, true, "and says so")
+
+    let radius = try Config.parse("[border]\nradius = -2\n")
+    t.equal(radius.border.radius, -1, "-1 is the only negative radius, so -2 keeps the default")
+    t.equal(radius.warnings.contains { $0.contains("border.radius") }, true, "and says so")
+
+    let ratio = try Config.parse("[dwindle]\ndefault_split_ratio = 5\n")
+    t.equal(ratio.dwindle.defaultSplitRatio, 1.0, "a ratio past the clamp keeps the default")
+    t.equal(ratio.warnings.contains { $0.contains("dwindle.default_split_ratio") }, true, "and says so")
+}
+
+h.test("numbers in range are still read, and warn about nothing") { t in
+    let c = try Config.parse("""
+    [general]
+    gaps_in = 12
+    gaps_out = 24
+    [border]
+    width = 3
+    angle = 90
+    radius = 8
+    [dwindle]
+    split_width_multiplier = 1.5
+    default_split_ratio = 1.2
+    """)
+    t.equal(c.gaps, Gaps(inner: 12, outer: 24), "gaps are read")
+    t.equal(c.border.width, 3, "border width is read")
+    t.equal(c.border.angle, 90, "border angle is read")
+    t.equal(c.border.radius, 8, "border radius is read")
+    t.equal(c.dwindle.splitWidthMultiplier, 1.5, "split_width_multiplier is read")
+    t.equal(c.dwindle.defaultSplitRatio, 1.2, "default_split_ratio is read")
+    t.equal(c.warnings, [], "no warnings")
+}
+
+h.test("a float where an integer was wanted cannot trap") { t in
+    // TOMLValue.intValue truncates a float, and Int(_: Double) traps on a NaN, an infinity
+    // or anything past Int's range. Reaching this line at all is the assertion.
+    let c = try Config.parse("[dwindle]\nforce_split = nan\nsplit_bias = 1e400\n[bar]\npersistent_workspaces = inf\n")
+    t.equal(c.dwindle.forceSplit, 2, "force_split = nan keeps the default")
+    t.equal(c.dwindle.splitBias, 0, "split_bias = 1e400 keeps the default")
+    t.equal(c.bar.persistentWorkspaces, 5, "persistent_workspaces = inf keeps the default")
+
+    let truncated = try Config.parse("[dwindle]\nforce_split = 1.7\n")
+    t.equal(truncated.dwindle.forceSplit, 1, "an ordinary float still truncates toward zero")
+}
+
 h.test("a negative radius survives the TOML parser") { t in
     let c = try Config.parse("[border]\nradius = -1\n")
     t.equal(c.border.radius, -1, "radius = -1")


### PR DESCRIPTION
Closes #17.

TOML spells `nan` and `inf`, and Swift's `Double(_: String)` takes both as readily as it takes `0x1p10`. `[bar]` and `[floating]` were range-checked; `[general]`, `[border]` and `[dwindle]` were not, so `gaps_in = nan` parsed with no warning at all.

### Why it matters

A NaN gap reaches `plan.frames` as a NaN coordinate, and three things go wrong at once:

1. **Change detection is defeated.** `Box` is `Equatable`, so `desired[id] != box` is always true against a NaN — every window is re-written on every render, forever.
2. **The correction budget never resets.** `settled()` compares with `abs(a.x - b.x) < 2`, false for the same reason, so the three-strike budget is burned continuously.
3. **NaN geometry is written into other applications** over Accessibility, from where the border overlay reads it back into `NSWindow.setFrame` — which traps on it.

`TOMLValue.intValue` had a shorter path to the same place. It truncates a float with `Int(_: Double)`, which traps on a NaN, an infinity, or anything past `Int`'s range, so `persistent_workspaces = inf` was an immediate crash:

```
Fatal error: Double value cannot be converted to Int because it is either infinite or NaN
```

That is the unfixed parser running the new suite — the test reproduces the crash before the guard, and the guard turns it into a value that is simply not usable, like a string.

### The fix

One helper, `Config.number`, does what `[floating]` already did: reject a value that is not finite or falls outside a range, append a warning, and keep the current one. It now covers `general.gaps_in`, `general.gaps_out`, `border.width`, `border.angle`, `border.radius`, `dwindle.split_width_multiplier` and `dwindle.default_split_ratio`.

The ranges are the ones the code already implies:

| Key | Range | Why |
| --- | --- | --- |
| `general.gaps_in` / `gaps_out` | 0 … 500 | Gaps are not negative; 500 is well past any real display |
| `border.width` | 0 … 100 | `-5` used to parse, and only survived because `nan > 0` and `-5 > 0` both happen to be false in `show()` |
| `border.angle` | 0 … 360 | Degrees |
| `border.radius` | -1 … 100 | -1 is the documented "follow the window's own corner radius", and is the only negative admitted: every other one means the same thing, and accepting them all would make a typo indistinguishable from a choice |
| `dwindle.split_width_multiplier` | 0.1 … 10 | |
| `dwindle.default_split_ratio` | 0.1 … 1.9 | Exactly the clamp the layout applies on use, so an out-of-range value is named here rather than silently becoming a different one later |

The range check also catches `0x1p10` — a hex float, which TOML has no notion of and which used to parse silently as a 1024 point gap. It is now a 1024 point gap that is out of range and says so. Left in the parser rather than rejected there, since TOML 1.0 genuinely does define `nan` and `inf` literals; the config layer is where "is this a usable number for *this* setting" belongs.

### Testing

`swift run -c debug toe-selftest` — 397 assertions pass, up from 357.

Four new tests, verified to fail without the fix: 29 failures with the `intValue` guard in place, and an outright trap without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184PPAns5xQzE1hTKwcGN1L