### PR TITLE
Send a detached window behind the tiles when it loses the focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,10 @@ by `make test` against hand-computed Hyprland output:
 - Dragging a tiled window swaps it with whichever tile the pointer crosses, live, and keeps
   going for as long as you hold it — Hyprland's `switchWindows` under the pointer, the mouse
   equivalent of `SUPER+SHIFT+arrow`.
-- Directional focus is **edge adjacency**, not nearest-centre: a window qualifies only if its
-  opposing edge lines up with yours within 2px, computed on un-gapped node boxes. Ties go to
-  the most recently focused window.
+- Directional focus between tiles is **edge adjacency**, not nearest-centre: a window qualifies
+  only if its opposing edge lines up with yours within 2px, computed on un-gapped node boxes.
+  Ties go to the most recently focused window. Detached windows are off the grid entirely and
+  are walked as a list — see **Floating windows**.
 
 ## Design notes
 
@@ -250,9 +251,26 @@ so dragging it afterwards sticks: toe writes a
 floating frame only when it actually changes and never re-asserts it, so a floating window is
 never fought the way a tile is. If the display it was last on has been unplugged, it is centred
 on the display that remains rather than clamped against an edge. It is raised when you float it
-and again whenever it is focused, but the Accessibility API offers no persistent always-on-top:
-activate a tiled window afterwards and it can cover the floating one. Floating windows stay
-reachable with `SUPER`+arrows.
+and again whenever it is focused, and it drops behind the tiles it covers the moment the focus
+moves on — so cycling with `SUPER`+arrows never lands you on a tile half-hidden by a window you
+have already left. Hyprland keeps a float above the tiles whatever has the focus; the
+Accessibility API has a raise action and no lower, so the way down is to raise what the float
+covers, and only the tiles it really overlaps are touched. Tiles never overlap each other, so
+re-ordering those among themselves is invisible. Activating an application brings all of its
+windows forward with it, float included, so the stack is checked against the window server
+rather than remembered — a float that comes back up goes straight back down, and one that is
+already at the bottom is left alone. Floating windows stay reachable with
+`SUPER`+arrows, and they are reached as a **list** rather than by where they are. Two of a size
+are centred identically, so they land exactly on top of each other, and no arrow can mean "the
+one underneath this one" — geometry has nothing to say about them. So they are not on the grid
+at all: they are the workspace's detached windows in the order they were opened, and a direction
+with no tile that way lands in that list, at whichever end it arrives from. From there the same
+direction walks along it and the opposite direction walks back, and off either end is the tile
+the focus came in from — so holding one arrow down goes round tile, detached windows, tile, and
+all four directions behave alike. Two detached windows are two presses past the last tile, and
+going back is going out reversed: every step has an exact inverse, which is the thing proximity
+could never give. Tile to tile is untouched by any of this — that is Hyprland's walk, edge
+adjacency and all, and it never answers with a detached window.
 
 **Windows toe leaves alone**: dialogs, sheets, palettes, minimized and natively-fullscreen (see
 **Dock swipes** for the one thing that changes about living in one)

--- a/Sources/ToeCore/Layout/Direction.swift
+++ b/Sources/ToeCore/Layout/Direction.swift
@@ -14,6 +14,12 @@ public enum Direction: String, CaseIterable, Sendable {
         }
     }
 
+    /// Which way a list is walked: right and down go forward through it, left and up back.
+    /// The grid has no use for this — a tree of tiles is not a list — but a workspace's
+    /// detached windows are one, and this is what makes walking it one way the exact inverse
+    /// of walking it the other.
+    public var isForward: Bool { self == .right || self == .down }
+
     public var opposite: Direction {
         switch self {
         case .left: return .right

--- a/Sources/ToeCore/Layout/DirectionalSearch.swift
+++ b/Sources/ToeCore/Layout/DirectionalSearch.swift
@@ -3,6 +3,11 @@ import Foundation
 /// Port of `CCompositor::getWindowInDirection` for tiled windows
 /// (`binds:focus_preferred_method = 0`, Hyprland's default: history tie-break).
 ///
+/// Tiles only. A detached window is not on the grid — `togglefloating` centres it, so its
+/// edges land inside tiles rather than against them, and two of a size land on top of each
+/// other — so `WorkspaceManager` walks those as a list instead of asking geometry a question
+/// it cannot answer.
+///
 /// Two things make this different from every "nearest window" heuristic, and both matter
 /// for matching Hyprland exactly:
 ///
@@ -68,75 +73,5 @@ public enum DirectionalSearch {
         }
 
         return leaderValue != -1 ? leader : nil
-    }
-
-    /// The search floating windows are found with, since they never touch the grid.
-    ///
-    /// `windowInDirection` walks the tiling grid by edge adjacency, and a window floating in
-    /// the middle of the screen sticks to nothing — `togglefloating` centres it, so its edges
-    /// land inside tiles rather than against them. It qualifies here instead: a candidate is
-    /// in `direction` when its centre lies inside the 90° cone opening that way from ours,
-    /// and the nearest centre wins, focus history breaking a tie. The distance comes back
-    /// with the winner so the caller can weigh it against what the grid walk found.
-    ///
-    /// A window stacked right on top of us — a float centred over the single tile it left
-    /// behind, the two centres one point — lies in no direction at all. Rather than strand
-    /// it, it comes back flagged `stacked`, for the caller to use only where nothing else
-    /// answers: it is a last resort, never something that outranks a real neighbour. It is
-    /// exactly that degenerate case, the two centres within `STICKS` of each other, and
-    /// nothing wider: a window merely overlapping ours still lies somewhere, and answering
-    /// with one that sits below and to the left of a press of `up` is worse than not moving.
-    public static func nearestInDirection(
-        from origin: Box,
-        ignoring: WindowID?,
-        candidates: [(id: WindowID, box: Box)],
-        direction: Direction,
-        focusHistory: [WindowID]
-    ) -> (id: WindowID, distance: Double, stacked: Bool)? {
-
-        let a = origin.middle
-        var leader: WindowID?
-        var leaderDistance = Double.infinity
-        var leaderRecency = -1
-        var stacked: WindowID?
-        var stackedRecency = -1
-
-        for candidate in candidates {
-            if let ignoring, candidate.id == ignoring { continue }
-
-            let b = candidate.box.middle
-            let dx = b.x - a.x
-            let dy = b.y - a.y
-            // History is ordered most-recent-first; a window not in it sorts last.
-            let idx = focusHistory.firstIndex(of: candidate.id) ?? focusHistory.count
-            let recency = focusHistory.count - idx
-
-            let along: Double
-            switch direction {
-            case .left:  along = -dx
-            case .right: along = dx
-            case .up:    along = -dy
-            case .down:  along = dy
-            }
-            let across = (direction == .left || direction == .right) ? abs(dy) : abs(dx)
-
-            guard along > 0, along >= across else {
-                if STICKS(dx, 0), STICKS(dy, 0), recency > stackedRecency {
-                    stackedRecency = recency
-                    stacked = candidate.id
-                }
-                continue
-            }
-
-            let distance = (dx * dx + dy * dy).squareRoot()
-            if distance < leaderDistance || (distance == leaderDistance && recency > leaderRecency) {
-                leaderDistance = distance
-                leaderRecency = recency
-                leader = candidate.id
-            }
-        }
-
-        if let leader { return (id: leader, distance: leaderDistance, stacked: false) }
-        return stacked.map { (id: $0, distance: .infinity, stacked: true) }
     }
 }

