### PR TITLE
Open the config with a binding, not a command toe owns

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,22 @@ as the defaults.
 | `SUPER` + `1`…`9`, `0` | Switch to workspace 1…10 |
 | `SUPER` + `SHIFT` + `1`…`9`, `0` | Move window to workspace and follow it |
 | `SUPER` + `TAB` / `SHIFT`+`TAB` / `CTRL`+`TAB` | Next / previous workspace in use, former workspace |
-| `SUPER` + `ENTER` | New terminal window |
-| `SUPER` + `SHIFT` + `ENTER` | New browser window |
+| `SUPER` + `ENTER` | New terminal window — Ghostty |
+| `SUPER` + `SHIFT` + `ENTER` | New browser window — Safari |
 | `SUPER` + `W` | Close window |
 | `SUPER` + `J` | Toggle split orientation |
 | `SUPER` + `T` | Cycle floating: 70×80% of the display, 80×90%, back to tiling |
 | `SUPER` + `SPACE` | The quick menu — Configure, Learn, Quit |
 | `SUPER` + `K` | Every binding, in a list |
-| `SUPER` + `,` | Edit the config — nano, in a terminal window |
+| `SUPER` + `,` | Edit the config — a VS Code window |
 | `SUPER` + `SHIFT` + `R` / `Q` | Reload the config / quit toe |
 | Drag a tiled window | Swap it with the tile you drag it over |
 
 `SUPER` is **Option (⌥)** — the same physical key position as SUPER on a PC keyboard, and it
 leaves ⌘S ⌘F ⌘T ⌘W ⌘1-9 ⌘Tab untouched. Configurable.
