### PR TITLE
Scope the fullscreen border check to a display, and stop raising tiles on a Space switch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,142 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A native macOS tiling window manager: a direct port of Hyprland's `CHyprDwindleLayout`, with
+Omarchy's defaults (`preserve_split = true`, `force_split = 2`). It runs as a background agent
+(`.accessory`) with no Dock icon and no main window — a menu bar item, key bindings and a
+gradient border around the focused window. Accessibility is the only permission it asks for.
+
+## Commands
+
+```sh
+make test      # layout suite — no permissions, no Xcode, ~1s
+make run       # build, bundle, sign, relaunch in place (replaces any running toe)
+make bundle    # build/Toe.app, runs `make test` first
+make install   # same, into /Applications
+make dev-cert  # once per machine — see "Accessibility and code signing" below
+make reset-perms
+make example-config   # regenerate toe.example.toml from the default baked into the binary
+```
+
+`swift build -c release` and `swift run -c debug toe-selftest` are what those wrap.
+
+**Running one test:** the harness has no filter. `Sources/toe-selftest/Harness.swift` is a plain
+executable rather than XCTest (XCTest ships with Xcode, not the Command Line Tools, so this keeps
+`make test` working on a bare CLT machine). The whole suite is ~600 assertions and runs in about a
+second, so run all of it. Failures print as `test name:line — what: got X, want Y`.
+
+**Diagnostics without launching the agent:**
+
+```sh
+toe --version                # what the bundle was stamped with
+toe --print-default-config   # the shipped default TOML
+toe --print-corner-radius    # what macOS rounds each on-screen window to
+log stream --predicate 'subsystem == "com.clifmeister.toe"' --level info
+```
+
+## The two-target split
+
+`Package.swift` enforces the architecture:
+
+- **`Sources/ToeCore`** — pure geometry and state. No AppKit, no Accessibility, no Carbon. The
+  dwindle port, workspaces, config parsing, the menu model, session snapshots, border geometry.
+  This is the only part the selftest can reach, so **anything worth testing belongs here.** When a
+  decision in `Sources/toe` needs test coverage, the move is to lift the arithmetic into ToeCore
+  and leave the system call behind — `BorderGeometry` exists entirely for that reason.
+- **`Sources/toe`** — everything touching the system. AX, CGWindowList, Carbon hotkeys, event
+  taps, AppKit panels.
+
+Adding an AppKit import to ToeCore breaks the test suite's reason for existing.
+
+## How a change reaches the screen
+
+`Coordinator` is the hub and the only `WindowTrackerDelegate`. Roughly:
+
+1. `WindowTracker` discovers windows per-application via `AXObserver` and calls back
+   (`windowAppeared`, `windowFocused`, `windowFrameChangedExternally`, `windowStackChanged`,
+   `activeSpaceChanged`, `screensChanged`).
+2. `Coordinator.dispatch(_ command:)` mutates `WorkspaceManager` — the layout model.
+3. `apply(refocus:)` calls `workspaces.render()` for a `RenderPlan` (`frames`, `floating`,
+   `stashed`, `focus`) and writes only what differs from `desired`.
+4. `updateBorder()` last.
+
+Two invariants in that loop are easy to break:
+
+- **`desired` / `corrections`.** Chromium, Electron and JetBrains apps re-apply their own geometry
+  after a window opens, so a frame is re-asserted when it changes behind toe's back — bounded at
+  three attempts, so an app whose minimum size exceeds its tile is written once and left alone.
+  Floating windows deliberately bypass this machinery: pointing it at one would fight the user's
+  own drags.
+- **A window the user has hold of is never written to.** `draggedWindow` is checked in `apply`,
+  `windowFrameChangedExternally` and `updateBorder`; the frame is written once, on release.
+
+## Things that will bite you
+
+**Coordinate spaces.** `Box` is Accessibility coordinates: origin top-left of the primary display,
+y growing *down*. `kCGWindowBounds` is already the same space — `WindowStack.ordinaryWindowsAbove`
+does no conversion, and adding one would be invisible on a single display and badly wrong on two.
+`Coordinates.toCocoa` / `toAX` flip about the primary display's height and are for AppKit only.
+
+**Workspaces are not macOS Spaces.** There is no public API for putting a window on another Space,
+so hidden workspaces park windows far off-screen (`stashPoint`) and restore their frames on return.
+Consequences: stashed windows are still visible to Cmd-Tab and Mission Control, and anything that
+asks the window server about an off-screen window gets an answer that means "not on screen", not
+"nothing there". `WindowStack.windowsAbove` returning an empty set is the trap — `Stacking.raiseOrder`
+reads empty as *this float is on top*, not *no idea*.
+
+**Native-fullscreen windows** are never managed (`isManageable` rejects them) but do affect the
+border: the border panel is `.canJoinAllSpaces` + `.fullScreenAuxiliary`, so it will happily paint
+across a fullscreen Space unless something stops it. With *Displays have separate Spaces* on (the
+macOS default) "is anything fullscreen" is never the right question — scope it to a display.
+
+**State that outlives the process.** Symbolic hotkeys (`CGSSetSymbolicHotKeyEnabled`) and the
+wallpaper-click preference are the window server's, not toe's, so a `kill -9` during development
+would leave `Ctrl`+`↑` dead with nothing to explain why. Both are journalled to
+`~/.local/state/toe/` *before* the change is made and replayed in reverse at startup. If you add
+another such global toggle, follow that pattern.
+
+**The session snapshot** (`~/.local/state/toe/session.json`) is keyed on `CGWindowID` plus
+`kern.boottime`, and is restored *before* the tracker starts. A stale snapshot is discarded unread
+rather than expired by age.
+
+**AX calls are synchronous and on the main thread**, capped at 250 ms (`axMessagingTimeout`). They
+are not rare — `isManageable` alone is six round trips per candidate window. Adding one to a path
+that runs on every focus change or stack change is a real cost; put it after the cheap conditions.
+
+## Accessibility and code signing
+
+macOS keys the Accessibility grant to the code signature, and an ad-hoc signature changes on every
+build — so without `make dev-cert` (a stable self-signed `toe-dev` identity, one password prompt)
+you re-grant permission after every rebuild. `scripts/bundle.sh` picks it up automatically. When
+hotkeys or window moves stop working after a rebuild, `make reset-perms` and re-grant.
+
+## Releasing
+
+Push a tag; nothing in the tree carries the version. `.github/workflows/release.yml` derives it
+from the tag name, stamps `Info.plist` via `TOE_VERSION`, signs with the Developer ID cert,
+notarizes, staples, publishes the release, then opens *and merges* its own `Casks/toe.rb` bump PR.
+
+```sh
+git tag -a v0.9.4 -m "toe 0.9.4 — <what changed>" && git push origin v0.9.4
+```
+
+`main` requires changes to arrive by PR, which is why the cask bump is a self-merging PR marked
+`[skip ci]` rather than a push.
+
+**The `claude-review` check reports `pass` while leaving inline comments.** `gh pr checks` does not
+surface them. Read `gh api repos/theclifmeister/toe/pulls/N/comments` before merging — a green
+check is not an empty review.
+
+## Conventions
+
+Comments here explain **why**, at length, and frequently name the bug or the platform behaviour
+that forced the code into its shape ("this guard has to come first", "learned at v0.9.1"). Match
+that density — a change that removes the reasoning is a regression even when the code is right.
+Commit subjects are sentences in the imperative: *Send a detached window behind the tiles when it
+loses the focus*.
+
+`Resources/Toe.icns` is committed and `make icon` regenerates it — deliberately not a build
+dependency, so don't run it unless the icon is the point.

