### PR TITLE
Take the focus border off a fullscreen Space

### DIFF
--- a/Sources/toe/AX/AXElement.swift
+++ b/Sources/toe/AX/AXElement.swift
@@ -42,6 +42,24 @@ enum AX {
     static func setGlobalMessagingTimeout() {
         AXUIElementSetMessagingTimeout(AXUIElementCreateSystemWide(), axMessagingTimeout)
     }
+
+    /// Whether the window in front right now is a native-fullscreen one.
+    ///
+    /// Asked of the frontmost application rather than of anything toe tracks, because the
+    /// window that matters here is usually one toe manages nothing for: `isManageable` turns
+    /// fullscreen windows away, so a Safari gone fullscreen is invisible to the tracker while
+    /// being exactly the window the border must not draw over.
+    ///
+    /// A fullscreen window owns its own Space, and the border panel is `.canJoinAllSpaces`
+    /// with `.fullScreenAuxiliary` — deliberately, so it survives the Space it sits on being
+    /// switched away and back — which is also what lets it paint the previous Space's outline
+    /// straight across a fullscreen one. This is the question that stops it.
+    static var frontmostWindowIsFullscreen: Bool {
+        guard let app = NSWorkspace.shared.frontmostApplication else { return false }
+        let element = application(app.processIdentifier)
+        guard let focused = element.elementValue(kAXFocusedWindowAttribute) else { return false }
+        return focused.isFullscreen
+    }
 }
 
 extension AXUIElement {

--- a/Sources/toe/AX/WindowTracker.swift
+++ b/Sources/toe/AX/WindowTracker.swift
@@ -59,6 +59,12 @@ final class WindowTracker {
                               name: NSWorkspace.didTerminateApplicationNotification, object: nil)
         workspace.addObserver(self, selector: #selector(appActivated(_:)),
                               name: NSWorkspace.didActivateApplicationNotification, object: nil)
+        // Switching Spaces usually activates a different application, and the notification
+        // above would have covered it — but not when the fullscreen window belongs to an
+        // application that also owns tiled windows, which is the one case where nothing else
+        // says the frontmost window has changed.
+        workspace.addObserver(self, selector: #selector(activeSpaceChanged),
+                              name: NSWorkspace.activeSpaceDidChangeNotification, object: nil)
         NotificationCenter.default.addObserver(
             self, selector: #selector(screensChanged),
             name: NSApplication.didChangeScreenParametersNotification, object: nil)
@@ -69,6 +75,8 @@ final class WindowTracker {
     }
 
     @objc private func screensChanged() { delegate?.screensChanged() }
+
+    @objc private func activeSpaceChanged() { noteStackChange() }
 
     @objc private func appLaunched(_ note: Notification) {
         guard let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -544,10 +544,14 @@ final class Coordinator: WindowTrackerDelegate {
     }
 
     private func updateBorder() {
+        // `frontmostWindowIsFullscreen` is two cross-process Accessibility calls, so it comes
+        // last of the four: the three cheap conditions turn the border off in every case where
+        // there is nothing to draw anyway, and this only decides between drawing and not.
         guard config.border.enabled,
               let focused = draggedWindow ?? workspaces.focusedWindow,
               let window = tracker.window(focused),
-              !window.isStashed
+              !window.isStashed,
+              !AX.frontmostWindowIsFullscreen
         else {
             border.hide()
             return


### PR DESCRIPTION
The focus border is a click-through `NSPanel` with `.canJoinAllSpaces` and `.fullScreenAuxiliary` on it. Both are deliberate — they are what keeps the ring on the window when its Space is switched away and back, instead of the panel being stranded on the Space it was ordered onto.

They are also what draws it across a fullscreen Space. Take Safari fullscreen and toe keeps painting the gradient where the tiled window it was last on used to be: a rectangle of border floating over an app on another Space, outlining nothing. Take a *managed* window fullscreen and it is worse — the frame becomes the whole display, so the ring is drawn round the edge of the screen.

## The check

`updateBorder` grows a fourth condition, and `AX` grows the question behind it:

```swift
static var frontmostWindowIsFullscreen: Bool {
    guard let app = NSWorkspace.shared.frontmostApplication else { return false }
    let element = application(app.processIdentifier)
    guard let focused = element.elementValue(kAXFocusedWindowAttribute) else { return false }
    return focused.isFullscreen
}
```

Asked of the frontmost application, not of anything toe tracks. `isManageable` already turns fullscreen windows away, so a Safari gone fullscreen is invisible to the tracker while being exactly the window the border must not cover — there is nothing in `windows` to ask.

It is last in the guard on purpose. Two cross-process Accessibility calls is not free at the rate `updateBorder` runs, and the three cheap conditions above it already switch the border off in every case where there was nothing to draw anyway; this one only decides between drawing and not.

## The notification

Switching Spaces almost always activates a different application, and `appActivated` already funnels into `noteStackChange` → `updateBorder`, so almost every case was covered by what was there.

The exception is a fullscreen window belonging to an application that *also* owns tiled windows — a second Ghostty window taken fullscreen, say. Swipe between the two Spaces and the frontmost application never changes, so nothing at all reported that the frontmost window did. `NSWorkspace.activeSpaceDidChangeNotification` joins the tracker's observers and routes into the same `noteStackChange`.

That path also runs `sinkUnfocusedFloats`, which is a no-op here rather than churn: `WindowStack.windowsAbove` returns empty for a window that is not on screen, so on a fullscreen Space every tile reads as uncovered and `Stacking.raiseOrder` asks for no raises.

## Testing

606 assertions pass (`make test`), none of them new — the behaviour is a panel, a Space and two AX round trips, so there is nothing here the layout suite can reach. The release build is clean and a `make run` build is up and managing.

The pixels themselves are unverified and want an eye on both paths before this lands:

- an app toe never tiled taken fullscreen and switched back — the `appActivated` path
- a second window of an already-tiled app taken fullscreen, swiping between the two Spaces — the `activeSpaceDidChangeNotification` path, the one nothing else reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ch3BzmVHBb4k5RTcQYe8yU