--- a/Sources/ToeCore/Layout/Stacking.swift
+++ b/Sources/ToeCore/Layout/Stacking.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Where a floating window belongs in the stack, and how to get it there.
+///
+/// Hyprland draws every floating window above the tiles, always. toe cannot: Accessibility
+/// has a raise action and no lower, so the only way to send a window back is to raise what
+/// sits over it. That leaves a rule of its own, and a better one for a keyboard: the float
+/// stays on top while it holds the focus, and goes behind the moment it loses it — so
+/// cycling along the grid with `SUPER`+arrows never lands on a tile half-covered by a window
+/// the user has already moved on from.
+public enum Stacking {
+
+    /// The windows to raise, in the order to raise them — the last one ends up in front.
+    ///
+    /// Empty when nothing has to move, which is every focus change with no unfocused float on
+    /// screen, so the caller leaves the stack alone in the ordinary case.
+    ///
+    /// Only the tiles a float actually covers are raised. Tiles never overlap each other, so
+    /// re-ordering those among themselves is invisible, and leaving the rest where they are
+    /// keeps this to the Accessibility calls the change really needs.
+    ///
+    /// A float already under everything it covers is left alone — which is the answer most of
+    /// the time, and the difference between correcting the stack and churning it. That has to
+    /// be asked of the window server rather than remembered, because toe is not the only thing
+    /// that re-orders windows: activating an application brings its windows forward as a group,
+    /// so focusing a tile can lift a float belonging to the same application right back up.
+    ///
+    /// - Parameters:
+    ///   - tiles: tiled windows on a visible workspace, and the frame each occupies.
+    ///   - floats: floating windows on a visible workspace, and the frame each occupies.
+    ///   - focused: the window that holds the focus, which ends up in front of the lot.
+    ///   - stackedAbove: the windows currently above the given one, asked only about floats
+    ///     that have lost the focus, and only when there are any.
+    public static func raiseOrder(tiles: [WindowID: Box],
+                                  floats: [WindowID: Box],
+                                  focused: WindowID?,
+                                  stackedAbove: (WindowID) -> Set<WindowID> = { _ in [] })
+    -> [WindowID] {
+        let sinking = floats.filter { $0.key != focused }
+        guard !sinking.isEmpty else { return [] }
+
+        var covered: Set<WindowID> = []
+        for (float, frame) in sinking {
+            let over = tiles.filter { overlaps(frame, $0.value) }.keys
+            guard !over.isEmpty else { continue }
+            // Already at the bottom of everything it covers: nothing to do for this one.
+            if over.allSatisfy(stackedAbove(float).contains) { continue }
+            covered.formUnion(over)
+        }
+        guard !covered.isEmpty else { return [] }
+
+        // Sorted only so the order is the same twice running: which tile goes above which
+        // cannot be seen, and a stable answer is what makes this testable.
+        var order = covered.sorted()
+        // The focused window last, whether or not a float covers it. It is the one place in
+        // the stack anybody can see, and raising the tiles under a float would otherwise
+        // bury a focused float along with them.
+        if let focused, tiles[focused] != nil || floats[focused] != nil {
+            order.removeAll { $0 == focused }
+            order.append(focused)
+        }
+        return order
+    }
+
+    /// Overlap worth acting on. Frames that merely share an edge are the tiling grid meeting
+    /// itself, and a sliver of a point is the difference between Accessibility's idea of a
+    /// frame and the window server's — neither is a window covering another one.
+    private static func overlaps(_ a: Box, _ b: Box) -> Bool {
+        let clipped = a.intersection(b)
+        return clipped.w > 1 && clipped.h > 1
+    }
+}