--- a/Sources/ToeCore/BorderGeometry.swift
+++ b/Sources/ToeCore/BorderGeometry.swift
@@ -28,6 +28,33 @@ public enum BorderGeometry {
         return Box(x: box.x - w, y: box.y - w, w: box.w + 2 * w, h: box.h + 2 * w)
     }
 
+    /// Whether `window` sits on a display a fullscreen window has taken over.
+    ///
+    /// The border panel is `.canJoinAllSpaces` with `.fullScreenAuxiliary` — deliberately, so
+    /// the ring survives the Space it sits on being switched away and back — which is also
+    /// what lets it paint a tiled window's outline straight across a fullscreen Space. This
+    /// is the test that stops it.
+    ///
+    /// Geometry rather than a global "is anything fullscreen" flag, because under macOS's
+    /// default *Displays have separate Spaces* both are true at once: a fullscreen Safari on
+    /// the second display leaves the first showing its ordinary Space, tiled windows and all,
+    /// and the ring there is covering nothing. A fullscreen window fills exactly one display,
+    /// so overlapping its frame is the same question as sharing its display.
+    ///
+    /// Measured against the window rather than the band drawn around it. The band is outset
+    /// past the window's edges, so a tile flush against the boundary between two displays
+    /// would bleed its border width into the neighbouring one and read as covered there —
+    /// the window itself never does.
+    ///
+    /// `epsilon` leans the same way `bandIsCovered` does: a sliver of overlap is the window
+    /// server and Accessibility disagreeing about an edge, not a shared display.
+    public static func isBehindFullscreen(window: Box, fullscreen: Box?,
+                                          epsilon: Double = 1) -> Bool {
+        guard let fullscreen else { return false }
+        let clipped = window.intersection(fullscreen)
+        return clipped.w > epsilon && clipped.h > epsilon
+    }
+
     /// Whether anything in `others` covers part of the *band*, rather than merely sitting over
     /// the window's own interior — which the border never draws on anyway, so a dialog centred
     /// on the window hides none of it.

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -1146,6 +1146,73 @@ h.test("the border only gives way to a window that covers the band") { t in
             "neither of two is still nothing")
 }
 
