### PR TITLE
Rename the acronym, and stop naming other window managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
-# Toe — The Omarchy Experience
+# Toe — The Opinionated Experience
 
-A small native macOS window manager that reproduces [Omarchy](https://omarchy.org)'s
-window management: Hyprland's **dwindle** layout, Omarchy's key bindings, ten workspaces,
-and nothing else.
+A small native macOS window manager: Hyprland's **dwindle** layout, ten workspaces, and
+nothing else. One layout, one set of key bindings, nothing to agonise over — that is the
+opinion, and it is the whole product.
 
-AeroSpace gets most of the way there, but it is i3-style — explicit splits, with container
-normalization that flattens the tree dwindle depends on — so the one thing it cannot
-reproduce is the layout itself. toe's tiler is a direct port of Hyprland's
+The opinions are borrowed, mind. `TOE` first stood for *The Omarchy Experience*, and toe
+still cribs every default from [Omarchy](https://omarchy.org) — the Linux that had these
+opinions first and, being an entire distribution, had a great many more of them.
+
+The layout is the part nothing else on macOS gets right. The tilers here are i3-style —
+explicit splits, with container normalization that flattens the tree dwindle depends on — so
+the one thing they cannot reproduce is dwindle itself. toe's tiler is a direct port of Hyprland's
 `CHyprDwindleLayout`, with Omarchy's settings (`preserve_split = true`, `force_split = 2`)
 as the defaults.
 
@@ -124,7 +128,7 @@ by `make test` against hand-computed Hyprland output:
 
 **Workspaces.** macOS has no API for putting a window on a virtual desktop without private
 SkyLight calls, so hidden workspaces park their windows far off-screen and restore their exact
-frames on return — the same approach AeroSpace takes. The trade-off is that stashed windows
+frames on return. The trade-off is that stashed windows
 remain visible to Cmd-Tab and Mission Control, and Cmd-Tabbing to one can pull it back onto the
 current workspace.
 
@@ -286,8 +290,8 @@ menu bar item's tooltip — a typo can never leave you without a keyboard. See
 [`toe.example.toml`](toe.example.toml), and
 [Treat your config as code](#treat-your-config-as-code) for what an `exec` binding can do.
 
-Binding specs parse in both spellings, so you can paste from an AeroSpace config or an Omarchy
-one: `"alt-shift-1"`, `"super+shift+1"` and `"SUPER SHIFT, 1"` are the same binding.
+Binding specs parse in both the dash spelling and Omarchy's, so you can paste from either:
+`"alt-shift-1"`, `"super+shift+1"` and `"SUPER SHIFT, 1"` are the same binding.
 
 `editconfig`, `reload` and `quit` are bound in code as well as in the file — `SUPER`+`,`,
 `SUPER`+`SHIFT`+`R` and `SUPER`+`SHIFT`+`Q` — so the ways out exist whether or not your config

--- a/Sources/ToeCore/Config/Binding.swift
+++ b/Sources/ToeCore/Config/Binding.swift
@@ -36,7 +36,7 @@ public enum BindingParser {
         "alt": .option, "opt": .option, "option": .option,
     ]
 
-    /// Parses both spellings so bindings can be pasted from either an AeroSpace config
+    /// Parses both spellings so bindings can be pasted from either a dash-style config
     /// (`"alt-shift-1"`) or an Omarchy one (`"SUPER SHIFT, 1"`).
     ///
     /// `super` resolves to whatever `general.super_key` says — Option by default, which is

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -5,7 +5,7 @@
 ///                                   preserve_split = true, force_split = 2
 ///   default/hypr/bindings/tiling.conf → the bindings below
 let defaultConfigText = #"""
-# toe — The Omarchy Experience
+# toe — The Opinionated Experience
 #
 # Reloads automatically when you save. If a line does not parse, the running config is kept
 # and the error is named in the menu bar item's tooltip, so a typo can never leave you

--- a/Sources/ToeCore/Layout/DwindleLayout.swift
+++ b/Sources/ToeCore/Layout/DwindleLayout.swift
@@ -193,7 +193,7 @@ public final class DwindleLayout {
     // MARK: - Rearranging
 
     /// Port of `switchWindows` — Omarchy's `swapwindow`. Only the window payloads move;
-    /// the tree shape is untouched. This is the behaviour AeroSpace cannot reproduce.
+    /// the tree shape is untouched, so a swap never reshuffles the rest of the layout.
     public func swap(_ a: WindowID, _ b: WindowID) {
         guard a != b, let na = nodes[a], let nb = nodes[b] else { return }
         na.window = b

--- a/Sources/ToeCore/Layout/DwindleNode.swift
+++ b/Sources/ToeCore/Layout/DwindleNode.swift
@@ -39,7 +39,7 @@ public final class DwindleNode {
     ///
     /// With `preserve_split` on, the orientation chosen at insertion is never revisited —
     /// that is what makes Hyprland's dwindle stable as windows come and go, and it is the
-    /// behaviour AeroSpace's container normalization destroys.
+    /// behaviour i3-style container normalization destroys.
     public func recalcSizePosRecursive(
         _ opts: DwindleOptions,
         horizontalOverride: Bool = false,

--- a/Sources/ToeCore/Layout/Monitor.swift
+++ b/Sources/ToeCore/Layout/Monitor.swift
@@ -22,8 +22,8 @@ public struct Monitor: Equatable, Sendable {
 /// drags it back until enough of its title bar is reachable, which leaves a wide strip of it
 /// visible. Asking for x = -20000 lands at x = -(width - 40).
 ///
-/// The trick — the same one AeroSpace uses — is to place the window's *top-left corner* on the
-/// monitor's bottom corner. The title bar is then still technically on screen, so nothing is
+/// The trick is to place the window's *top-left corner* on the monitor's bottom corner. The
+/// title bar is then still technically on screen, so nothing is
 /// clamped, and all that remains visible is a single pixel.
 public enum Stash {
 

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -1137,7 +1137,7 @@ h.test("binding specs parse in both spellings") { t in
         guard let (m, code, name) = try? BindingParser.parse(s, superKey: .option) else { return nil }
         return "\(m.description)|\(code)|\(name)"
     }
-    t.equal(parse("SUPER SHIFT, LEFT"), parse("super-shift-left"), "Omarchy and AeroSpace spellings agree")
+    t.equal(parse("SUPER SHIFT, LEFT"), parse("super-shift-left"), "Omarchy and dash spellings agree")
     t.equal(parse("alt-shift-1"), parse("super+shift+1"), "'+' separators and alt/super alias")
     t.equal(parse("cmd-alt-ctrl-shift-f"), "ctrl-alt-shift-cmd|3|f", "all four modifiers")
     t.equal(parse("super-minus")?.hasSuffix("|27|minus"), true, "'minus' is a key, not a modifier prefix")

--- a/Sources/toe/AX/AXElement.swift
+++ b/Sources/toe/AX/AXElement.swift
@@ -2,9 +2,9 @@ import AppKit
 import ApplicationServices
 import ToeCore
 
-/// `_AXUIElementGetWindow` is private but stable, and is how every macOS tiler (AeroSpace,
-/// yabai) turns an AXUIElement into a CGWindowID. Resolved with dlsym so a missing symbol
-/// degrades instead of failing to launch.
+/// `_AXUIElementGetWindow` is private but stable, and is the only way to turn an AXUIElement
+/// into a CGWindowID. Resolved with dlsym so a missing symbol degrades instead of failing
+/// to launch.
 private let axGetWindow: (@convention(c) (AXUIElement, UnsafeMutablePointer<CGWindowID>) -> AXError)? = {
     guard let sym = dlsym(UnsafeMutableRawPointer(bitPattern: -2), "_AXUIElementGetWindow") else {
         return nil
@@ -19,7 +19,7 @@ private let axGetWindow: (@convention(c) (AXUIElement, UnsafeMutablePointer<CGWi
 /// window creation and focus change, and `WindowMover.setFrame` five more per tile. The macOS
 /// default timeout is measured in seconds, so one unresponsive application — an Electron app
 /// mid-startup, a process stopped in a debugger — would stall hotkeys, the menu bar strip and
-/// the layout for every other app along with it. yabai and AeroSpace cap it for this reason.
+/// the layout for every other app along with it. Hence the cap.
 ///
 /// A quarter of a second is far more than a healthy app needs to answer, and short enough that
 /// a hung one costs a frame rather than a freeze.

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -1,4 +1,4 @@
-# toe — The Omarchy Experience
+# toe — The Opinionated Experience
 #
 # Reloads automatically when you save. If a line does not parse, the running config is kept
 # and the error is named in the menu bar item's tooltip, so a typo can never leave you


### PR DESCRIPTION
`TOE` now expands to **The Opinionated Experience** instead of *The Omarchy Experience*.

toe only does window management, so borrowing a whole distribution's name oversold what it is. The README keeps the joke and the credit — Omarchy is still where every default comes from — but the name now describes the product: one layout, one set of bindings, nothing to configure your way out of.

The same pass removes every mention of AeroSpace and yabai. Each site is rewritten to say what toe does and why, rather than what another tiler does not:

- **README** — the layout argument now stands on the layout, not on a competitor; the off-screen stash and the binding spellings are described directly.
- **`AXElement.swift`** — `_AXUIElementGetWindow` is "the only way to turn an AXUIElement into a CGWindowID"; the messaging-timeout rationale ends in "Hence the cap."
- **`DwindleNode.swift`** — "the behaviour i3-style container normalization destroys."
- **`DwindleLayout.swift`** — the swap comment now states the guarantee it actually gives: the tree shape is untouched, so a swap never reshuffles the rest of the layout.
- **`Monitor.swift`**, **`Binding.swift`** — attribution dropped, mechanism kept.
- **`toe-selftest/main.swift`** — one assertion *message* reworded ("Omarchy and dash spellings agree"); the assertion itself is unchanged.

Comments, docs and one test label only — no behaviour change. `swift build` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184PPAns5xQzE1hTKwcGN1L