+
+The last three of those bindings name an application, because an opinion about your terminal is
+still an opinion — see [What the defaults assume](#what-the-defaults-assume).
 
 The focused window gets a gradient border, and everything is driven by a hot-reloaded config
 at `~/.config/toe/toe.toml`.
@@ -78,6 +81,39 @@ separate `homebrew-toe` one. `brew upgrade --cask toe` picks up new releases.
 
 Grant **System Settings → Privacy & Security → Accessibility** when asked. That single
 permission is all toe needs.
+
+### What the defaults assume
+
+The window manager itself needs nothing but that permission: the layout, the workspaces, the
+border, the menu bar item and the quick menu are all toe's own, and the menu's font ships inside
+the app (JetBrainsMono Nerd Font, the one Omarchy's walker resolves `monospace` to). Three of
+the shipped bindings are a different matter — they launch an application, and toe borrowed
+Omarchy's opinion about which one:
+
+| Binding | Opens | If you have not got it |
+|---|---|---|
+| `SUPER` + `ENTER` | [Ghostty](https://ghostty.org) | `brew install --cask ghostty` |
+| `SUPER` + `SHIFT` + `ENTER` | Safari | ships with macOS |
+| `SUPER` + `,` | [Visual Studio Code](https://code.visualstudio.com) | `brew install --cask visual-studio-code` |
+
+Each is one `exec` line in your config and nothing more. toe has no terminal, browser or editor
+of its own — the three names appear once, in the config it writes on first run, and nowhere in
+what it does — and it will not launch anything you did not bind. Point them wherever you like:
+
+```toml
+"super-enter"       = "exec open -na Alacritty"
+"super-shift-enter" = "exec open -na \"Google Chrome\" --args --new-window"
+"super-comma"       = "exec open -a Zed ~/.config/toe/toe.toml"
+```
+
+A binding naming an application you do not have fails quietly: `/bin/sh` runs, `open` reports
+that it cannot find it, and no window appears. Nothing else in toe depends on the press. The one
+knock-on is the quick menu's *Edit configuration* row, which is whichever `exec` mentions
+`toe.toml` — repoint `SUPER`+`,` and the row follows it; remove the binding and the row goes.
+
+The `[[float]]` rules name 1Password, Raycast, System Settings and Activity Monitor, but those
+are only *never tile this* rules. A rule for an application you have not installed costs nothing
+and can stay.
 
 ### Treat your config as code
 
@@ -189,6 +225,13 @@ had to know. *Run on startup* is `SMAppService`, so it appears in System Setting
 Login Items too — and it is left out of the menu entirely where it cannot work: from a build
 directory rather than `/Applications`, or alongside a LaunchAgent that `make start-at-login`
 wrote. The log says which, and what fixes it.
+
+*Edit configuration* runs **your** binding rather than an editor toe picked: it is whichever
+`exec` in your config mentions `toe.toml`, so pointing `SUPER`+`,` at Zed points the menu row at
+Zed, moving it to another key takes the row with it, and removing it removes the row. The
+keybindings list names that same binding *Edit the config* instead of printing the shell line, by
+the same rule. Where neither row can be offered — no such binding, and *Run on startup*
+unavailable — `Configure` is left out too, rather than leading into an empty level.
 
 Typing searches what a row does as well as what it is called — on the keybindings page the name
 is `SUPER`+`W` and the description is *Close window*, so a filter that read only names would have
@@ -344,8 +387,9 @@ rules.
 ## Config
 
 `~/.config/toe/toe.toml` is written on first run and reloaded whenever you save it. `SUPER`+`,`
-opens it in nano, in a Terminal.app window; bind `exec` with your own terminal instead if you
-would rather. If it fails to parse, the running config is kept and the error is named in the
+opens it in Visual Studio Code — an ordinary `exec` binding, the same kind as the one that opens
+a terminal on `SUPER`+`ENTER`, so point it at Zed, TextEdit, or nano in whichever terminal you
+use. toe has no editor of its own. If it fails to parse, the running config is kept and the error is named in the
 menu bar item's tooltip — a typo can never leave you without a keyboard. See
 [`toe.example.toml`](toe.example.toml), and
 [Treat your config as code](#treat-your-config-as-code) for what an `exec` binding can do.
@@ -353,18 +397,19 @@ menu bar item's tooltip — a typo can never leave you without a keyboard. See
 Binding specs parse in both the dash spelling and Omarchy's, so you can paste from either:
 `"alt-shift-1"`, `"super+shift+1"` and `"SUPER SHIFT, 1"` are the same binding.
 
-`editconfig`, `reload`, `quit` and the quick menu are bound in code as well as in the file —
-`SUPER`+`,`, `SUPER`+`SHIFT`+`R`, `SUPER`+`SHIFT`+`Q`, `SUPER`+`SPACE` and `SUPER`+`K` — so the
+`reload`, `quit` and the quick menu are bound in code as well as in the file —
+`SUPER`+`SHIFT`+`R`, `SUPER`+`SHIFT`+`Q`, `SUPER`+`SPACE` and `SUPER`+`K` — so the
 ways out exist whether or not your config mentions them. Your config is never rewritten once it is there, so a binding introduced after you
 first ran toe would otherwise never reach you: that is how the menu bar item losing its menu left
 anyone upgrading with no way to quit but `pkill`. A fallback applies only when the command is
 bound nowhere, so rebinding `quit` keeps your key and does not also collect the default, and a
 fallback whose own combination you have already used for something else is dropped rather than
-registered on top of yours.
+registered on top of yours. Opening the config is not on that list: it is an `exec` like any
+other now, and a fallback would have to name an editor toe has no business choosing.
 
 Commands: `movefocus`, `swapwindow`, `movewindow`, `workspace`, `movetoworkspace`,
 `movetoworkspacesilent`, `killactive`, `togglefloating`, `togglesplit`, `swapsplit`, `exec`,
-`reload`, `editconfig`, `menu`, `keybindings`, `quit`.
+`reload`, `menu`, `keybindings`, `quit`.
 
 The TOML parser is a dependency-free subset: tables, arrays of tables, bare and quoted keys,
 basic and literal strings, numbers, booleans, arrays and inline tables. No multi-line strings

--- a/Sources/ToeCore/Config/Config.swift
+++ b/Sources/ToeCore/Config/Config.swift
@@ -137,6 +137,12 @@ public struct FloatRule: Equatable {
 }
 
 public struct Config: Equatable {
+
+    /// The file a config is read from, by name. `Coordinator` owns the path; ToeCore needs only
+    /// this much of it, to recognise the `exec` binding that opens it — see
+    /// `MenuModel.configOpener`.
+    public static let fileName = "toe.toml"
+
     public var superKey: Modifiers = .option
     public var gaps: Gaps = Gaps(inner: 5, outer: 10)
     public var dwindle: DwindleOptions = DwindleOptions()
@@ -162,15 +168,19 @@ public struct Config: Equatable {
     /// losing its menu left them with no way to quit toe but `pkill`.
     ///
     /// Deliberately only the escape hatches. A fallback that covered every binding would be a
-    /// second config competing with yours; these three exist so that a config which forgot them
+    /// second config competing with yours; these exist so that a config which forgot them
     /// cannot leave you stuck, in the same spirit as keeping the last good config when a new one
     /// will not parse.
+    ///
+    /// Editing the config is not one of them, though it used to be. It is an `exec` binding now,
+    /// like the ones that open a terminal or a browser, and a fallback would have to name an
+    /// editor toe has no business choosing — and would put itself back on `SUPER`+`,` every time
+    /// you moved that binding to another key.
     public static let fallbackBindings: [(spec: String, command: Command)] = [
-        ("super-comma", .editConfig),
         ("super-shift-r", .reload),
         ("super-shift-q", .quit),
-        // The menu holds the escape hatches now — Quit and Edit configuration are rows in it —
-        // so it belongs on this list by the same reasoning that put them here.
+        // The menu holds the escape hatches now — Quit is a row in it — so it belongs on this
+        // list by the same reasoning that put them here.
         ("super-space", .menu(.root)),
         ("super-k", .menu(.keybindings)),
     ]

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -9,7 +9,8 @@ let defaultConfigText = #"""
 #
 # Reloads automatically when you save. If a line does not parse, the running config is kept
 # and the error is named in the menu bar item's tooltip, so a typo can never leave you
-# keyboardless. SUPER+, opens this file in nano.
+# keyboardless. SUPER+, opens this file in Visual Studio Code — a binding like any other,
+# so point it at the editor you actually use.
 #
 # This file is code, not just settings: an `exec` binding below runs a shell command, and toe
 # picks up a change within about 150 ms of the save. Anything that can write this file can run
@@ -178,9 +179,14 @@ font_size  = 18
 # ── toe itself ────────────────────────────────────────────────────────────────
 # The menu bar item is only the workspace strip — waybar's has nothing behind it either — so
 # these are the way in to everything toe can do to itself.
-# `editconfig` opens this file in nano, in a Terminal.app window. To use your own terminal,
-# bind exec instead:  "exec open -na Ghostty --args -e nano ~/.config/toe/toe.toml"
-"super-comma"   = "editconfig"
+# Editing this file is nothing special — it is an `exec`, the same as the launchers below, and
+# toe has no editor of its own. Whichever exec below mentions toe.toml is the one the quick menu
+# offers as "Edit configuration", so the menu follows this line wherever you point it. It runs
+# through /bin/sh, so ~ expands and any editor works:
+#   "exec open -a Zed ~/.config/toe/toe.toml"
+#   "exec open -e ~/.config/toe/toe.toml"                     # TextEdit, always installed
+#   "exec open -na Ghostty --args -e nano ~/.config/toe/toe.toml"
+"super-comma"   = "exec open -a \"Visual Studio Code\" ~/.config/toe/toe.toml"
 # Saving this file already reloads it; this is the manual way.
 "super-shift-r" = "reload"
 # Puts every window on a hidden workspace back where it came from on the way out.

--- a/Sources/ToeCore/Dispatch/Command.swift
+++ b/Sources/ToeCore/Dispatch/Command.swift
@@ -20,14 +20,30 @@ public enum Command: Equatable {
     case swapSplit
     case exec(String)
     case reload
-    /// Opens the config file in a terminal, in nano. toe has no settings window and, since
-    /// the menu bar item lost its menu, no other way in.
-    case editConfig
     /// The quick menu, and the keybindings list it holds. One case with a page rather than two
     /// cases: the keybindings view *is* the menu on another page — same panel, same filter, same
     /// keys — so two cases would give `dispatch` two arms with one body between them.
     case menu(MenuPage)
     case quit
+}
+
+public extension Command {
+
+    /// True for the `exec` that opens the config file.
+    ///
+    /// There is no `editconfig` command any more — opening the file is an `exec` like the ones
+    /// that launch a terminal or a browser — so the two places that want to know which binding
+    /// edits your config read the line rather than a command name: any `exec` that mentions the
+    /// config file is taken to be it. `MenuModel.configOpener` finds the menu row that way, and
+    /// `CommandLabel` names the row in the keybindings list that way, so both follow your config
+    /// instead of a command toe used to own.
+    ///
+    /// A shell line that merely touches the file for some other reason matches too. That is the
+    /// price of not asking you to declare which binding is the editor one.
+    var opensConfig: Bool {
+        guard case .exec(let line) = self else { return false }
+        return line.contains(Config.fileName)
+    }
 }
 
 public enum CommandError: Error, CustomStringConvertible {
@@ -80,7 +96,6 @@ public enum CommandParser {
         case "togglesplit":                 return .toggleSplit
         case "swapsplit":                   return .swapSplit
         case "reload":                      return .reload
-        case "editconfig", "config":        return .editConfig
         case "quit", "exit":                return .quit
 
         // Spelled the way `omarchy-menu` and `omarchy-menu keybindings` are invoked, so a

--- a/Sources/ToeCore/Dispatch/CommandLabel.swift
+++ b/Sources/ToeCore/Dispatch/CommandLabel.swift
@@ -22,9 +22,13 @@ public enum CommandLabel {
         case .toggleFloating:       return "Cycle floating"
         case .toggleSplit:          return "Toggle split orientation"
         case .swapSplit:            return "Swap the split"
-        case .exec(let line):       return "Run \(ellipsised(line))"
+        case .exec(let line):
+            // The one exec the list can name for you: `SUPER`+`,` read as "Edit the config"
+            // while toe owned the command, and a row that reads `Run open -a "Visual Studio
+            // Code" ~/.config/toe/…` is a worse answer to the same question. The text comes from
+            // the line you bound, not from a command — see `Command.opensConfig`.
+            return command.opensConfig ? "Edit the config" : "Run \(ellipsised(line))"
         case .reload:               return "Reload the config"
-        case .editConfig:           return "Edit the config"
         case .quit:                 return "Quit toe"
         case .menu(let page):
             switch page {

--- a/Sources/ToeCore/Menu/MenuModel.swift
+++ b/Sources/ToeCore/Menu/MenuModel.swift
@@ -70,18 +70,41 @@ public enum LoginItemState: Equatable, Sendable {
 /// row that shows a remembered value instead of launchd's is a row that will eventually lie.
 public enum MenuModel {
 
-    public static func root(loginItem: LoginItemState) -> [MenuItem] {
-        var configure: [MenuItem] = []
-        if let startup = startup(loginItem) { configure.append(startup) }
-        configure.append(MenuItem(title: "Edit configuration", icon: .pencil,
-                                  action: .run(.editConfig)))
-        return [
-            MenuItem(title: "Configure", icon: .gear, action: .submenu(configure)),
-            MenuItem(title: "Learn", icon: .book, action: .submenu([
-                MenuItem(title: "Keybindings", icon: .keyboard, action: .page(.keybindings)),
-            ])),
-            MenuItem(title: "Quit", icon: .power, action: .run(.quit)),
-        ]
+    public static func root(loginItem: LoginItemState, bindings: [Binding]) -> [MenuItem] {
+        var items: [MenuItem] = []
+        // Configure can come out empty — neither of its rows is guaranteed — and a row that
+        // leads into an empty level is worse than no row, so the parent goes with it.
+        let configure = configure(loginItem: loginItem, bindings: bindings)
+        if !configure.isEmpty {
+            items.append(MenuItem(title: "Configure", icon: .gear, action: .submenu(configure)))
+        }
+        items.append(MenuItem(title: "Learn", icon: .book, action: .submenu([
+            MenuItem(title: "Keybindings", icon: .keyboard, action: .page(.keybindings)),
+        ])))
+        items.append(MenuItem(title: "Quit", icon: .power, action: .run(.quit)))
+        return items
+    }
+
+    /// The Configure level. Also built on its own, by the menu, when throwing the startup toggle
+    /// rebuilds the level under the cursor.
+    public static func configure(loginItem: LoginItemState, bindings: [Binding]) -> [MenuItem] {
+        var rows: [MenuItem] = []
+        if let startup = startup(loginItem) { rows.append(startup) }
+        if let opener = configOpener(in: bindings) {
+            rows.append(MenuItem(title: "Edit configuration", icon: .pencil,
+                                 action: .run(opener.command)))
+        }
+        return rows
+    }
+
+    /// The binding that opens the config, if you have one — the row cannot name an editor of its
+    /// own without being exactly the hardcoding that was taken out, so it reads your config
+    /// instead. Point the binding at Zed and the row opens Zed; move it to another key and the
+    /// row follows it there; take the binding out and the row goes too, rather than the menu
+    /// offering an editor you never chose. `Command.opensConfig` is the rule, shared with the
+    /// label the keybindings list gives the same binding.
+    public static func configOpener(in bindings: [Binding]) -> Binding? {
+        bindings.first { $0.command.opensConfig }
     }
 
     /// nil where the toggle cannot work — the row is left out rather than shown dimmed beside a
@@ -136,7 +159,7 @@ public enum MenuModel {
         case .workspace:        return 5
         case .killActive, .toggleFloating, .toggleSplit, .swapSplit: return 6
         case .menu:             return 7
-        case .editConfig, .reload, .quit: return 8
+        case .reload, .quit:    return 8
         case .exec:             return 9
         }
     }

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -868,7 +868,9 @@ h.test("the shipped default config parses cleanly") { t in
     t.equal(binding("super-shift-v"), nil, "SUPER+SHIFT+V is no longer bound")
 
     // Everything the menu bar item used to offer, now that it offers nothing.
-    t.equal(binding("super-comma")?.command, .editConfig, "SUPER+, edits the config")
+    t.equal(binding("super-comma")?.command,
+            .exec("open -a \"Visual Studio Code\" ~/.config/toe/toe.toml"),
+            "SUPER+, opens the config in an editor, as an ordinary exec you can repoint")
     t.equal(binding("super-shift-r")?.command, .reload, "SUPER+SHIFT+R reloads it")
     t.equal(binding("super-shift-q")?.command, .quit, "SUPER+SHIFT+Q quits toe")
     t.equal(binding("super-space")?.command, .menu(.root), "SUPER+SPACE opens the quick menu")
@@ -963,9 +965,12 @@ h.test("the escape hatches are bound even when the config forgets them") { t in
     // rewritten, so without a fallback there is no way to quit toe but `pkill`.
     let old = try Config.parse("[binds]\n\"super-w\" = \"killactive\"\n")
     t.equal(binding(old, .quit)?.source, "super-shift-q", "quit is bound")
-    t.equal(binding(old, .editConfig)?.source, "super-comma", "editconfig is bound")
     t.equal(binding(old, .reload)?.source, "super-shift-r", "reload is bound")
     t.equal(old.warnings, [], "silently, with no warnings")
+    // Opening the config is not on the list: it is an exec of your own now, and a fallback
+    // would have to pick an editor for you.
+    t.equal(old.bindings.contains { $0.source == "super-comma" }, false,
+            "and SUPER+, is left free rather than bound to somebody's editor")
 
     // Your binding wins, and does not also collect the default.
     let rebound = try Config.parse("[binds]\n\"super-shift-x\" = \"quit\"\n")
@@ -974,14 +979,14 @@ h.test("the escape hatches are bound even when the config forgets them") { t in
 
     // A fallback whose combination you already used for something else is dropped, not
     // registered on top of yours — the system would refuse the duplicate anyway.
-    let clash = try Config.parse("[binds]\n\"super-comma\" = \"killactive\"\n")
-    t.equal(binding(clash, .editConfig), nil, "a taken fallback key is left alone")
-    t.equal(binding(clash, .killActive)?.source, "super-comma", "and stays yours")
-    t.equal(binding(clash, .quit)?.source, "super-shift-q", "the others still land")
+    let clash = try Config.parse("[binds]\n\"super-shift-q\" = \"killactive\"\n")
+    t.equal(binding(clash, .quit), nil, "a taken fallback key is left alone")
+    t.equal(binding(clash, .killActive)?.source, "super-shift-q", "and stays yours")
+    t.equal(binding(clash, .reload)?.source, "super-shift-r", "the others still land")
 
-    // The shipped config binds all three itself, so nothing should be duplicated.
+    // The shipped config binds both itself, so nothing should be duplicated.
     let shipped = try Config.parse(Config.defaultTOML)
-    for command in [Command.quit, .editConfig, .reload] {
+    for command in [Command.quit, .reload] {
         t.equal(shipped.bindings.filter { $0.command == command }.count, 1,
                 "the shipped config binds \(command) exactly once")
     }
@@ -1541,16 +1546,16 @@ h.test("an empty query keeps every item in the order it was written") { t in
 }
 
 h.test("the filter matches a subsequence rather than a substring") { t in
-    t.equal(FuzzyFilter.rank("ecfg", in: ["Edit configuration"]).map(\.index), [0],
+    t.equal(FuzzyFilter.rank("kbnd", in: ["Keybindings"]).map(\.index), [0],
             "letters in order with gaps between them still match, the way walker's does")
-    t.equal(FuzzyFilter.rank("gfce", in: ["Edit configuration"]).count, 0,
+    t.equal(FuzzyFilter.rank("dnbk", in: ["Keybindings"]).count, 0,
             "the same letters out of order do not")
     t.equal(FuzzyFilter.rank("zz", in: ["Setup", "Learn"]).count, 0,
             "and what matches nothing is dropped, not merely ranked last")
 }
 
 h.test("typing puts the selection back at the top") { t in
-    var m = MenuState(root: MenuModel.root(loginItem: .off), visibleRows: 10)
+    var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 10)
     m.move(by: 2)
     t.equal(m.selection, 2, "moved down two")
     m.type("q")
@@ -1559,7 +1564,7 @@ h.test("typing puts the selection back at the top") { t in
 }
 
 h.test("a submenu is entered, backed out of, and clears the query on the way in") { t in
-    var m = MenuState(root: MenuModel.root(loginItem: .on), visibleRows: 10)
+    var m = MenuState(root: MenuModel.root(loginItem: .on, bindings: []), visibleRows: 10)
     t.equal(m.prompt, "Go…", "walker's placeholder at the root")
     m.type("configure")
     t.equal(m.visible.count, 1, "one row matches 'configure'")
@@ -1567,13 +1572,13 @@ h.test("a submenu is entered, backed out of, and clears the query on the way in"
     t.equal(m.query, "", "the query does not follow you into the submenu")
     t.equal(m.breadcrumb, ["Configure"], "the level is named")
     t.equal(m.prompt, "Configure…", "and the placeholder says where you are")
-    t.equal(m.visible.map(\.title), ["Run on startup", "Edit configuration"], "Omarchy's two rows")
+    t.equal(m.visible.map(\.title), ["Run on startup"], "what toe can actually change for you")
     t.equal(m.pop(), .popped, "Escape climbs one level")
     t.equal(m.pop(), .closed, "and closes at the root")
 }
 
 h.test("backspace eats the query, then leaves the submenu") { t in
-    var m = MenuState(root: MenuModel.root(loginItem: .off), visibleRows: 10)
+    var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 10)
     m.type("learn")
     t.equal(m.activate(), .pushed, "into Learn")
     m.type("ke")
@@ -1611,14 +1616,14 @@ h.test("an empty field is not a match") { t in
 }
 
 h.test("typing searches the whole tree, not the level in front of you") { t in
-    var m = MenuState(root: MenuModel.root(loginItem: .off), visibleRows: 10)
+    var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 10)
     m.type("startup")
     t.equal(m.visible.map(\.title), ["Run on startup"],
             "found two levels down without anyone having to go there")
     t.equal(m.visible.first?.subtitle, "Configure", "and the row says where it lives")
     t.equal(m.activate(), .toggleLoginItem, "acting on it needs no descent either")
 
-    var deep = MenuState(root: MenuModel.root(loginItem: .off), visibleRows: 10)
+    var deep = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 10)
     deep.type("keyb")
     t.equal(deep.visible.map(\.title), ["Keybindings"], "the same for the other branch")
     t.equal(deep.visible.first?.subtitle, "Learn", "named by its path")
@@ -1626,7 +1631,7 @@ h.test("typing searches the whole tree, not the level in front of you") { t in
 }
 
 h.test("a branch found by searching is still a branch") { t in
-    var m = MenuState(root: MenuModel.root(loginItem: .off), visibleRows: 10)
+    var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 10)
     m.type("learn")
     t.equal(m.visible.map(\.title), ["Learn"], "the branch itself matches, not only its children")
     t.equal(m.visible.first?.subtitle, nil, "a row at the level you are on has no path to show")
@@ -1634,7 +1639,7 @@ h.test("a branch found by searching is still a branch") { t in
 }
 
 h.test("an empty query is one level at a time, with no paths") { t in
-    var m = MenuState(root: MenuModel.root(loginItem: .off), visibleRows: 10)
+    var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 10)
     m.type("z")
     t.equal(m.visible.count, 0, "nothing matches")
     m.backspace()
@@ -1644,13 +1649,13 @@ h.test("an empty query is one level at a time, with no paths") { t in
 }
 
 h.test("the rows lead where the menu says they do") { t in
-    var m = MenuState(root: MenuModel.root(loginItem: .off), visibleRows: 10)
+    var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 10)
     t.equal(m.visible.map(\.title), ["Configure", "Learn", "Quit"], "the whole menu, bare minimum")
     t.equal(m.visible.map(\.leadsOn), [true, true, false], "two lead on, Quit acts")
     m.type("quit")
     t.equal(m.activate(), .run(.quit), "and Quit dispatches rather than descending")
 
-    var learn = MenuState(root: MenuModel.root(loginItem: .off), visibleRows: 10)
+    var learn = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 10)
     learn.type("learn")
     _ = learn.activate()
     t.equal(learn.activate(), .page(.keybindings), "Learn holds the keybindings page")
@@ -1658,28 +1663,66 @@ h.test("the rows lead where the menu says they do") { t in
 
 h.test("the startup row reads the state it is handed") { t in
     func startup(_ state: LoginItemState) -> MenuItem? {
-        guard case .submenu(let setup)? = MenuModel.root(loginItem: state).first?.action else {
-            return nil
-        }
+        let root = MenuModel.root(loginItem: state, bindings: [])
+        // By title rather than by position: Configure is the first row only while it is there
+        // at all, and the case below is the one where it is not.
+        guard case .submenu(let setup)? = root.first(where: { $0.title == "Configure" })?.action
+        else { return nil }
         return setup.first
     }
     t.equal(startup(.on)?.value, "on", "the row shows launchd's answer, not a preference")
     t.equal(startup(.on)?.action, .toggleLoginItem, "and pressing it flips it")
     t.equal(startup(.off)?.value, "off", "the other way round")
-    t.equal(startup(.unavailable("needs /Applications"))?.title, "Edit configuration",
+    t.equal(startup(.unavailable("needs /Applications"))?.title, nil,
             "where it cannot work the row is not there at all — a switch you can see but not "
             + "throw is worse than one you were never offered")
 }
 
-h.test("Configure keeps working with the startup row gone") { t in
-    var m = MenuState(root: MenuModel.root(loginItem: .unavailable("needs /Applications")),
-                      visibleRows: 10)
-    m.type("configure")
-    t.equal(m.activate(), .pushed, "into Configure")
-    t.equal(m.visible.map(\.title), ["Edit configuration"], "one row, and it is the one that works")
-    t.equal(m.activate(), .run(.editConfig), "which still does what it says")
+h.test("the Edit configuration row is your binding, not toe's idea of an editor") { t in
+    func rows(_ toml: String, loginItem: LoginItemState = .off) throws -> [MenuItem] {
+        MenuModel.configure(loginItem: loginItem, bindings: try Config.parse(toml).bindings)
+    }
 
-    var searching = MenuState(root: MenuModel.root(loginItem: .unavailable("needs /Applications")),
+    // The shipped config: the row runs exactly the line the file bound, character for character.
+    let shipped = try rows(Config.defaultTOML)
+    t.equal(shipped.map(\.title), ["Run on startup", "Edit configuration"], "both rows")
+    t.equal(shipped.last?.action,
+            .run(.exec("open -a \"Visual Studio Code\" ~/.config/toe/toe.toml")),
+            "and it opens the config the way your config says to")
+
+    // Point it at another editor and the row follows — nothing here names one.
+    let zed = try rows("[binds]\n\"super-comma\" = \"exec open -a Zed ~/.config/toe/toe.toml\"\n")
+    t.equal(zed.last?.action, .run(.exec("open -a Zed ~/.config/toe/toe.toml")),
+            "the menu opens Zed because the config does")
+
+    // On another key, too: the row is found by what it does, not by where it is bound.
+    let moved = try rows("[binds]\n\"super-shift-c\" = \"exec open -e ~/.config/toe/toe.toml\"\n")
+    t.equal(moved.last?.action, .run(.exec("open -e ~/.config/toe/toe.toml")),
+            "SUPER+SHIFT+C is as good as SUPER+, — the row follows the binding")
+
+    // An exec that opens something else is not an editor for this file.
+    let unrelated = try rows("[binds]\n\"super-enter\" = \"exec open -a Ghostty\"\n")
+    t.equal(unrelated.map(\.title), ["Run on startup"],
+            "no binding that opens the config, no row offering to")
+    t.equal(MenuModel.root(loginItem: .unavailable("needs /Applications"),
+                           bindings: try Config.parse("[binds]\n\"super-enter\" = \"exec open -a Ghostty\"\n").bindings)
+                .map(\.title),
+            ["Learn", "Quit"],
+            "and with the startup row gone as well, Configure has nothing left to hold")
+
+    // The row is there even when the startup toggle cannot be.
+    let buildDir = try rows(Config.defaultTOML, loginItem: .unavailable("needs /Applications"))
+    t.equal(buildDir.map(\.title), ["Edit configuration"],
+            "the one row that works is still offered")
+}
+
+h.test("Configure goes with the startup row, being all that was left in it") { t in
+    let m = MenuState(root: MenuModel.root(loginItem: .unavailable("needs /Applications"), bindings: []),
+                      visibleRows: 10)
+    t.equal(m.visible.map(\.title), ["Learn", "Quit"],
+            "a row that leads into an empty level is worse than no row")
+
+    var searching = MenuState(root: MenuModel.root(loginItem: .unavailable("needs /Applications"), bindings: []),
                               visibleRows: 10)
     searching.type("startup")
     t.equal(searching.visible.count, 0, "and the search cannot turn it up either")
@@ -1702,7 +1745,7 @@ h.test("the second column never runs into the title") { t in
 }
 
 h.test("the selection clamps at both ends") { t in
-    var m = MenuState(root: MenuModel.root(loginItem: .off), visibleRows: 10)
+    var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 10)
     m.move(by: -1)
     t.equal(m.selection, 0, "up from the top stays at the top — a list is not a carousel")
     m.move(by: 99)
@@ -1747,7 +1790,7 @@ h.test("every command has a label a reader could use") { t in
         .workspace(.index(3)), .workspace(.next), .workspace(.previous), .workspace(.former),
         .moveToWorkspace(5, follow: true), .moveToWorkspace(5, follow: false),
         .killActive, .toggleFloating, .toggleSplit, .swapSplit,
-        .exec("open -a Safari"), .reload, .editConfig, .quit,
+        .exec("open -a Safari"), .reload, .quit,
         .menu(.root), .menu(.keybindings),
     ]
     for command in all {
@@ -1757,6 +1800,24 @@ h.test("every command has a label a reader could use") { t in
     }
     t.equal(CommandLabel.describe(.moveFocus(.left)), "Move focus left", "a sample of the prose")
     t.equal(CommandLabel.describe(.menu(.keybindings)), "Show the keybindings", "and the new one")
+}
+
+h.test("the binding that opens the config is named rather than spelled out") { t in
+    // It read "Edit the config" while toe owned an `editconfig` command. The label is derived
+    // from the line you bound now, so it survives the command's removal without hardcoding one.
+    t.equal(CommandLabel.describe(.exec("open -a \"Visual Studio Code\" ~/.config/toe/toe.toml")),
+            "Edit the config", "the shipped binding, named")
+    t.equal(CommandLabel.describe(.exec("open -a Zed ~/.config/toe/toe.toml")),
+            "Edit the config", "and so is yours, whichever editor it names")
+    t.equal(CommandLabel.describe(.exec("open -a Ghostty")), "Run open -a Ghostty",
+            "an exec that opens something else still shows what it runs")
+
+    // The same rule the menu row is found by, so the two can never disagree.
+    let c = try Config.parse(Config.defaultTOML)
+    t.equal(MenuModel.configOpener(in: c.bindings)?.source, "super-comma",
+            "and it is the binding the menu offers as Edit configuration")
+    t.equal(c.bindings.filter { $0.command.opensConfig }.count, 1,
+            "exactly one binding in the shipped config opens it")
 }
 
 h.test("a long exec line cannot set the width of every row") { t in

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -6,7 +6,7 @@ import ToeCore
 final class Coordinator: WindowTrackerDelegate {
 
     static let configURL = FileManager.default.homeDirectoryForCurrentUser
-        .appendingPathComponent(".config/toe/toe.toml")
+        .appendingPathComponent(".config/toe/" + Config.fileName)
 
     private let workspaces = WorkspaceManager()
     private let tracker = WindowTracker()
@@ -849,9 +849,6 @@ final class Coordinator: WindowTrackerDelegate {
         case .reload:
             loadConfig()
 
-        case .editConfig:
-            openConfigInTerminal()
-
         case .menu(let page):
             quickMenu.toggle(page: page, config: config,
                              usable: workspaces.monitor(id: workspaces.focusedMonitorID)?.usable)
@@ -859,32 +856,6 @@ final class Coordinator: WindowTrackerDelegate {
         case .quit:
             shutDown()
             NSApp.terminate(nil)
-        }
-    }
-
-    /// The config has no window of its own and, since the menu bar item lost its menu, no
-    /// menu item either — so `editconfig` opens it the way you would edit it anyway: a
-    /// terminal with nano in it. Terminal.app rather than the terminal you launch with
-    /// SUPER+ENTER, because it is the one that is always installed; bind `exec` instead if
-    /// you want your own (there is a line for it in the default config).
-    private func openConfigInTerminal() {
-        let shell = "nano '" + Coordinator.configURL.path.replacingOccurrences(of: "'", with: "'\\''") + "'"
-        let quoted = shell
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"")
-        let script = """
-            tell application "Terminal"
-                activate
-                do script "\(quoted)"
-            end tell
-            """
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
-        process.arguments = ["-e", script]
-        do {
-            try process.run()
-        } catch {
-            Log.error("editconfig: could not open Terminal: \(error)")
         }
     }
 }

--- a/Sources/toe/UI/QuickMenu.swift
+++ b/Sources/toe/UI/QuickMenu.swift
@@ -106,7 +106,7 @@ final class QuickMenu {
 
         let items = page == .keybindings
             ? MenuModel.keybindings(config.bindings, superKey: config.superKey)
-            : MenuModel.root(loginItem: LoginItem.state())
+            : MenuModel.root(loginItem: LoginItem.state(), bindings: config.bindings)
         state = MenuState(root: items, visibleRows: 10)
 
         frontmostAtOpen = NSWorkspace.shared.frontmostApplication?.processIdentifier
@@ -190,15 +190,16 @@ final class QuickMenu {
         case .toggleLoginItem:
             // Deliberately does not close: the value flips under the cursor, as omarchy-menu's
             // toggles do, so you can see what you just did.
-            let items = MenuModel.root(loginItem: LoginItem.toggle())
-            if case .submenu(let setup)? = items.first?.action {
-                state?.replaceLevel(with: setup)
-            }
+            let setup = MenuModel.configure(loginItem: LoginItem.toggle(),
+                                            bindings: config.bindings)
+            // The level itself rather than the root's first row: Configure is not always the
+            // first row, and on the day the toggle answers `unavailable` it is not there at all.
+            if !setup.isEmpty { state?.replaceLevel(with: setup) }
             layoutAndRender()
         case .run(let command):
-            // Closed first, and dispatched a turn later: `editConfig` brings Terminal forward
-            // and `quit` tears the process down, and both want the panel gone and the keyboard
-            // handed back before they begin.
+            // Closed first, and dispatched a turn later: an `exec` brings another application
+            // forward and `quit` tears the process down, and both want the panel gone and the
+            // keyboard handed back before they begin.
             close()
             DispatchQueue.main.async { [weak self] in self?.onCommand?(command) }
         }

--- a/Sources/toe/UI/StatusItem.swift
+++ b/Sources/toe/UI/StatusItem.swift
@@ -7,7 +7,7 @@ import ToeCore
 /// a filled rounded square, every other one its own digit. Clicking a workspace switches to
 /// it, as Omarchy's `on-click: activate` does, and that is the whole of it: waybar's strip
 /// has no menu behind it, so neither has this one. Everything the menu used to offer lives
-/// on a key binding instead — `editconfig`, `reload`, `quit`.
+/// on a key binding instead — `reload`, `quit`, and the `exec` that opens the config.
 final class StatusItem: NSObject {
 
     private let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -2,7 +2,8 @@
 #
 # Reloads automatically when you save. If a line does not parse, the running config is kept
 # and the error is named in the menu bar item's tooltip, so a typo can never leave you
-# keyboardless. SUPER+, opens this file in nano.
+# keyboardless. SUPER+, opens this file in Visual Studio Code — a binding like any other,
+# so point it at the editor you actually use.
 #
 # This file is code, not just settings: an `exec` binding below runs a shell command, and toe
 # picks up a change within about 150 ms of the save. Anything that can write this file can run
@@ -171,9 +172,14 @@ font_size  = 18
 # ── toe itself ────────────────────────────────────────────────────────────────
 # The menu bar item is only the workspace strip — waybar's has nothing behind it either — so
 # these are the way in to everything toe can do to itself.
-# `editconfig` opens this file in nano, in a Terminal.app window. To use your own terminal,
-# bind exec instead:  "exec open -na Ghostty --args -e nano ~/.config/toe/toe.toml"
-"super-comma"   = "editconfig"
+# Editing this file is nothing special — it is an `exec`, the same as the launchers below, and
+# toe has no editor of its own. Whichever exec below mentions toe.toml is the one the quick menu
+# offers as "Edit configuration", so the menu follows this line wherever you point it. It runs
+# through /bin/sh, so ~ expands and any editor works:
+#   "exec open -a Zed ~/.config/toe/toe.toml"
+#   "exec open -e ~/.config/toe/toe.toml"                     # TextEdit, always installed
+#   "exec open -na Ghostty --args -e nano ~/.config/toe/toe.toml"
+"super-comma"   = "exec open -a \"Visual Studio Code\" ~/.config/toe/toe.toml"
 # Saving this file already reloads it; this is the manual way.
 "super-shift-r" = "reload"
 # Puts every window on a hidden workspace back where it came from on the way out.


### PR DESCRIPTION
`editconfig` was toe's own dispatcher: it drove Terminal.app with osascript and put nano in it. That is an editor chosen for you, in the one place it is hardest to override, and it sat oddly beside `SUPER`+`ENTER` and `SUPER`+`SHIFT`+`ENTER` — which have always been ordinary `exec` lines you can point anywhere.

So it is one now.

## What went

The command, entirely: the case, the `editconfig`/`config` verbs in `CommandParser`, the label, the dispatch arm, and `Coordinator.openConfigInTerminal()`.

It is not a fallback binding any more either. Fallbacks exist so a config that never mentioned an escape hatch cannot strand you, and `reload`, `quit` and the menu still qualify — but a fallback here would have to name an editor, and would put itself back on `SUPER`+`,` every time you moved the binding to another key.

## What replaces it

```toml
"super-comma"   = "exec open -a \"Visual Studio Code\" ~/.config/toe/toe.toml"
```

with Zed, TextEdit and Ghostty+nano written beside it in the shipped config as the ways to differ.

The two places that used to know what "edit the config" meant read your config instead, through one shared rule — `Command.opensConfig`: any `exec` whose line mentions the config file is taken to be the one that edits it.

- The quick menu's *Edit configuration* row runs that binding. Point it at Zed and the row opens Zed; move it to `super-shift-c` and the row follows; remove it and the row goes, rather than the menu offering an editor you never chose. `Configure` can now come out empty — its other row is the startup toggle, already left out where `SMAppService` cannot work — and the parent row is then left out too rather than leading into an empty level.
- The keybindings list names that binding *Edit the config* rather than printing the shell line, which is what it read before the command went.

```
SUPER + SHIFT + R      Reload the config
SUPER + ,              Edit the config
SUPER + ENTER          Run osascript -e 'tell application "Ghostty" to…
```

Also fixed next door: the login-item toggle rebuilt the open level from `items.first`, which stopped being `Configure` the moment that row could be absent. It asks `MenuModel.configure` for the level directly now.

## Upgrading

A config written before this says `editconfig` and will warn that the command is unknown, in the menu bar item's tooltip, until the line is changed. Deliberate, over keeping the word as an alias to the new `exec`: the point was to stop toe having an opinion about your editor, and a silent alias to one is still an opinion.

## Docs

New **What the defaults assume** section under Install, naming the three applications the shipped bindings launch — Ghostty, Safari, Visual Studio Code — with the casks that install them and the `exec` lines that replace them, plus what needs nothing installed at all.

## Tests

606 assertions pass (`make test`), 12 of them new: the shipped binding, a Zed binding, the binding moved to another key, an `exec` that opens something else, the startup row unavailable, both labels, and that exactly one shipped binding matches the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ch3BzmVHBb4k5RTcQYe8yU