### PR TITLE
Stop the wallpaper click from sweeping the tiles aside

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,19 @@ replayed in reverse, which is what repairs a crash, a `kill -9` or a logout. Sho
 alone, because its gesture is a thumb-and-three-finger spread rather than a dock swipe — the key
 and the gesture stay consistent. `misc.disable_expose_shortcuts = false` leaves all of them alone.
 
+**The wallpaper click.** Clicking a bare patch of wallpaper sweeps every window off the sides of
+the screen and leaves them there until the next click — and with `gaps_out` set, bare wallpaper is
+one missed window edge away at any time. It takes the off-screen stash along with the tiles, so
+it lands toe in the same place a swipe up would. There is nothing to swallow here: WindowManager
+decides it from a click that belongs to the wallpaper rather than to any window, and it is a
+setting rather than a gesture. So toe writes the setting — `EnableStandardClickToShowDesktop` in
+`com.apple.WindowManager`, the one System Settings › Desktop & Dock calls "Click wallpaper to show
+desktop" — and, since that outlives the process just as a symbolic hotkey does, journals it to
+`~/.local/state/toe/wallpaper-click` first. An absent key is journalled as absent and restored by
+removing the key again, so a setting you never set is not left holding a value you never chose.
+A reveal you had already switched off yourself is left alone. `misc.disable_wallpaper_click = false`
+hands the click back.
+
 **Hiding.** `⌘H` and `⌘⌥H` take an application's windows out of the layout without closing them:
 the tree reflows around the gap, and `SUPER`+arrows cannot reach them again because they are no
 longer on any workspace. Omarchy has no equivalent, so toe puts a hidden application straight