+// The two displays are the built-in Retina panel at the origin and a 2560x1440 external one
+// to its right, which is where the coordinates below come from. A fullscreen window fills
+// exactly one display, so the fullscreen frames here are the display frames.
+h.test("the border gives way only on the display a fullscreen window took over") { t in
+    let builtIn = box(0, 0, 1512, 982)
+    let external = box(1512, 0, 2560, 1440)
+    let tile = box(15, 48, 842, 934)                    // a tile on the built-in display
+    func behind(_ fullscreen: Box?) -> Bool {
+        BorderGeometry.isBehindFullscreen(window: tile, fullscreen: fullscreen)
+    }
+
+    t.equal(behind(nil), false, "nothing is fullscreen, so the border stays")
+    t.equal(behind(builtIn), true, "fullscreen on this display covers the tile")
+    t.equal(behind(external), false,
+            "fullscreen on the other display leaves this one showing its own Space")
+
+    // The regression the display scoping exists for: with `Displays have separate Spaces` both
+    // of these are true at once, and a global "is anything fullscreen" flag cannot tell them
+    // apart. It answered `true` for both, and took the ring off a tile covering nothing.
+    let tileOnExternal = box(1600, 48, 900, 1300)
+    t.equal(BorderGeometry.isBehindFullscreen(window: tileOnExternal, fullscreen: external), true,
+            "the same fullscreen window does cover a tile on its own display")
+
+    // A window flush against the boundary between the displays. Measured against the window
+    // and not the band drawn around it, so the outset cannot bleed onto the neighbour.
+    let flush = box(1112, 48, 400, 934)                 // right edge exactly on the boundary
+    t.equal(BorderGeometry.isBehindFullscreen(window: flush, fullscreen: external), false,
+            "a tile touching the boundary is not on the display across it")
+    t.equal(BorderGeometry.isBehindFullscreen(window: flush, fullscreen: builtIn), true,
+            "it is on its own display, though")
+
+    // Leaning the same way `bandIsCovered` does: a sliver is AX and the window server
+    // disagreeing about an edge, not a shared display.
+    t.equal(BorderGeometry.isBehindFullscreen(window: box(1112, 48, 400.5, 934),
+                                              fullscreen: external), false,
+            "a right edge half a point past the boundary is rounding noise")
+    t.equal(BorderGeometry.isBehindFullscreen(window: box(1112, 48, 402, 934),
+                                              fullscreen: external), true,
+            "two points past it is a window really reaching onto that display")
+}
+
+// Guards the reason `activeSpaceChanged` is its own callback rather than `windowStackChanged`.
+// `WindowStack.windowsAbove` returns an empty set for a window that is not on screen, and this
+// is what `raiseOrder` does with that — so a Space switch that ran the float sink would raise
+// the tiles on the Space just left, three times over.
+h.test("an off-screen float reads as needing its tiles raised, not as settled") { t in
+    let tiles: [WindowID: Box] = [1: box(0, 0, 756, 982), 2: box(756, 0, 756, 982)]
+    let floats: [WindowID: Box] = [3: box(300, 200, 900, 500)]   // overlaps both tiles
+
+    // What `WindowStack.windowsAbove` answers for a window on another Space.
+    let offScreen = Stacking.raiseOrder(tiles: tiles, floats: floats, focused: 1,
+                                        stackedAbove: { _ in [] })
+    t.equal(offScreen.isEmpty, false,
+            "an empty set reads as 'the float is on top', so the tiles are raised")
+
+    // The same float genuinely at the bottom of what it covers asks for nothing.
+    let settled = Stacking.raiseOrder(tiles: tiles, floats: floats, focused: 1,
+                                      stackedAbove: { _ in [1, 2] })
+    t.equal(settled.isEmpty, true, "a float already under both tiles is left alone")
+
+    // And with no float at all there is nothing to sink either way, which is why this went
+    // unnoticed on a layout of pure tiles.
+    t.equal(Stacking.raiseOrder(tiles: tiles, floats: [:], focused: 1,
+                                stackedAbove: { _ in [] }).isEmpty, true,
+            "no floats, no raises")
+}
+
 h.test("binding specs parse in both spellings") { t in
     func parse(_ s: String) -> String? {
         guard let (m, code, name) = try? BindingParser.parse(s, superKey: .option) else { return nil }

--- a/Sources/toe/AX/AXElement.swift
+++ b/Sources/toe/AX/AXElement.swift
@@ -43,22 +43,29 @@ enum AX {
         AXUIElementSetMessagingTimeout(AXUIElementCreateSystemWide(), axMessagingTimeout)
     }
 
-    /// Whether the window in front right now is a native-fullscreen one.
+    /// The frame of the window in front, when that window is a native-fullscreen one — and
+    /// `nil` whenever it is not, which is the ordinary case.
     ///
     /// Asked of the frontmost application rather than of anything toe tracks, because the
     /// window that matters here is usually one toe manages nothing for: `isManageable` turns
     /// fullscreen windows away, so a Safari gone fullscreen is invisible to the tracker while
     /// being exactly the window the border must not draw over.
     ///
-    /// A fullscreen window owns its own Space, and the border panel is `.canJoinAllSpaces`
-    /// with `.fullScreenAuxiliary` — deliberately, so it survives the Space it sits on being
-    /// switched away and back — which is also what lets it paint the previous Space's outline
-    /// straight across a fullscreen one. This is the question that stops it.
-    static var frontmostWindowIsFullscreen: Bool {
-        guard let app = NSWorkspace.shared.frontmostApplication else { return false }
+    /// A frame rather than a yes/no, because "something is fullscreen somewhere" is not the
+    /// question. Under macOS's default *Displays have separate Spaces*, each display shows its
+    /// own Space at the same time, so a fullscreen Safari on one display says nothing about
+    /// the tiled window holding the border on another. The frame is what lets the caller ask
+    /// about the display the border is actually on; see `BorderGeometry.isBehindFullscreen`.
+    ///
+    /// `frame` is only read once `isFullscreen` says yes, so the common answer still costs the
+    /// two Accessibility round trips it always did rather than four.
+    static var frontmostFullscreenFrame: Box? {
+        guard let app = NSWorkspace.shared.frontmostApplication else { return nil }
         let element = application(app.processIdentifier)
-        guard let focused = element.elementValue(kAXFocusedWindowAttribute) else { return false }
-        return focused.isFullscreen
+        guard let focused = element.elementValue(kAXFocusedWindowAttribute),
+              focused.isFullscreen
+        else { return nil }
+        return focused.frame
     }
 }
 

--- a/Sources/toe/AX/WindowTracker.swift
+++ b/Sources/toe/AX/WindowTracker.swift
@@ -35,6 +35,10 @@ protocol WindowTrackerDelegate: AnyObject {
     /// forward, or one opened a window toe will never tile. Neither changes the layout, but
     /// both change what is stacked over the focused window.
     func windowStackChanged()
+    /// The displays are showing different Spaces than they were. Nothing toe manages has
+    /// moved — not the layout, and not the stacking within it — but what is in front of it
+    /// all has changed, which is a different fact and deliberately a separate callback.
+    func activeSpaceChanged()
 }
 
 /// Discovers windows and keeps them in sync with the running applications.
@@ -63,7 +67,7 @@ final class WindowTracker {
         // above would have covered it — but not when the fullscreen window belongs to an
         // application that also owns tiled windows, which is the one case where nothing else
         // says the frontmost window has changed.
-        workspace.addObserver(self, selector: #selector(activeSpaceChanged),
+        workspace.addObserver(self, selector: #selector(spaceChanged),
                               name: NSWorkspace.activeSpaceDidChangeNotification, object: nil)
         NotificationCenter.default.addObserver(
             self, selector: #selector(screensChanged),
@@ -76,7 +80,23 @@ final class WindowTracker {
 
     @objc private func screensChanged() { delegate?.screensChanged() }
 
-    @objc private func activeSpaceChanged() { noteStackChange() }
+    /// Deliberately not `noteStackChange`. That one sinks unfocused floats, and a Space switch
+    /// is the one moment it must not: `WindowStack.windowsAbove` returns an empty set for a
+    /// window that is off screen, and `Stacking.raiseOrder` reads empty as "this float is on
+    /// top of the tiles it covers" rather than "no idea" — so every switch away would raise
+    /// the tiles on the Space just left. Nothing toe manages has restacked here; only what is
+    /// in front of it has.
+    ///
+    /// Fires now and twice more shortly after, for the reason `noteStackChange` does: the
+    /// frontmost application is not necessarily the new Space's yet.
+    @objc private func spaceChanged() {
+        delegate?.activeSpaceChanged()
+        for delay in [0.15, 0.4] {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+                self?.delegate?.activeSpaceChanged()
+            }
+        }
+    }
 
     @objc private func appLaunched(_ note: Notification) {
         guard let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -491,6 +491,13 @@ final class Coordinator: WindowTrackerDelegate {
         updateBorder()
     }
 
+    /// A different Space is on show. The layout is untouched and so is the stacking inside it,
+    /// so the floats are left exactly where they are — the border is the only thing that cares,
+    /// because the window now in front may be a fullscreen one it must not draw over.
+    func activeSpaceChanged() {
+        updateBorder()
+    }
+
     // MARK: - Applying the layout
 
     private func apply(refocus: Bool) {
@@ -544,18 +551,20 @@ final class Coordinator: WindowTrackerDelegate {
     }
 
     private func updateBorder() {
-        // `frontmostWindowIsFullscreen` is two cross-process Accessibility calls, so it comes
-        // last of the four: the three cheap conditions turn the border off in every case where
-        // there is nothing to draw anyway, and this only decides between drawing and not.
         guard config.border.enabled,
               let focused = draggedWindow ?? workspaces.focusedWindow,
               let window = tracker.window(focused),
-              !window.isStashed,
-              !AX.frontmostWindowIsFullscreen
+              !window.isStashed
         else {
             border.hide()
             return
         }
+
+        // Read once, after the cheap conditions rather than among them: it costs a
+        // cross-process Accessibility round trip, and the guard above already turns the border
+        // off in every case where there was nothing to draw. Both `show` paths below test
+        // against it, because either can be the one pointed at a fullscreen display.
+        let fullscreen = AX.frontmostFullscreenFrame
 
         // While the user has hold of a window the border marks the tile it will land in rather
         // than the window itself. Two reasons, and they point the same way: toe hears about the
@@ -566,7 +575,8 @@ final class Coordinator: WindowTrackerDelegate {
         if focused == draggedWindow {
             // Behind the window being dragged, and above every other one — where Hyprland puts
             // it, since it draws each border with its own window and the focused window last.
-            if let tile = desired[focused] {
+            if let tile = desired[focused],
+               !BorderGeometry.isBehindFullscreen(window: tile, fullscreen: fullscreen) {
                 border.show(around: tile, of: focused, depth: .behindFrontmost)
             } else {
                 border.hide()
@@ -575,7 +585,8 @@ final class Coordinator: WindowTrackerDelegate {
         }
 
         // Prefer the frame we wrote; fall back to asking the window for floating ones.
-        if let box = window.element.frame ?? desired[focused] {
+        if let box = window.element.frame ?? desired[focused],
+           !BorderGeometry.isBehindFullscreen(window: box, fullscreen: fullscreen) {
             border.show(around: box, of: focused, depth: borderDepth(around: box, of: focused))
         } else {
             border.hide()


### PR DESCRIPTION
The review on #69 left two inline comments. Both were right, and neither was addressed before that PR merged and shipped as v0.9.3 — this is the follow-up.

## The border went out on every display

`AX.frontmostWindowIsFullscreen` asked one global question: is the frontmost window fullscreen. Under macOS's default *Displays have separate Spaces*, that is not the question. Each display shows its own Space at the same time, so a fullscreen Safari on the external display leaves the built-in one showing tiled windows, ordinary and uncovered — and the ring there was taken off anyway. Before #69 it stayed.

`frontmostFullscreenFrame` returns the frame instead of a flag, and the decision moves into ToeCore where the selftest can reach it:

```swift
public static func isBehindFullscreen(window: Box, fullscreen: Box?,
                                      epsilon: Double = 1) -> Bool {
    guard let fullscreen else { return false }
    let clipped = window.intersection(fullscreen)
    return clipped.w > epsilon && clipped.h > epsilon
}
```

A fullscreen window fills exactly one display, so overlapping its frame and sharing its display are the same question — no `NSScreen` lookup needed to answer it.

Measured against the window, not the band drawn around it. The band is outset past the window's edges, so a tile flush against the boundary between two displays would bleed its border width onto the neighbour and read as covered there; the window itself never does. `epsilon` leans the way `bandIsCovered` already does, so a sliver is AX and the window server disagreeing about an edge rather than a shared display.

Both `show` paths test it now, the drag one included — either can be the one pointed at a fullscreen display.

`frame` is still only read once `isFullscreen` says yes, so the ordinary answer costs the two Accessibility round trips it did before rather than four.

## Every Space switch raised tiles

This one contradicted the justification I wrote for adding the observer in the first place. I claimed `sinkUnfocusedFloats` no-ops on the Space-change path because `WindowStack.windowsAbove` reads an off-screen window as uncovered. The opposite is true.

`Stacking.raiseOrder` skips a float only when `over.allSatisfy(stackedAbove(float).contains)`, and `over` is guaranteed non-empty by the guard above it. `allSatisfy` against an *empty* set is therefore always false — an empty `stackedAbove` means "nothing is above this float", which reads as *the float is on top and must be sunk*, not "it is off screen and I have no idea". So every Space switch raised the tiles on the Space just left, three times over via `noteStackChange`'s repeats.

Reachable only with an unfocused float on a visible workspace — `sinking` is empty otherwise — which is why a layout of pure tiles showed nothing.

The fix is not to touch `Stacking`, whose behaviour is right for the on-screen float it was written for. A Space switch gets its own delegate callback:

```swift
func activeSpaceChanged() {
    updateBorder()
}
```

Nothing toe manages has restacked. Only what is in front of it has, and the border is the one thing that cares. The float sink stays on `windowStackChanged`, where the windows really were on screen to be asked about.

## Tests

617 assertions pass (`make test`), 11 new:

- the display scoping either side of a two-display boundary, including the case a global flag got wrong — one fullscreen window, two tiles, opposite answers
- a tile flush on the boundary, and half a point versus two points across it
- what `raiseOrder` actually does with an off-screen float, the settled float that asks for nothing, and the no-float case that hid this

The pixels still want an eye on them; that part of #69 is unverified too.

## Also here: CLAUDE.md

The repository had none. It is aimed at what is wrong-turn expensive rather than what a file listing already says — the ToeCore/toe split stated as a rule about where testable logic goes, the write loop and the two invariants easiest to break in it, and four traps none of which are visible from any single file: AX versus Cocoa coordinates (and that `kCGWindowBounds` needs no conversion), workspaces as off-screen stashes rather than Spaces, fullscreen windows being unmanaged yet still reaching the border, and journalling window-server state before changing it.

Both bugs above are in it as guidance: that an empty `windowsAbove` means "not on screen" rather than "nothing there", and that the `claude-review` check reports `pass` while leaving inline comments `gh pr checks` does not surface — which is how they reached v0.9.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ch3BzmVHBb4k5RTcQYe8yU