--- a/Sources/ToeCore/Layout/WorkspaceManager.swift
+++ b/Sources/ToeCore/Layout/WorkspaceManager.swift
@@ -52,8 +52,8 @@ public final class WorkspaceManager {
     public private(set) var focusHistory: [WindowID] = []
     /// Previous workspace on the focused monitor, for `workspace previous`.
     private var previousWorkspace: [UInt32: Int] = [:]
-    /// Frames of floating windows, supplied by the app layer so directional search has an
-    /// origin box for them.
+    /// Frames of floating windows, kept current by the app layer so a float stays where the
+    /// user last put it — what `floatingBox` renders, and what the session file remembers.
     public var floatingFrames: [WindowID: Box] = [:]
     /// Where each window is on `togglefloating`'s cycle: 1 is the first floating size, 2 the
     /// larger one, and a window with no entry is either tiled or floating because the app
@@ -240,63 +240,82 @@ public final class WorkspaceManager {
     // MARK: - Commands
 
     /// `movefocus <dir>` — returns the window that should receive focus.
+    ///
+    /// Two different searches, because a workspace holds two different kinds of window.
+    ///
+    /// Tiles are laid out in space, and the walk between them is Hyprland's exactly: edge
+    /// adjacency, most recently focused breaking a tie, crossing monitors.
+    ///
+    /// Detached windows are not in that space at all. `togglefloating` centres every one of
+    /// them, so two of a size land exactly on top of each other and no arrow can mean "the one
+    /// underneath this one" — geometry has nothing left to say about them. They are a list
+    /// instead, in a stable order, walked forward and back, which is reversible by
+    /// construction: whatever a direction does, its opposite undoes.
+    ///
+    /// The two meet at the edge of the grid. A direction with no tile that way lands in the
+    /// list, at whichever end it arrives from, and walking off either end of the list returns
+    /// to the tile the focus came from — so holding down one arrow goes round tile, list,
+    /// tile, and every direction behaves the same way.
     public func windowInDirection(_ dir: Direction, from id: WindowID? = nil) -> WindowID? {
         guard let source = id ?? focusedWindow,
               let index = workspaceIndex(of: source),
-              let ws = workspaces[index],
-              let origin = ws.layout.idealBox(of: source) ?? floatingFrames[source]
+              let ws = workspaces[index]
         else { return nil }
 
-        // Candidates: every window on a *visible* workspace, floating ones included — a
-        // floated window you cannot focus again is a window you have lost. Hyprland's
-        // `window_direction_monitor_fallback` defaults to true, so focus crosses monitors.
+        if ws.floating.contains(source) { return stepThroughDetached(on: ws, from: source, dir) }
+
+        guard let origin = ws.layout.idealBox(of: source) else { return nil }
+
+        // Every tile on a *visible* workspace, and only tiles: Hyprland's
+        // `window_direction_monitor_fallback` defaults to true, so the walk crosses monitors.
         var candidates: [(id: WindowID, box: Box)] = []
-        var floatingCandidates: [(id: WindowID, box: Box)] = []
         for wsIndex in visibleWorkspaceIndices {
             guard let w = workspaces[wsIndex] else { continue }
             candidates.append(contentsOf: w.layout.idealBoxes())
-            for id in w.floating {
-                if let box = floatingFrames[id] { floatingCandidates.append((id: id, box: box)) }
-            }
         }
-        candidates.append(contentsOf: floatingCandidates)
 
-        let onTheGrid = DirectionalSearch.windowInDirection(
+        if let onTheGrid = DirectionalSearch.windowInDirection(
             from: origin,
             ignoring: source,
             candidates: candidates,
             direction: dir,
             focusHistory: focusHistory
-        )
+        ) { return onTheGrid }
 
-        // A floating window is off the grid: `togglefloating` centres it, so its edges land
-        // inside tiles instead of against them and edge adjacency never names it. Left at
-        // that, a detached window is one only the mouse can get back to. So it competes on
-        // proximity instead, and the nearer centre wins — a window floating between two
-        // tiles is a stop on the way across, not a window you have to step over. Tile to
-        // tile stays exactly Hyprland's grid walk; only a floating window takes this route,
-        // in either role.
-        let sourceIsFloating = ws.floating.contains(source)
-        let nearby = DirectionalSearch.nearestInDirection(
-            from: origin,
-            ignoring: source,
-            candidates: sourceIsFloating ? candidates : floatingCandidates,
-            direction: dir,
-            focusHistory: focusHistory
-        )
+        // Nothing that way on the grid. What lies past its edge is this workspace's detached
+        // windows: one you cannot reach with the keyboard is one you have lost.
+        let detached = detachedList(on: ws)
+        return dir.isForward ? detached.first : detached.last
+    }
 
-        guard let nearby else { return onTheGrid }
-        // A window merely stacked over us lies in no direction; it answers only where the
-        // grid has nothing, so that a float centred over the one tile it left behind is
-        // still a keypress away.
-        guard !nearby.stacked else { return onTheGrid ?? nearby.id }
-        guard let onTheGrid, onTheGrid != nearby.id,
-              let box = candidates.first(where: { $0.id == onTheGrid })?.box
-        else { return nearby.id }
+    /// The workspace's detached windows, in a stable order.
+    ///
+    /// By window id, which is the order they were opened in. It needs no bookkeeping of its
+    /// own, it survives a restart — the session file already sorts them the same way — and a
+    /// window keeps its place in it when another is floated or tiled. A list that reshuffled
+    /// under the focus would be no better than the geometry it replaces.
+    private func detachedList(on ws: Workspace) -> [WindowID] { ws.floating.sorted() }
 
-        let dx = box.middle.x - origin.middle.x
-        let dy = box.middle.y - origin.middle.y
-        return (dx * dx + dy * dy).squareRoot() <= nearby.distance ? onTheGrid : nearby.id
+    /// One step along that list.
+    ///
+    /// Off either end is the way back to the tiles, rather than the dead stop the edge of the
+    /// grid is: a list hanging off one tile has no far side to be stranded on, and stopping
+    /// there made the two directions behave differently for no reason the user could see.
+    private func stepThroughDetached(on ws: Workspace,
+                                     from source: WindowID,
+                                     _ dir: Direction) -> WindowID? {
+        let list = detachedList(on: ws)
+        guard let here = list.firstIndex(of: source) else { return nil }
+        let next = dir.isForward ? here + 1 : here - 1
+        guard list.indices.contains(next) else { return tileToComeBackTo(on: ws) }
+        return list[next]
+    }
+
+    /// Where leaving the list puts the focus: the tile it came in from. With nothing in the
+    /// history to go back to — a workspace whose tiles have never held the focus — the first
+    /// tile on it, rather than nowhere.
+    private func tileToComeBackTo(on ws: Workspace) -> WindowID? {
+        focusHistory.first { ws.layout.contains($0) } ?? ws.layout.windowIDs.first
     }
 
     /// `swapwindow <dir>` — exchange the focused window with its neighbour, leaving the

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -499,70 +499,94 @@ h.test("a floating window is not a letterbox on an ultrawide") { t in
     t.equalBox(wm.render().floating[2], box(768, 141, 3584, 1128), "uncapped, it is the full 70%")
 }
 
-h.test("movefocus reaches a floating window") { t in
+/// Two tiles side by side and two detached windows, exactly on top of each other and of
+/// different sizes — the arrangement geometry could never separate.
+private func listWorkspace() -> WorkspaceManager {
     let wm = WorkspaceManager()
     wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
-    wm.addWindow(1); wm.addWindow(2)                 // left half / right half
+    wm.addWindow(1); wm.addWindow(2)                    // left half | right half
+    wm.addWindow(3, floating: true); wm.addWindow(4, floating: true)
+    wm.floatingFrames[3] = box(227, 98, 1058, 786)
+    wm.floatingFrames[4] = box(151, 49, 1211, 885)      // over w3, larger, centres half a point apart
+    wm.noteFocus(1)
+    return wm
+}
+
+h.test("detached windows are a list past the edge of the grid") { t in
+    let wm = listWorkspace()
+
+    t.equal(wm.windowInDirection(.right), 2, "the grid first: w2 is the tile to w1's right")
+    wm.noteFocus(2)
+    t.equal(wm.windowInDirection(.right), 3, "nothing to w2's right on the grid, so the list")
+    wm.noteFocus(3)
+    t.equal(wm.windowInDirection(.right), 4, "then the next detached window, whatever it looks like")
+    wm.noteFocus(4)
+    t.equal(wm.windowInDirection(.right), 2,
+            "and off the end is back to the tile it came from, so one arrow held down goes round")
+    wm.noteFocus(2)
+    t.equal(wm.windowInDirection(.right), 3, "round again")
+}
+
+h.test("walking the list back is walking it forward, reversed") { t in
+    let wm = listWorkspace()
+    wm.noteFocus(2); wm.noteFocus(3); wm.noteFocus(4)   // out along the list
+
+    t.equal(wm.windowInDirection(.left), 3, "back down the list")
+    wm.noteFocus(3)
+    t.equal(wm.windowInDirection(.left), 2, "and out of it, to the tile the focus came from")
+    wm.noteFocus(2)
+    t.equal(wm.windowInDirection(.left), 1, "the grid again from there")
+}
+
+h.test("the list is entered from whichever end the direction arrives at") { t in
+    let wm = listWorkspace()
+
+    t.equal(wm.windowInDirection(.left), 4,
+            "nothing to the left of the leftmost tile, so the list, from its far end")
+    t.equal(wm.windowInDirection(.up), 4, "up is the same walk backwards; down and right forwards")
+    wm.noteFocus(4)
+    t.equal(wm.windowInDirection(.left), 3, "carrying on the same way")
+    wm.noteFocus(3)
+    t.equal(wm.windowInDirection(.left), 1, "and out where it came in")
+}
+
+h.test("the list is the same walk wherever the detached windows are") { t in
+    let wm = listWorkspace()
+    // Nothing about the geometry is load-bearing any more: put them in opposite corners and
+    // the walk is unchanged, because the order is the order they were opened in.
+    wm.floatingFrames[3] = box(1312, 782, 200, 200)     // bottom right
+    wm.floatingFrames[4] = box(0, 0, 200, 200)          // top left
+    wm.noteFocus(2)
+
+    t.equal(wm.windowInDirection(.right), 3, "the first of the list, though it is the further away")
+    wm.noteFocus(3)
+    t.equal(wm.windowInDirection(.right), 4, "and on to the second")
+    wm.noteFocus(4)
+    t.equal(wm.windowInDirection(.left), 3, "the way back is the same list")
+}
+
+h.test("a detached window is never a step on the grid") { t in
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
+    wm.addWindow(1); wm.addWindow(2)
     wm.addWindow(3, floating: true)
     wm.floatingFrames[3] = box(756, 0, 400, 300)     // over w2, sharing w1's right edge
-    wm.noteFocus(1)
-
-    t.equal(wm.windowInDirection(.right), 3,
-            "w2 and the floating w3 both abut w1; the more recently focused w3 wins")
-    t.equal(wm.windowInDirection(.left, from: 3), 1, "and it hands focus back")
-}
-
-h.test("movefocus reaches a window togglefloating detached from the grid") { t in
-    let wm = WorkspaceManager()
-    wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
-    wm.addWindow(1); wm.addWindow(2); wm.addWindow(3)
-    wm.noteFocus(3)
-    wm.toggleFloating(3)                    // super+t: w3 leaves the tree, centred over w1|w2
-
-    t.equal(wm.isFloating(3), true, "w3 floats")
-    t.equal(wm.windowInDirection(.right, from: 1), 3,
-            "w3 is centred between the two tiles, so it is what lies to w1's right")
-    t.equal(wm.windowInDirection(.left, from: 2), 3, "and to w2's left")
-    t.equal(wm.windowInDirection(.left, from: 3), 1, "from the float, the grid is reachable again")
-    t.equal(wm.windowInDirection(.right, from: 3), 2, "in both directions")
-}
-
-h.test("movefocus reaches a floating window stacked over the only tile left") { t in
-    let wm = WorkspaceManager()
-    wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
-    wm.addWindow(1); wm.addWindow(2)
-    wm.noteFocus(2)
-    wm.toggleFloating(2)                    // w1 now fills the display, w2 floats over it
+    wm.noteFocus(3)                                  // and the most recently focused window
 
     t.equal(wm.windowInDirection(.right, from: 1), 2,
-            "the two centres are one point, so no direction holds w2 — it answers anyway")
-    t.equal(wm.windowInDirection(.left, from: 2), 1, "and hands focus back")
+            "w3 abuts w1 and was focused more recently, and is still not a step: the grid is tiles")
+    t.equal(wm.windowInDirection(.right, from: 2), 3, "it is past the edge of the grid instead")
+    t.equal(wm.windowInDirection(.left, from: 3), 2, "and hands the focus back to the tile it came from")
 }
 
-h.test("a floating window overlapping a tile is not a direction of its own") { t in
+h.test("a workspace of nothing but detached windows still walks") { t in
     let wm = WorkspaceManager()
     wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
-    wm.addWindow(1); wm.addWindow(2); wm.addWindow(3); wm.addWindow(4)
-    wm.noteFocus(4)
-    wm.toggleFloating(4)                    // 70%x80%, centred: it covers all three tiles' centres
+    wm.addWindow(1, floating: true); wm.addWindow(2, floating: true)
 
-    t.equal(wm.windowInDirection(.up, from: 2), nil,
-            "w4's centre is below w2's and to the left; covering w2 does not put it above")
-    t.equal(wm.windowInDirection(.right, from: 2), nil, "nor to its right")
-    t.equal(wm.windowInDirection(.left, from: 2), 4, "it is where it actually is")
-}
-
-h.test("a floating window never outranks the tile a grid step points at") { t in
-    let wm = WorkspaceManager()
-    wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
-    wm.addWindow(1); wm.addWindow(2)
-    wm.addWindow(3, floating: true)
-    wm.floatingFrames[3] = box(1300, 391, 200, 200)   // tucked against the right edge
-    wm.noteFocus(3)
-
-    t.equal(wm.windowInDirection(.right, from: 1), 2,
-            "w2's centre is nearer than the float's, recent focus notwithstanding")
-    t.equal(wm.windowInDirection(.right, from: 2), 3, "past the last tile, the float is there")
+    t.equal(wm.windowInDirection(.right, from: 1), 2, "the list is the whole workspace")
+    t.equal(wm.windowInDirection(.left, from: 1), nil, "with no tile to come back out to")
+    t.equal(wm.windowInDirection(.right, from: 2), nil, "at either end of it")
 }
 
 h.test("a floating window keeps its frame across a workspace round trip") { t in
@@ -630,6 +654,68 @@ h.test("a workspace follows its monitor") { t in
     // And coming back to workspace 5 returns to its own monitor.
     wm.switchTo(workspace: 5)
     t.equal(wm.focusedMonitorID, home, "workspace 5 pulled focus back to its monitor")
+}
+
+// MARK: - Stacking
+
+h.test("an unfocused float is sunk under the tiles it covers") { t in
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
+    wm.addWindow(1); wm.addWindow(2)        // left half / right half
+    wm.addWindow(3); wm.noteFocus(3)
+    wm.toggleFloating(3)                    // w3 floats, centred over both halves
+    let plan = wm.render()
+
+    // Focus on the float: it is the window in hand, and nothing moves.
+    t.equal(Stacking.raiseOrder(tiles: plan.frames, floats: plan.floating, focused: 3), [],
+            "the focused float stays where it is")
+
+    // Focus moves to a tile: both halves come up over the float, the focused one last.
+    wm.noteFocus(1)
+    t.equal(Stacking.raiseOrder(tiles: plan.frames, floats: plan.floating, focused: 1), [2, 1],
+            "the tiles it covers are raised, and the focused tile ends up in front")
+    wm.noteFocus(2)
+    t.equal(Stacking.raiseOrder(tiles: plan.frames, floats: plan.floating, focused: 2), [1, 2],
+            "and the other way round when the focus is on w2")
+}
+
+h.test("stacking leaves alone what a float does not cover") { t in
+    let tiles: [WindowID: Box] = [1: box(0, 0, 756, 982), 2: box(756, 0, 756, 982)]
+
+    t.equal(Stacking.raiseOrder(tiles: tiles, floats: [:], focused: 1), [],
+            "no float, nothing to raise")
+    t.equal(Stacking.raiseOrder(tiles: tiles, floats: [3: box(0, 0, 400, 300)], focused: 1),
+            [1], "a float over one tile only raises that tile")
+    t.equal(Stacking.raiseOrder(tiles: tiles, floats: [3: box(1600, 0, 400, 300)], focused: 1),
+            [], "a float over no tile at all — another monitor — raises nothing")
+    t.equal(Stacking.raiseOrder(tiles: tiles, floats: [3: box(756, 0, 0, 982)], focused: 1),
+            [], "sharing an edge with a tile is not covering it")
+}
+
+h.test("a float already at the bottom asks for no raises") { t in
+    let tiles: [WindowID: Box] = [1: box(0, 0, 756, 982), 2: box(756, 0, 756, 982)]
+    let floats: [WindowID: Box] = [3: box(200, 100, 1000, 700)]   // over both halves
+
+    t.equal(Stacking.raiseOrder(tiles: tiles, floats: floats, focused: 1,
+                                stackedAbove: { _ in [1, 2] }), [],
+            "both tiles are already above the float, so the stack is left alone")
+    t.equal(Stacking.raiseOrder(tiles: tiles, floats: floats, focused: 1,
+                                stackedAbove: { _ in [2] }), [2, 1],
+            "w1 has come back up over the float — activating its app brings its windows with "
+            + "it — so both are raised again")
+    t.equal(Stacking.raiseOrder(tiles: tiles, floats: floats, focused: 1,
+                                stackedAbove: { _ in [1, 2, 99] }), [],
+            "a window toe knows nothing about, above the float, changes none of this")
+}
+
+h.test("a focused float is raised back over the tiles under a second one") { t in
+    let tiles: [WindowID: Box] = [1: box(0, 0, 1512, 982)]
+    let floats: [WindowID: Box] = [2: box(100, 100, 600, 400), 3: box(400, 300, 600, 400)]
+
+    t.equal(Stacking.raiseOrder(tiles: tiles, floats: floats, focused: 2), [1, 2],
+            "w3 sinks under the tile, and the focused w2 is raised over it again")
+    t.equal(Stacking.raiseOrder(tiles: tiles, floats: floats, focused: nil), [1],
+            "with nothing focused the tile is simply lifted over both floats")
 }
 
 // MARK: - Dragging

--- a/Sources/toe/AX/WindowMover.swift
+++ b/Sources/toe/AX/WindowMover.swift
@@ -41,8 +41,15 @@ enum WindowMover {
     static func focus(_ window: ManagedWindow) {
         window.element.set(kAXMainAttribute, kCFBooleanTrue)
         window.element.set(kAXFocusedAttribute, kCFBooleanTrue)
-        AXUIElementPerformAction(window.element, kAXRaiseAction as CFString)
+        raise(window)
         NSRunningApplication(processIdentifier: window.pid)?.activate()
+    }
+
+    /// Stacking only: no `kAXMain`, no `kAXFocused`, no activation. Raising a window does not
+    /// make its application the active one, which is what lets toe lift a tile over a float
+    /// belonging to some other app without taking the focus off either of them.
+    static func raise(_ window: ManagedWindow) {
+        AXUIElementPerformAction(window.element, kAXRaiseAction as CFString)
     }
 
     static func close(_ window: ManagedWindow) {

--- a/Sources/toe/AX/WindowStack.swift
+++ b/Sources/toe/AX/WindowStack.swift
@@ -4,8 +4,8 @@ import ToeCore
 
 /// The window server's stacking order, which Accessibility does not expose at all.
 ///
-/// Reads `kCGWindowBounds`, `kCGWindowLayer`, `kCGWindowOwnerPID` and `kCGWindowAlpha`, and
-/// nothing else. `kCGWindowName` would need Screen Recording; Accessibility is the one
+/// Reads `kCGWindowNumber`, `kCGWindowBounds`, `kCGWindowLayer`, `kCGWindowOwnerPID` and
+/// `kCGWindowAlpha`, and nothing else. `kCGWindowName` would need Screen Recording; Accessibility is the one
 /// permission toe asks for, so the window list is read for geometry and never for content.
 enum WindowStack {
 
@@ -16,28 +16,41 @@ enum WindowStack {
     /// `.floating`: change one and change the other.
     private static let levels = 0...Int(CGWindowLevelForKey(.floatingWindow))
 
-    /// Ordinary windows stacked above `id`, in Accessibility coordinates.
+    /// The ordinary windows stacked above `id`.
     ///
     /// Empty when the window is not on screen — a stale id, another Space, a window on its way
     /// out — which reads as "nothing is covering it". That is the right way to fail: the
     /// fallback is the behaviour toe has always had, not a new one.
-    static func ordinaryWindowsAbove(_ id: WindowID) -> [Box] {
+    private static func infoForWindowsAbove(_ id: WindowID) -> [[String: Any]] {
         let options: CGWindowListOption = [.optionOnScreenAboveWindow, .excludeDesktopElements]
         guard let list = CGWindowListCopyWindowInfo(options, id) as? [[String: Any]] else {
             return []
         }
         let ownPID = Int(ProcessInfo.processInfo.processIdentifier)
 
-        return list.compactMap { info in
+        return list.filter { info in
             // toe's own border panel is above the focused window by construction, so without
             // this the border would demote itself every single time, in every case.
-            guard info[kCGWindowOwnerPID as String] as? Int != ownPID else { return nil }
+            guard info[kCGWindowOwnerPID as String] as? Int != ownPID else { return false }
             guard let layer = info[kCGWindowLayer as String] as? Int,
                   levels.contains(layer)
-            else { return nil }
+            else { return false }
             // Apps keep invisible helper windows around; one of those covering the band is not
             // something anyone can see.
-            if let alpha = info[kCGWindowAlpha as String] as? Double, alpha < 0.01 { return nil }
+            if let alpha = info[kCGWindowAlpha as String] as? Double, alpha < 0.01 { return false }
+            return true
+        }
+    }
+
+    /// The ids of the windows above `id`. This is how toe knows whether a float it has already
+    /// sunk is still down there, so a stack that is right is left alone rather than re-raised.
+    static func windowsAbove(_ id: WindowID) -> Set<WindowID> {
+        Set(infoForWindowsAbove(id).compactMap { $0[kCGWindowNumber as String] as? WindowID })
+    }
+
+    /// The same windows as frames, in Accessibility coordinates.
+    static func ordinaryWindowsAbove(_ id: WindowID) -> [Box] {
+        infoForWindowsAbove(id).compactMap { info in
             guard let bounds = info[kCGWindowBounds as String] as? NSDictionary,
                   let rect = CGRect(dictionaryRepresentation: bounds as CFDictionary),
                   rect.width > 1, rect.height > 1

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -33,6 +33,18 @@ final class Coordinator: WindowTrackerDelegate {
     /// than fought with forever.
     private var corrections: [WindowID: Int] = [:]
     private var focusApplied: WindowID?
+    /// Windows toe raised itself, and when — see `isEchoOfOwnRaise`.
+    private var selfRaised: [WindowID: TimeInterval] = [:]
+    /// How long a focus notification can still be the echo of one of those raises.
+    ///
+    /// Generous, because the cost of getting this wrong runs the two ways round very
+    /// differently. An echo let through is recorded as a focus change that never happened, and
+    /// toe then works from a window the user is not on — `movefocus` walks from the wrong
+    /// place, and the border sits on the wrong window until something corrects it. A click let
+    /// through late is one focus change toe hears about a beat later than it might have.
+    /// Applications answer a raise in milliseconds when they are idle and take their time when
+    /// they are not, so this is set for the slow ones.
+    private static let raiseEchoWindow: TimeInterval = 1.2
     /// True from the moment a snapshot is restored until the windows it named have had their
     /// chance to turn up. Saving is suspended meanwhile: a snapshot taken halfway through
     /// adoption would record a layout missing most of its windows, over the top of the good
@@ -378,9 +390,12 @@ final class Coordinator: WindowTrackerDelegate {
     }
 
     func windowFocused(_ id: WindowID) {
-        guard workspaces.workspaceIndex(of: id) != nil else { return }
+        guard workspaces.workspaceIndex(of: id) != nil, !isEchoOfOwnRaise(id) else { return }
         workspaces.noteFocus(id)
         focusApplied = id
+        // Clicking a window raises it, so the focused one is already in front and stays there;
+        // this is only about the float it has just taken the focus from.
+        sinkUnfocusedFloats(workspaces.render())
         updateBorder()
         refreshStatus()
         scheduleSessionSave()
@@ -441,6 +456,11 @@ final class Coordinator: WindowTrackerDelegate {
     /// Nothing about the layout has changed — only what is stacked over the focused window,
     /// which is what decides whether the border can sit above everything.
     func windowStackChanged() {
+        // Somebody else has re-ordered the stack — most often an application coming forward,
+        // which brings all of its windows with it, float included. That is the one thing toe
+        // cannot predict from its own state, so the floats are put back down from what the
+        // window server says is up there now, before the border is asked where it belongs.
+        sinkUnfocusedFloats(workspaces.render())
         updateBorder()
     }
 
@@ -482,6 +502,8 @@ final class Coordinator: WindowTrackerDelegate {
             if id == draggedWindow { continue }
             WindowMover.setFrame(box, element: window.element, pid: window.pid)
         }
+
+        sinkUnfocusedFloats(plan)
 
         if refocus, let target = plan.focus, target != focusApplied,
            let window = tracker.window(target) {
@@ -541,6 +563,61 @@ final class Coordinator: WindowTrackerDelegate {
         let above = WindowStack.ordinaryWindowsAbove(id)
         return BorderGeometry.bandIsCovered(window: box, width: config.border.width, by: above)
             ? .behindFrontmost : .aboveEverything
+    }
+
+    /// Sends every floating window that has lost the focus behind the tiles it covers.
+    ///
+    /// `togglefloating` raises a float, and focusing it raises it again — right while it is the
+    /// window in hand, wrong the moment the focus moves on, because the float was then left
+    /// sitting over half of whichever tile the focus had moved to. Accessibility has no lower
+    /// action, so the way down is to raise what the float covers; see `Stacking.raiseOrder`,
+    /// which works out the shortest set of raises that gets there.
+    ///
+    /// Not while a window is being dragged: the stack the user is looking at then is one they
+    /// are making themselves, and the drag ends in an `apply` that settles it anyway.
+    private func sinkUnfocusedFloats(_ plan: RenderPlan) {
+        guard draggedWindow == nil else { return }
+        // One focus change reaches this several ways over — the command, the notification the
+        // application sends back, the render that follows — so the order is worked out against
+        // the stack as it really is, and a float already at the bottom asks for no raises at
+        // all. Without that, the repeats are what the user sees as flicker.
+        let order = Stacking.raiseOrder(tiles: plan.frames,
+                                        floats: plan.floating,
+                                        focused: workspaces.focusedWindow,
+                                        stackedAbove: WindowStack.windowsAbove)
+        guard !order.isEmpty else { return }
+
+        let now = ProcessInfo.processInfo.systemUptime
+        selfRaised = selfRaised.filter { now - $0.value < Self.raiseEchoWindow }
+        for id in order {
+            guard let window = tracker.window(id), !window.isStashed else { continue }
+            selfRaised[id] = now
+            WindowMover.raise(window)
+        }
+    }
+
+    /// Whether a focus notification is toe's own restacking coming back at it.
+    ///
+    /// Raising a window makes it its application's focused window, and the notification that
+    /// arrives is the very one a click produces — nothing in it tells the two apart. Taken at
+    /// face value it is a loop: toe hands the focus to a window it only meant to re-order, that
+    /// focus sinks a float, sinking raises more windows, and every one of those reports a focus
+    /// change of its own. The window toe is focusing for real is the exception — it is raised
+    /// on purpose, and its echo is the truth.
+    private func isEchoOfOwnRaise(_ id: WindowID) -> Bool {
+        guard id != focusApplied, let raisedAt = selfRaised[id] else { return false }
+        // Raising a window does not bring its application forward, so a window toe raised that
+        // reports the focus from an application which is not the frontmost one is an echo
+        // however long it took to arrive. A click is never that: it activates as it focuses.
+        if let window = tracker.window(id),
+           NSWorkspace.shared.frontmostApplication?.processIdentifier != window.pid {
+            return true
+        }
+        guard ProcessInfo.processInfo.systemUptime - raisedAt < Self.raiseEchoWindow else {
+            selfRaised.removeValue(forKey: id)
+            return false
+        }
+        return true
     }
 
     /// The user has let go. The window has been off its tile for the length of the drag, so
@@ -672,6 +749,10 @@ final class Coordinator: WindowTrackerDelegate {
         guard let window = tracker.window(id) else { return }
         workspaces.noteFocus(id)
         focusApplied = id
+        // Before the focus, not after: this raises the tiles a float has stopped being
+        // entitled to cover, and doing it afterwards would raise them over the very window
+        // that is being focused.
+        sinkUnfocusedFloats(workspaces.render())
         WindowMover.focus(window)
         updateBorder()
         refreshStatus()


### PR DESCRIPTION
A float was raised when you floated it and again whenever it was focused, and then it stayed
there: focus a tile afterwards and the float sat over half of it, so walking the grid with
`SUPER`+arrows meant reading tiles through a window you had already left.

Accessibility has a raise action and no lower, so the way down is to raise what the float
covers. Only the tiles it really overlaps are raised — tiles never overlap each other, so
re-ordering those among themselves is invisible — and the order ends with the focused window,
the one place in the stack anybody can see. Hyprland keeps a float above the tiles whatever has
the focus; this is a deliberate parting of company, because the rule toe can implement is also
the better one for a keyboard.

### The stack is read, not remembered

Activating an application brings all of its windows forward with it, float included, so focusing
a tile can lift a float belonging to the same application straight back up — after toe's raises,
where toe would never see it. `Stacking.raiseOrder` is given the ids the window server has above
each float, from the window list the border already consults, so no new permission and nothing
to keep in sync. A float already at the bottom of everything it covers asks for no raises at
all, which is also what stops the flicker: one focus change reaches this three ways over, and
re-raising windows already in the right order is what the eye sees.

### A raise is not a focus change

`AXRaise` makes the raised window its application's focused window, and the notification that
comes back is the very one a click produces. Taken at face value it is a loop: toe hands the
focus to a window it only meant to re-order, that focus sinks a different float, sinking raises
more windows, and each reports a focus change of its own. Windows toe raised are now tracked,
and a focus notification for one is dropped — at any age when the window's application is not
frontmost, since a raise never activates anything, and for 1.2 s even when it is, which covers
the application the focus is leaving.

### A detached window is not a place

`togglefloating` centres every float at the same fraction of the display, so two of a size land
exactly on top of each other and no arrow can mean "the one underneath this one" — the window
below was unreachable from the keyboard entirely. Worse, the two mechanisms that looked at
floats disagreed about what "the same place" was: `Box.rounded()` leaves two centred boxes up to
1.5 pt apart, which one treated as the same spot and the other as a direction, so the walk went
into a pile, through it, and back to the window it had come from before leaving.

So floats leave the geometry. They are a list — the workspace's detached windows in the order
they were opened — and a direction with no tile that way lands in it, at whichever end it
arrives from. The same direction walks along it, the opposite direction walks back, and off
either end is the tile the focus came in from, so holding one arrow goes round tile, list, tile,
and all four directions behave alike. Every step has an exact inverse, which is what proximity
could never give. Tile to tile is untouched: still Hyprland's walk, edge adjacency and history
tie-break, and it now never answers with a detached window.

That deletes rather more than it adds. `nearestInDirection` is gone entirely — the 90° cone, the
nearest-centre distance, the "stacked" last resort, the tie-breaks and the two tolerances — and
`DirectionalSearch` is back to being nothing but the port of `CCompositor::getWindowInDirection`
it says it is.

### Testing

The nine geometric focus tests are replaced by six that walk the list out and back, enter it
from either end, put the floats in opposite corners to show that where they are no longer
matters, and check that a float sharing a tile's edge is still not a step on the grid. 416
assertions pass. Driven by hand on a four-window layout throughout — two tiles, two detached
windows of different sizes stacked on each other — which is where each of the above was found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184PPAns5xQzE1hTKwcGN1L
