### PR TITLE
Bump toe cask to 0.9.1

### DIFF
--- a/Casks/toe.rb
+++ b/Casks/toe.rb
@@ -2,8 +2,8 @@
 
 cask "toe" do
   # Both lines below are rewritten by .github/workflows/release.yml on each tag.
-  version "0.9.0"
-  sha256 "25a37e91437a78dbb42d672eb23c45ea25f5982eef536d348c2cd435940b32d7"
+  version "0.9.1"
+  sha256 "5fba11e39fa157753ce1268a2831777f37538ec352049f206fa87593a9e6d229"
 
   url "https://github.com/theclifmeister/toe/releases/download/v#{version}/toe-#{version}-arm64.zip"
   name "Toe"


### PR DESCRIPTION
The v0.9.1 release workflow built, notarized and published the release, then failed on this last step — `gh pr create` came back with a transient GitHub error (`GraphQL: Something went wrong while executing your query`, ref `A732:341E96:3C6F33:480A29:6A983431`). The branch and its commit were already pushed, so this is that PR, opened by hand.

Nothing about the build is in question:

- `v0.9.1` is published and not a draft, with `toe-0.9.1-arm64.zip` attached (2,143,976 bytes).
- The `sha256` in this diff is verified against the published asset: `5fba11e3…9e6d229`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184PPAns5xQzE1hTKwcGN1L