### PR TITLE
Widen the quick menu to 400 points so every row draws whole

### DIFF
--- a/Sources/ToeCore/Config/Config.swift
+++ b/Sources/ToeCore/Config/Config.swift
@@ -70,8 +70,15 @@ public struct MenuConfig: Equatable {
     public var border: String?
     /// `.box-wrapper { background: alpha(@base, 0.95) }`. The search strip stays opaque.
     public var opacity: Double = 0.95
-    /// `omarchy-menu` invokes walker with `--width 295`, and `--width 800` for a list view.
-    public var width: Double = 295
+    /// `omarchy-menu` invokes walker with `--width 295`, and `--width 800` for a list view. The
+    /// list width is walker's; the menu's is not, and the divergence is deliberate — see #74.
+    /// 295 leaves 193 points for a title once the icon and the paddings are out, and "Edit
+    /// configuration" at 18pt JetBrainsMono measures 194, so it truncated by a single point;
+    /// the second column beside "Run on startup" had 28 points to draw `off` in, which needs
+    /// 32. Both were a hair short rather than plainly wrong, which is why it read as a rendering
+    /// glitch for so long. 400 leaves 298 and 133, and every row in `MenuModel.root` draws
+    /// whole. Re-measure these before narrowing it again.
+    public var width: Double = 400
     public var listWidth: Double = 800
     /// GTK's 18px, one for one. The one metric worth a knob: 18 pt is large by macOS convention
     /// and this is how you disagree with that without re-theming the rest.

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -116,9 +116,11 @@ foreground = "#a9b1d6"
 accent     = "#7aa2f7"
 # The window is the background at 95%, as walker's .box-wrapper is. The search line stays solid.
 opacity    = 0.95
-# omarchy-menu asks walker for 295 points, and 800 for a list like the keybindings page. Both
-# are clamped to the display if it is narrower.
-width      = 295
+# omarchy-menu asks walker for 295 points, and 800 for a list like the keybindings page. The list
+# width is walker's; the menu's is not — at 295 the row "Edit configuration" was a point too wide
+# to draw whole, and the column that says on or off beside "Run on startup" was four points too
+# narrow. 400 fits every row. Both are clamped to the display if it is narrower.
+width      = 400
 list_width = 800
 # walker draws at 18px and so does this. The one measurement here worth changing: the padding,
 # the icon size and the gaps are all walker's and are left alone.

--- a/Sources/ToeCore/Menu/MenuModel.swift
+++ b/Sources/ToeCore/Menu/MenuModel.swift
@@ -108,9 +108,11 @@ public enum MenuModel {
     }
 
     /// nil where the toggle cannot work — the row is left out rather than shown dimmed beside a
-    /// reason. Walker's menu is 295 points wide and its second column holds about three
-    /// characters, so a row that has to explain itself has nowhere to do it; and a switch you
-    /// can see but not throw is worse than one that is not offered. `LoginItem` logs why.
+    /// reason. Even at the 400 points the menu widened to in #74, the second column beside this
+    /// title is 133 points: enough for `on` or `off` and nowhere near the reason it would have
+    /// to give ("needs /Applications"), so a row that has to explain itself has nowhere to do
+    /// it. And a switch you can see but not throw is worse than one that is not offered.
+    /// `LoginItem` logs why.
     private static func startup(_ state: LoginItemState) -> MenuItem? {
         switch state {
         case .on:

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -1797,12 +1797,18 @@ h.test("Configure goes with the startup row, being all that was left in it") { t
 
 h.test("the second column never runs into the title") { t in
     let m = MenuMetrics(lineHeight: 22)
-    let row = MenuLayout.rowFrame(0, width: 295, m)
-    // "Run on startup" at 18pt JetBrainsMono, past a 16pt icon and its 14pt gap.
-    let titleEnd = row.x + m.itemPaddingLeft + m.iconSide + m.iconGap + 151
+    let narrow = MenuLayout.rowFrame(0, width: 295, m)
+    // "Run on startup" at 18pt JetBrainsMono, past a 16pt icon and its 14pt gap. The row's x is
+    // the content inset, so it is the same at every width and the title ends in the same place.
+    let titleEnd = narrow.x + m.itemPaddingLeft + m.iconSide + m.iconGap + 151
+    t.equal(MenuLayout.valueSpace(inRow: narrow, titleEnd: titleEnd, m), 28,
+            "at walker's 295 there are 28 points for a value that needs 32 to say off — why #74")
+
+    let row = MenuLayout.rowFrame(0, width: MenuConfig().width, m)
     let space = MenuLayout.valueSpace(inRow: row, titleEnd: titleEnd, m)
-    t.expect(space < 40, "at walker's 295 points there is room for about three characters")
-    t.expect(space > 0, "but not less than none")
+    t.equal(space, 133, "the 400 the default widened to leaves 133, which off fits inside")
+    t.expect(space < 200, "and is still too little to name a reason in, which is why the "
+                          + "unavailable startup row is dropped rather than dimmed")
 
     let wide = MenuLayout.rowFrame(0, width: 800, m)
     t.expect(MenuLayout.valueSpace(inRow: wide, titleEnd: titleEnd, m) > 400,
@@ -1913,7 +1919,7 @@ h.test("the panel is as tall as its rows, and never taller than the display") { 
     let small = MenuLayout.size(rows: 3, width: 295, maxHeight: 900, m)
     t.equal(small.visibleRows, 3, "three rows fit with room to spare")
     t.equal(small.size.y, 246, "and the panel is exactly that tall")
-    t.equal(small.size.x, 295, "omarchy-menu's --width 295")
+    t.equal(small.size.x, 295, "and as wide as it was asked for")
 
     let long = MenuLayout.size(rows: 50, width: 800, maxHeight: 900, m)
     t.expect(long.size.y <= 900, "fifty bindings do not make a panel taller than the screen")
@@ -1977,7 +1983,7 @@ h.test("the menu table defaults to Omarchy's Tokyo Night") { t in
     t.equal(c.menu.accent, "#7aa2f7", "@selected-text")
     t.equal(c.menu.borderColor, c.menu.foreground, "walker maps the border to the foreground")
     t.equal(c.menu.opacity, 0.95, "alpha(@base, 0.95)")
-    t.equal(c.menu.width, 295, "omarchy-menu's --width for the menu")
+    t.equal(c.menu.width, 400, "wider than omarchy-menu's 295: these rows are sentences")
     t.equal(c.menu.listWidth, 800, "and for a list view")
     t.equal(c.menu.fontSize, 18, "walker draws at 18px")
 }

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -109,9 +109,11 @@ foreground = "#a9b1d6"
 accent     = "#7aa2f7"
 # The window is the background at 95%, as walker's .box-wrapper is. The search line stays solid.
 opacity    = 0.95
-# omarchy-menu asks walker for 295 points, and 800 for a list like the keybindings page. Both
-# are clamped to the display if it is narrower.
-width      = 295
+# omarchy-menu asks walker for 295 points, and 800 for a list like the keybindings page. The list
+# width is walker's; the menu's is not — at 295 the row "Edit configuration" was a point too wide
+# to draw whole, and the column that says on or off beside "Run on startup" was four points too
+# narrow. 400 fits every row. Both are clamped to the display if it is narrower.
+width      = 400
 list_width = 800
 # walker draws at 18px and so does this. The one measurement here worth changing: the padding,
 # the icon size and the gaps are all walker's and are left alone.


### PR DESCRIPTION
Fixes #74.

295 is what `omarchy-menu` asks walker for, and porting it over was right up until the rows stopped being walker's. Measured against `MenuLayout`'s metrics with the bundled JetBrainsMono at 18pt:

| | title space | widest title | `on`/`off` column |
|---|---|---|---|
| **295** | 193 pt | 194 pt (*Edit configuration*) — truncated | 28 pt, `off` needs 32 — truncated |
| **400** | 298 pt | 194 pt — fits | 133 pt — fits |

Both symptoms were a handful of points short rather than plainly wrong, which is why it read as a rendering glitch rather than a width.

`list_width` stays at walker's 800 — the keybindings page was never the problem.

## Changed

- `MenuConfig.width` 295 → 400, and the same in the baked default TOML plus the regenerated `toe.example.toml`.
- The two comments whose reasoning cited "295 points / about three characters". `MenuModel.startup` still drops the unavailable row rather than dimming it beside a reason — 133 pt is room for `off` and nowhere near `needs /Applications` — but the number it argues from has changed.
- Tests assert the measured 28 and 133 exactly, and the default-width case now comes from `MenuConfig().width` rather than a literal.

## Testing

`make test` — 618 assertions pass. `make bundle` builds and signs.