### PR TITLE
Say that the config runs shell commands, and create it 0600

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,20 @@ separate `homebrew-toe` one. `brew upgrade --cask toe` picks up new releases.
 Grant **System Settings → Privacy & Security → Accessibility** when asked. That single
 permission is all toe needs.
 
+### Treat your config as code
+
+`~/.config/toe/toe.toml` is not merely settings. An `exec` binding runs `/bin/sh -c` with
+whatever the file says, toe reloads the file about 150 ms after it changes, and it does so
+inside a long-running login agent holding the Accessibility grant you just gave. That is by
+design — it is Hyprland's `exec` dispatcher, and it is what `SUPER`+`RETURN` opening a terminal
+is built on — but the consequence is worth saying plainly: **anything that can write that file
+can run commands as you, with no prompt.** Give it the same care you would a shell profile.
+
+toe creates the directory `0700` and the file `0600` on first run, so nothing else on the
+machine can write it by default. If the file is later found writable by other users, or owned
+by someone else, the menu bar item says so. Symlinking it into a dotfiles repository still
+works, and is checked at the far end of the link.
+
 ### From source
 
 ```sh
@@ -251,7 +265,8 @@ rules.
 opens it in nano, in a Terminal.app window; bind `exec` with your own terminal instead if you
 would rather. If it fails to parse, the running config is kept and the error is named in the
 menu bar item's tooltip — a typo can never leave you without a keyboard. See
-[`toe.example.toml`](toe.example.toml).
+[`toe.example.toml`](toe.example.toml), and
+[Treat your config as code](#treat-your-config-as-code) for what an `exec` binding can do.
 
 Binding specs parse in both spellings, so you can paste from an AeroSpace config or an Omarchy
 one: `"alt-shift-1"`, `"super+shift+1"` and `"SUPER SHIFT, 1"` are the same binding.

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -10,6 +10,10 @@ let defaultConfigText = #"""
 # Reloads automatically when you save. If a line does not parse, the running config is kept
 # and the error is named in the menu bar item's tooltip, so a typo can never leave you
 # keyboardless. SUPER+, opens this file in nano.
+#
+# This file is code, not just settings: an `exec` binding below runs a shell command, and toe
+# picks up a change within about 150 ms of the save. Anything that can write this file can run
+# commands as you. It is created mode 600 for that reason — keep it that way.
 
 [general]
 # Omarchy's SUPER maps to Option: same physical key position as SUPER on a PC keyboard, and

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -148,12 +148,63 @@ final class Coordinator: WindowTrackerDelegate {
 
     // MARK: - Config
 
+    /// Writes the shipped default on first run, for this user only.
+    ///
+    /// This file is executable code, not merely settings: an `exec` binding runs `/bin/sh -c`
+    /// with whatever it says, about 150 ms after it changes, inside a login agent holding the
+    /// Accessibility grant. So the mode is set here rather than inherited from whatever umask
+    /// happens to be in effect, and a failure is named rather than swallowed — a first run
+    /// that could not write its config used to behave exactly like one that had, leaving you
+    /// looking for a file that was never created.
     private func writeDefaultConfigIfMissing() {
         let url = Coordinator.configURL
         guard !FileManager.default.fileExists(atPath: url.path) else { return }
-        try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
-                                                 withIntermediateDirectories: true)
-        try? Config.defaultTOML.write(to: url, atomically: true, encoding: .utf8)
+
+        do {
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                                    withIntermediateDirectories: true,
+                                                    attributes: [.posixPermissions: 0o700])
+        } catch {
+            Log.error("could not create \(url.deletingLastPathComponent().path): \(error.localizedDescription)")
+            return
+        }
+
+        // open with O_EXCL rather than a write through FileManager, for two reasons: it
+        // refuses rather than following a symlink already sitting at that path, and it is one
+        // call that both creates the file and fixes its mode, so the file never exists at the
+        // umask's mode even briefly.
+        let fd = open(url.path, O_WRONLY | O_CREAT | O_EXCL, 0o600)
+        guard fd >= 0 else {
+            Log.error("could not create \(url.path): \(String(cString: strerror(errno)))")
+            return
+        }
+        defer { close(fd) }
+
+        let bytes = Data(Config.defaultTOML.utf8)
+        let written = bytes.withUnsafeBytes { write(fd, $0.baseAddress, $0.count) }
+        if written != bytes.count {
+            Log.error("could not write \(url.path): \(String(cString: strerror(errno)))")
+        }
+    }
+
+    /// Names a config file that other people can rewrite, or that belongs to someone else.
+    ///
+    /// A warning and not a refusal: symlinking this file into a dotfiles repository is how a
+    /// good many people manage it, and refusing to load a symlink would break every one of
+    /// them. `stat` rather than `lstat` for exactly that reason — what runs is the file at the
+    /// end of the link, so that is the file whose permissions matter.
+    private static func permissionWarning(for url: URL) -> String? {
+        var info = stat()
+        guard stat(url.path, &info) == 0 else { return nil }
+        let name = url.lastPathComponent
+        if info.st_uid != getuid() {
+            return "\(name) belongs to uid \(info.st_uid), not to you — whoever owns it can run commands as you"
+        }
+        if info.st_mode & (S_IWGRP | S_IWOTH) != 0 {
+            let mode = String(info.st_mode & 0o777, radix: 8)
+            return "\(name) is mode \(mode), writable by other users — it runs shell commands, so chmod 600 it"
+        }
+        return nil
     }
 
     private func loadConfig() {
@@ -171,6 +222,9 @@ final class Coordinator: WindowTrackerDelegate {
 
         config = newConfig
         warnings = newConfig.warnings
+        if let warning = Coordinator.permissionWarning(for: Coordinator.configURL) {
+            warnings.append(warning)
+        }
 
         let rejected = hotkeys.register(newConfig.bindings)
         warnings += rejected.map { "\($0.source): already claimed by another app" }

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -3,6 +3,10 @@
 # Reloads automatically when you save. If a line does not parse, the running config is kept
 # and the error is named in the menu bar item's tooltip, so a typo can never leave you
 # keyboardless. SUPER+, opens this file in nano.
+#
+# This file is code, not just settings: an `exec` binding below runs a shell command, and toe
+# picks up a change within about 150 ms of the save. Anything that can write this file can run
+# commands as you. It is created mode 600 for that reason — keep it that way.
 
 [general]
 # Omarchy's SUPER maps to Option: same physical key position as SUPER on a PC keyboard, and


### PR DESCRIPTION
Closes #23.

Anything that can write `~/.config/toe/toe.toml` gets `/bin/sh -c` execution within about 150 ms, with no prompt, inside a long-running login agent holding Accessibility. That is by design — it is Hyprland's `exec` dispatcher — but nothing said so out loud, which is the part that actually matters when users are being asked to grant one of the most powerful TCC permissions on macOS.

### The part that matters

It is now said in two places:

- **README**, immediately after the Accessibility instructions, under its own heading — since that is the moment the grant is being made.
- **The config file's own header**, where the person editing an `exec` binding will actually see it. `toe.example.toml` is regenerated from it.

### The two smaller things

**Explicit modes.** The directory is created `0700` and the file `0600`, rather than at whatever umask is in effect.

**No symlink following on create.** `FileManager.fileExists` follows a symlink, so a dangling one pre-created at that path reported `false` and was then written straight through. `open(O_CREAT | O_EXCL)` refuses it instead, and is a single call that both creates the file and sets its mode, so the file never exists at the umask's mode even briefly. Verified:

```
directory mode: 700
file mode: 600
fileExists follows the dangling link: false
O_EXCL refuses the symlink: true errno 17 File exists
nothing was written through it: true
```

**No more silent failure.** Both writes used `try?`, so a first run that could not write its config behaved exactly like one that had, leaving you looking for a file that was never created. Both now name the failure in the log.

### On refusing symlinked configs

The issue suggested considering a refusal to load a config that is a symlink or is not owned by the current user. This warns instead, and does not refuse: symlinking this file into a dotfiles repository is how a good many people manage it, and refusing symlinks would break every one of them for no gain — the attack the refusal is meant to stop is *writing* the file, which the link's presence says nothing about.

So a config found writable by group or other, or owned by another uid, is reported through the existing warnings channel and shows in the menu bar item. `stat` rather than `lstat`, because what runs is the file at the far end of the link, so that is the file whose permissions matter. Verified:

```
600 warns: (no warning)
644 warns: (no warning)
664 warns: toe.toml is mode 664, writable by other users — it runs shell commands, so chmod 600 it
606 warns: toe.toml is mode 606, writable by other users — it runs shell commands, so chmod 600 it
through a symlink: link-to-bad.toml is mode 666, writable by other users — …
```

`644` is deliberately silent: it is the mode an existing install already has, and it is not a hole.

### Testing

`swift build -c release`, `swift run -c debug toe-selftest` (357 assertions), `./scripts/bundle.sh release` and the `--version` smoke test all pass. The permission and symlink behaviour above was verified against the real filesystem with a standalone probe of the same code, since `Sources/toe` is outside the headless suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184PPAns5xQzE1hTKwcGN1L