--- a/Sources/ToeCore/Config/Config.swift
+++ b/Sources/ToeCore/Config/Config.swift
@@ -63,6 +63,10 @@ public struct MiscConfig: Equatable {
     /// does, and a symbolic hotkey is resolved inside the window server, so the tap cannot reach
     /// them.
     public var disableExposeShortcuts: Bool = true
+    /// A click on bare wallpaper sweeps every window off the sides of the screen, tiles and the
+    /// off-screen stash alike, and macOS decides that inside WindowManager rather than from an
+    /// event any tap could swallow — so it is switched off through its preference instead.
+    public var disableWallpaperClick: Bool = true
     /// `⌘H` takes an application's windows out of the layout with no way to reach them again.
     public var preventHiding: Bool = true
     /// Whether the layout is written to disk and put back on the next launch. See
@@ -306,6 +310,13 @@ public struct Config: Equatable {
                     config.misc.disableExposeShortcuts = v
                 } else {
                     config.warnings.append("misc.disable_expose_shortcuts: must be true or false, using \(config.misc.disableExposeShortcuts)")
+                }
+            }
+            if let raw = m["disable_wallpaper_click"] {
+                if let v = raw.boolValue {
+                    config.misc.disableWallpaperClick = v
+                } else {
+                    config.warnings.append("misc.disable_wallpaper_click: must be true or false, using \(config.misc.disableWallpaperClick)")
                 }
             }
             if let raw = m["prevent_hiding"] {

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -79,6 +79,13 @@ swallow_dock_swipes = true
 # alone: it is the way out of a fullscreen app now that swiping is not.
 disable_expose_shortcuts = true
 
+# A click on bare wallpaper — the gaps between the tiles count — sweeps every window off the sides
+# of the screen, the windows parked off-screen on hidden workspaces along with them, until you
+# click again. macOS decides that inside WindowManager rather than from an event a tap could
+# swallow, so toe switches the setting itself (the one System Settings › Desktop & Dock calls
+# "Click wallpaper to show desktop") and puts it back the way it found it when it quits.
+disable_wallpaper_click = true
+
 # ⌘H and ⌘⌥H take an application's windows out of the layout without closing them — the tree
 # reflows around the gap and SUPER+arrows cannot reach them again, because they are no longer on
 # any workspace. toe puts a hidden application straight back.

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -916,19 +916,24 @@ h.test("dock swipe swallowing is configurable") { t in
 }
 
 h.test("the macOS behaviours toe takes over are configurable") { t in
-    let off = try Config.parse("[misc]\ndisable_expose_shortcuts = false\nprevent_hiding = false\n")
+    let off = try Config.parse("[misc]\ndisable_expose_shortcuts = false\nprevent_hiding = false\ndisable_wallpaper_click = false\n")
     t.equal(off.misc.disableExposeShortcuts, false, "the Exposé shortcuts can be handed back")
     t.equal(off.misc.preventHiding, false, "hiding can be allowed")
+    t.equal(off.misc.disableWallpaperClick, false, "the wallpaper click can be handed back")
     t.equal(off.warnings, [], "no warnings")
 
     let absent = try Config.parse("[general]\ngaps_in = 5\n")
     t.equal(absent.misc.disableExposeShortcuts, true, "omitting the table keeps the defaults")
     t.equal(absent.misc.preventHiding, true, "omitting the table keeps the defaults")
+    t.equal(absent.misc.disableWallpaperClick, true, "omitting the table keeps the defaults")
 
-    let bad = try Config.parse("[misc]\nprevent_hiding = 1\n")
+    let bad = try Config.parse("[misc]\nprevent_hiding = 1\ndisable_wallpaper_click = \"no\"\n")
     t.equal(bad.misc.preventHiding, true, "a non-boolean keeps the default")
+    t.equal(bad.misc.disableWallpaperClick, true, "a non-boolean keeps the default")
     t.equal(bad.warnings.contains { $0.contains("misc.prevent_hiding") }, true,
             "and says so in the menu bar")
+    t.equal(bad.warnings.contains { $0.contains("misc.disable_wallpaper_click") }, true,
+            "and says so for the wallpaper click too")
 }
 
 h.test("restoring the layout across a restart is configurable") { t in

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -72,6 +72,9 @@ final class Coordinator: WindowTrackerDelegate {
         // than quit may have left Mission Control's shortcut switched off. Give it back before
         // anything else, so the config below decides from a known-good baseline.
         SymbolicHotkeys.repairAfterUncleanExit()
+        // Same reasoning, same shape: the reveal-desktop preference is the window server's, not
+        // toe's, so a copy that was killed rather than quit may have left it switched off.
+        WallpaperClick.repairAfterUncleanExit()
         writeDefaultConfigIfMissing()
         loadConfig()
 
@@ -274,8 +277,8 @@ final class Coordinator: WindowTrackerDelegate {
         }
     }
 
-    /// The two macOS behaviours toe takes over, applied at startup and on every reload. Neither
-    /// needs Accessibility, but both are gated on `isManaging` so they arrive together with the
+    /// The macOS behaviours toe takes over, applied at startup and on every reload. None of them
+    /// needs Accessibility, but all are gated on `isManaging` so they arrive together with the
     /// tap rather than flickering on before toe can actually manage anything.
     private func applyMiscSettings() {
         guard isManaging else { return }
@@ -284,6 +287,12 @@ final class Coordinator: WindowTrackerDelegate {
             SymbolicHotkeys.disable(SymbolicHotkeys.expose)
         } else {
             SymbolicHotkeys.restoreAll()
+        }
+
+        if config.misc.disableWallpaperClick {
+            WallpaperClick.disable()
+        } else {
+            WallpaperClick.restore()
         }
 
         if config.misc.preventHiding {
@@ -643,9 +652,11 @@ final class Coordinator: WindowTrackerDelegate {
         // WindowServer, so it is taken down deliberately rather than left to process death.
         dockSwipes.stop()
         hideBlocker.stop()
-        // The only one of the three that would otherwise outlive toe: the window server keeps a
-        // symbolic hotkey switched off until something switches it back on.
+        // The two that would otherwise outlive toe: the window server keeps a symbolic hotkey
+        // switched off until something switches it back on, and the reveal-desktop preference is
+        // written to the user's settings.
         SymbolicHotkeys.restoreAll()
+        WallpaperClick.restore()
     }
 
     private func unstashEverything() {

--- a/Sources/toe/Input/WallpaperClick.swift
+++ b/Sources/toe/Input/WallpaperClick.swift
@@ -1,0 +1,111 @@
+import CoreFoundation
+import Foundation
+
+/// macOS's "click the wallpaper to show desktop", switched off for as long as toe runs.
+///
+/// A click on any bare patch of wallpaper sweeps every window off the sides of the screen and
+/// leaves them there until the next click. That is the same problem `DockSwipeTap` and
+/// `SymbolicHotkeys` exist for, arriving by a third route: toe's tiles go somewhere toe did not
+/// put them, and a hidden workspace's off-screen stash — see `Stash` — slides into view alongside
+/// them. With `[general] gaps_out` set, the wallpaper shows through around the tiles, so the click
+/// is one missed window edge away at any time.
+///
+/// There is nothing to swallow here. The reveal is decided inside WindowManager from a click that
+/// belongs to the wallpaper, not to any window, and it is a setting rather than a gesture:
+/// `EnableStandardClickToShowDesktop` in `com.apple.WindowManager`, which is the same preference
+/// System Settings › Desktop & Dock › "Click wallpaper to show desktop" writes. Unset means on —
+/// revealing the desktop is the macOS default — so an absent key is a value to put back, not a
+/// value to ignore.
+///
+/// Like a symbolic hotkey, **this state outlives the process**, so it is handled the same way:
+/// journalled to disk *before* the change, and a journal found at startup is replayed, which is
+/// what repairs a crash, a force-quit or a logout.
+enum WallpaperClick {
+
+    private static let domain = "com.apple.WindowManager" as CFString
+    private static let key = "EnableStandardClickToShowDesktop" as CFString
+
+    private static let journalURL = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".local/state/toe/wallpaper-click")
+
+    /// What the preference was before toe touched it, and so what `restore` owes the user back.
+    /// `absent` is not the same as `on`: writing `true` where there was no key at all would leave
+    /// the user's settings holding a value they never set.
+    private enum Previous: String {
+        case on
+        case absent
+    }
+
+    private static var previous: Previous?
+
+    // MARK: - Applying
+
+    /// Turns the reveal off, remembering what was there. Idempotent, and a no-op when the user has
+    /// already turned it off themselves — there is then nothing to take and nothing to give back.
+    static func disable() {
+        guard previous == nil else { return }
+        let current = (CFPreferencesCopyAppValue(key, domain) as? NSNumber)?.boolValue
+        guard current ?? true else { return }
+
+        // Journalled before the change, not after: a crash between the two must leave a record
+        // that says too much, never one that says too little.
+        let was: Previous = current == nil ? .absent : .on
+        previous = was
+        writeJournal(was)
+        write(false)
+        Log.info("wallpaper click: reveal-desktop switched off")
+    }
+
+    /// Gives back exactly what `disable` took, and clears the journal. Safe to call twice.
+    static func restore() {
+        guard let previous else {
+            clearJournal()
+            return
+        }
+        put(back: previous)
+        Self.previous = nil
+        clearJournal()
+        Log.info("wallpaper click: reveal-desktop restored")
+    }
+
+    /// Replays a journal left behind by a toe that did not get to restore — a crash, a `kill -9`,
+    /// a logout. Call once at startup, before `disable`.
+    static func repairAfterUncleanExit() {
+        guard let text = try? String(contentsOf: journalURL, encoding: .utf8) else { return }
+        if let was = Previous(rawValue: text.trimmingCharacters(in: .whitespacesAndNewlines)) {
+            put(back: was)
+            Log.info("wallpaper click: repaired reveal-desktop after an unclean exit")
+        }
+        clearJournal()
+    }
+
+    // MARK: - The preference
+
+    private static func put(back previous: Previous) {
+        switch previous {
+        case .on: write(true)
+        case .absent: write(nil)
+        }
+    }
+
+    /// nil removes the key, which is how a setting the user never set is left the way it was.
+    private static func write(_ value: Bool?) {
+        let property: CFPropertyList? = value.map { $0 ? kCFBooleanTrue : kCFBooleanFalse }
+        CFPreferencesSetAppValue(key, property, domain)
+        // WindowManager reads the preference rather than being told, so the write has to be out of
+        // toe's own cache and in `cfprefsd` before the next click asks.
+        CFPreferencesAppSynchronize(domain)
+    }
+
+    // MARK: - The journal
+
+    private static func writeJournal(_ previous: Previous) {
+        try? FileManager.default.createDirectory(at: journalURL.deletingLastPathComponent(),
+                                                 withIntermediateDirectories: true)
+        try? previous.rawValue.write(to: journalURL, atomically: true, encoding: .utf8)
+    }
+
+    private static func clearJournal() {
+        try? FileManager.default.removeItem(at: journalURL)
+    }
+}

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -72,6 +72,13 @@ swallow_dock_swipes = true
 # alone: it is the way out of a fullscreen app now that swiping is not.
 disable_expose_shortcuts = true
 
+# A click on bare wallpaper — the gaps between the tiles count — sweeps every window off the sides
+# of the screen, the windows parked off-screen on hidden workspaces along with them, until you
+# click again. macOS decides that inside WindowManager rather than from an event a tap could
+# swallow, so toe switches the setting itself (the one System Settings › Desktop & Dock calls
+# "Click wallpaper to show desktop") and puts it back the way it found it when it quits.
+disable_wallpaper_click = true
+
 # ⌘H and ⌘⌥H take an application's windows out of the layout without closing them — the tree
 # reflows around the gap and SUPER+arrows cannot reach them again, because they are no longer on
 # any workspace. toe puts a hidden application straight back.


### PR DESCRIPTION
Clicking a bare patch of wallpaper — and with `gaps_out` set, that is one missed window edge away at any time — sweeps every window off the sides of the screen until the next click, taking a hidden workspace's off-screen stash into view along with the tiles. It lands toe in the same place a swipe up would, by a third route.

**Why not the tap.** There is nothing to swallow: WindowManager decides the reveal from a click that belongs to the wallpaper rather than to any window, and it is a setting rather than a gesture. Widening `DockSwipeTap`'s mask to mouse events would buy nothing and cost the property that no keystroke, click or scroll can reach that tap even in principle. So toe writes the setting instead — `EnableStandardClickToShowDesktop` in `com.apple.WindowManager`, the one System Settings › Desktop & Dock calls "Click wallpaper to show desktop".

**Why it is journalled.** Like a symbolic hotkey, this state outlives the process, so it gets the same treatment as `SymbolicHotkeys`: written to `~/.local/state/toe/wallpaper-click` *before* the change, and a journal found at startup is replayed — which is what repairs a crash, a `kill -9` or a logout. An absent key is journalled as `absent` and given back by removing the key again, so a setting the user never set is not left holding a value they never chose. A reveal already switched off by hand is left alone: nothing taken, nothing to give back.

`misc.disable_wallpaper_click = false` hands the click back.

## Verified on macOS 26.6.2

- **Taking it.** With toe running, clicking bare wallpaper does nothing; pref reads `0`, journal reads `absent`.
- **Giving it back.** A clean quit logs `wallpaper click: reveal-desktop restored`, *removes* the key rather than writing `true` back, and deletes the journal — settings identical to before toe ever ran.
- **Repair.** A staged leftover (pref `0`, journal on disk) logs `wallpaper click: repaired reveal-desktop after an unclean exit` on the next launch, then re-takes the setting from that known-good baseline.
- `make test` — 420 assertions pass. `toe.example.toml` regenerates identical to `--print-default-config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184PPAns5xQzE1hTKwcGN1L