### PR TITLE
Add Omarchy themes, fetched from Omarchy rather than shipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ as the defaults.
 | `SUPER` + `W` | Close window |
 | `SUPER` + `J` | Toggle split orientation |
 | `SUPER` + `T` | Cycle floating: 70×80% of the display, 80×90%, back to tiling |
-| `SUPER` + `SPACE` | The quick menu — Configure, Learn, Quit |
+| `SUPER` + `SPACE` | The quick menu — Configure, Learn, Style, Quit |
+| `SUPER` + `CTRL` + `SPACE` | Next background, when the theme has any |
 | `SUPER` + `K` | Every binding, in a list |
 | `SUPER` + `,` | Edit the config — a VS Code window |
 | `SUPER` + `SHIFT` + `R` / `Q` | Reload the config / quit toe |
@@ -130,6 +131,11 @@ toe creates the directory `0700` and the file `0600` on first run, so nothing el
 machine can write it by default. If the file is later found writable by other users, or owned
 by someone else, the menu bar item says so. Symlinking it into a dotfiles repository still
 works, and is checked at the far end of the link.
+
+toe writes this file in exactly one place: the `[theme] name` line, when you pick a theme from
+the quick menu. Every other byte is preserved, the symlink is followed rather than replaced, the
+mode is left as it was, and the result is parsed before it is committed — if it would not say
+what it was asked to say, nothing is written and the log says why.
 
 ### From source
 
@@ -262,6 +268,102 @@ never trap you.
 The costs, plainly: `SUPER`+`SPACE` and `SUPER`+`K` are ⌥Space and ⌥K, and Carbon claims them
 system-wide while toe runs, so neither types ` ` or `˚` any more. Neither collides with a system
 shortcut — Spotlight is ⌘Space — and both are ordinary bindings you can move.
+
+**Themes.** Omarchy's menu has a `Style` › `Theme` level, and it is the surface toe was missing:
+the border and the menu were six hex strings you edited by hand. toe ports it, and the mapping
+turned out to be exact — `[menu]`'s shipped `#1a1b26` / `#a9b1d6` / `#7aa2f7` *are* Tokyo Night's
+`colors.toml`, resolved through walker's tokens. So with no theme set toe already looks like one,
+which is why an install that has never been online does not look unthemed.
+
+**toe ships no themes.** A theme is somebody else's work — palettes and photographs with no stated
+licence — and bundling them inside a notarised app distributed through a Homebrew cask would be
+toe redistributing them rather than Omarchy. So the list you choose from is what is in
+`~/.config/toe/themes` plus what Omarchy publishes, and choosing one you have not got downloads it
+from Omarchy for you. All nineteen of them, rather than a chosen three, and 79 MB of pictures that
+never ship.
+
+`Style` › `Theme` lists what you have first, then what you could have, each with what it would
+cost to fetch:
+
+```
+Tokyo Night           current
+Rose Pine
+Everforest            0.3 MB
+Kanagawa              2.1 MB
+Gruvbox               9.2 MB
+Your own colours
+```
+
+The size is the disclosure — they run from a third of a megabyte to nine, and a row that fetched
+nine without saying so would be a row that surprised you. Choosing one is the same act either way:
+if you have it, it is applied; if you do not, it is fetched and then applied.
+
+**The network, stated plainly.** toe asks for Accessibility and nothing else, and it makes exactly
+two kinds of request, both to github.com and both because you did something: the list of themes
+when you open `Style` › `Theme`, cached and refreshed at most once a day, and a theme when you
+choose one. Nothing at launch, no update check, no telemetry. A machine that has never been online
+has no themes to choose from and toe's own colours, which is the cost of not shipping other
+people's work.
+
+While either is running the menu bar item says so — `⟳ Gruvbox 3/6` after the workspaces, never
+instead of them — because a nine-megabyte download happens with the menu closed and the tooltip
+behind it needs you to already suspect something is happening.
+
+A theme is a folder: `~/.config/toe/themes/<name>/colors.toml` in Omarchy's own format, plus an
+optional `backgrounds/`. That is the same shape a theme directory copied straight out of an
+Omarchy install has, and the same shape the downloader writes, so a theme you fetched and one you
+put there yourself are the same thing afterwards with nothing that treats them differently.
+Nothing is registered: a folder you add appears the moment you next open the menu, and saving its
+palette recolours the screen within about 150 ms the way saving `toe.toml` does.
+
+Pictures come only from that folder. `Style` › `Background` appears exactly when the current theme
+has some, and `SUPER`+`CTRL`+`SPACE` steps through them — the key Omarchy gives to backgrounds,
+where it opens the picker, which here is the menu's job.
+
+The focused border goes **flat** under a theme. That is Omarchy's, not a simplification:
+`hyprland.conf.tpl` renders `col.active_border = rgb({{ accent_strip }})` — one opaque colour,
+`rgb` and not `rgba`. toe's gradient is what you get when you have *not* chosen a theme, and it
+stays exactly as it was for that case, angle and all, so clearing the theme brings the sweep back
+the way you left it.
+
+A theme wins outright: with `[theme] name` set, the colour keys in `[border]` and `[menu]` are not
+consulted, and the sizes still are. Not a merge, because a merge would mean a theme that
+recoloured your border but not your menu depending on which keys you happened to have written.
+And no warning about the shadowed keys either, deliberately — the config toe ships sets every one
+of them, so that warning would fire for everybody the first time they picked a theme, five deep in
+a tooltip. The comment blocks in the file say it instead, where there is room to say it once.
+
+Picking a theme **writes one line of your config** — the `[theme] name` line, with every other
+byte preserved, comments and alignment included — and the existing watcher reloads it. So picking
+one in the menu and editing the line by hand are the same act, with the same result, and the theme
+is in the file you version rather than in a state directory that can disagree with it. The write
+follows a symlink rather than replacing it, since keeping the config in a dotfiles repository is
+supported and an ordinary atomic write would quietly turn the link into a regular file; it keeps
+the mode the file already had, since a config checked out of a repository is often `0644` and a
+silent `chmod` is a diff you did not make. And it parses its own output before committing it: a
+line-based edit cannot see everything a parser can — `["theme"]` is the same table as `[theme]` —
+so anything it would get wrong becomes *toe declined to edit your config* rather than a config
+that will not load.
+
+Everything that arrives over the network is treated as hostile, because it is being written next
+to a file that runs shell commands. The directory is `Slug.make`'s output, so it is one path
+component and cannot be anything else; every filename is checked by shape rather than searched for
+tricks, since "does not contain `..`" is one encoding trick away from being wrong; the palette is
+parsed before anything is moved into place; and a theme is assembled in a temporary directory and
+moved in one step, so a download that fails halfway leaves nothing behind.
+
+The desktop picture is the one piece of this that is not toe's own window. It is set per
+`NSScreen` — and with *Displays have separate Spaces* on, which is the macOS default, that means
+per Space rather than per screen, so a Space you have not visited since the theme changed is
+still showing the old one until toe catches it up on the next switch. Same underlying fact as
+toe's workspaces not being macOS Spaces, one API over — see **Workspaces** above.
+
+It is also the one setting toe changes that it does **not** hand back on quit. The symbolic
+hotkeys and the reveal-desktop preference are given back in `shutDown()` because toe *borrows*
+those — you never asked for `Ctrl`+`↑` to stop working — and it owes them. A wallpaper you chose
+from a menu is the other kind. So it is written down before it is first changed, the way
+CLAUDE.md asks of anything that outlives the process, and given back when you *clear* the theme,
+which is the moment the choice is actually withdrawn rather than the moment toe stops running.
 
 **Hiding.** `⌘H` and `⌘⌥H` take an application's windows out of the layout without closing them:
 the tree reflows around the gap, and `SUPER`+arrows cannot reach them again because they are no
@@ -399,19 +501,33 @@ menu bar item's tooltip — a typo can never leave you without a keyboard. See
 Binding specs parse in both the dash spelling and Omarchy's, so you can paste from either:
 `"alt-shift-1"`, `"super+shift+1"` and `"SUPER SHIFT, 1"` are the same binding.
 
-`reload`, `quit` and the quick menu are bound in code as well as in the file —
-`SUPER`+`SHIFT`+`R`, `SUPER`+`SHIFT`+`Q`, `SUPER`+`SPACE` and `SUPER`+`K` — so the
-ways out exist whether or not your config mentions them. Your config is never rewritten once it is there, so a binding introduced after you
+`reload`, `quit`, the quick menu and `nextbackground` are bound in code as well as in the file —
+`SUPER`+`SHIFT`+`R`, `SUPER`+`SHIFT`+`Q`, `SUPER`+`SPACE`, `SUPER`+`K` and
+`SUPER`+`CTRL`+`SPACE` — so they exist whether or not your config mentions them. Your config is never rewritten once it is there, so a binding introduced after you
 first ran toe would otherwise never reach you: that is how the menu bar item losing its menu left
 anyone upgrading with no way to quit but `pkill`. A fallback applies only when the command is
 bound nowhere, so rebinding `quit` keeps your key and does not also collect the default, and a
 fallback whose own combination you have already used for something else is dropped rather than
-registered on top of yours. Opening the config is not on that list: it is an `exec` like any
+registered on top of yours.
+
+The first four are escape hatches — a config that forgot them leaves you stuck. `nextbackground`
+is not, and is the only entry on that list which isn't: it is there because it is a key that
+could otherwise never reach an install that predates it, and because stepping through a theme's
+pictures is the one thing the menu cannot do for you. Those same two rules are how you take it
+back: bind `nextbackground` to another key and `SUPER`+`CTRL`+`SPACE` is yours again, and if you
+already use that combination it is left alone. Opening the config is not on that list: it is an `exec` like any
 other now, and a fallback would have to name an editor toe has no business choosing.
 
 Commands: `movefocus`, `swapwindow`, `movewindow`, `workspace`, `movetoworkspace`,
 `movetoworkspacesilent`, `killactive`, `togglefloating`, `togglesplit`, `swapsplit`, `exec`,
-`reload`, `menu`, `keybindings`, `quit`.
+`reload`, `menu`, `keybindings`, `theme`, `background`, `nextbackground`, `quit`.
+
+`[theme] name` names a folder in `~/.config/toe/themes` — one you put there, or one the menu
+downloaded from Omarchy; empty is toe's own colours. toe ships none. `theme` takes a name in either spelling (`theme gruvbox`, `theme Tokyo Night`) and,
+alone, clears it. Only `nextbackground` is bound by default, on `SUPER`+`CTRL`+`SPACE`. That is
+the one binding with a macOS shortcut behind it: ⌃⌥Space is *select next input source*, a
+symbolic hotkey the window server resolves ahead of anything toe can register — but one that is
+switched off unless you have two or more input sources.
 
 The TOML parser is a dependency-free subset: tables, arrays of tables, bare and quoted keys,
 basic and literal strings, numbers, booleans, arrays and inline tables. No multi-line strings

--- a/Sources/ToeCore/Config/Config.swift
+++ b/Sources/ToeCore/Config/Config.swift
@@ -57,6 +57,17 @@ public struct GestureConfig: Equatable {
     public init() {}
 }
 
+/// Which theme is in effect, by name.
+///
+/// Empty is toe's own colours — the `[border]` and `[menu]` values below — which is what every
+/// config written before themes existed says, and what it keeps saying.
+public struct ThemeConfig: Equatable {
+    /// Kept exactly as the file spelled it rather than slugified on the way in, so that a name
+    /// which turns out not to exist can be quoted back at the user in the words they used.
+    public var name: String = ""
+    public init() {}
+}
+
 /// The quick menu's colours and size — walker's theme, as config.
 ///
 /// The defaults are Omarchy's default theme (Tokyo Night) resolved through walker's own token
@@ -158,6 +169,7 @@ public struct Config: Equatable {
     public var floating: FloatingSize = FloatingSize()
     public var gestures: GestureConfig = GestureConfig()
     public var menu: MenuConfig = MenuConfig()
+    public var theme: ThemeConfig = ThemeConfig()
     public var misc: MiscConfig = MiscConfig()
     public var bindings: [Binding] = []
     public var floatRules: [FloatRule] = Config.defaultFloatRules
@@ -174,10 +186,17 @@ public struct Config: Equatable {
     /// before a binding was introduced: their config is never rewritten, so the menu bar item
     /// losing its menu left them with no way to quit toe but `pkill`.
     ///
-    /// Deliberately only the escape hatches. A fallback that covered every binding would be a
-    /// second config competing with yours; these exist so that a config which forgot them
-    /// cannot leave you stuck, in the same spirit as keeping the last good config when a new one
-    /// will not parse.
+    /// Kept short on purpose. A fallback that covered every binding would be a second config
+    /// competing with yours, so the bar is high: either the binding is an escape hatch — a config
+    /// which forgot it leaves you stuck, in the same spirit as keeping the last good config when
+    /// a new one will not parse — or it is a key that has no other way of ever reaching an
+    /// install that predates it *and* is worth that. Four of the five below are the first kind;
+    /// `nextbackground` is the second, and the note beside it says why it cleared the bar.
+    ///
+    /// The bar matters more than the list. Every binding toe adds from here on will have this
+    /// same argument available to it — "existing configs will never see it" is true of all of
+    /// them — and the answer is usually still no, because a key taken from someone who did not
+    /// ask for it is a worse failure than a feature they have to go and bind.
     ///
     /// Editing the config is not one of them, though it used to be. It is an `exec` binding now,
     /// like the ones that open a terminal or a browser, and a fallback would have to name an
@@ -190,6 +209,18 @@ public struct Config: Equatable {
         // list by the same reasoning that put them here.
         ("super-space", .menu(.root)),
         ("super-k", .menu(.keybindings)),
+        // Not an escape hatch, and the one entry here that is not. It is on the list because the
+        // problem this list exists to solve is exactly its problem: a config is never rewritten,
+        // so a binding introduced after you first ran toe reaches nobody who already had one, and
+        // every existing user is in that position for this key. The menu is not a substitute —
+        // Style › Background can pick a picture, but the thing worth having on a key is stepping
+        // through them without stopping to choose, which is the one thing the menu cannot do.
+        //
+        // The cost, stated plainly because it is real: unlike the four above, this is a key you
+        // may not want given away. Binding `nextbackground` anywhere else takes it back — a
+        // fallback applies only when its command is bound nowhere — and if ⌃⌥Space is already
+        // claimed the fallback is dropped rather than registered on top of whatever has it.
+        ("super-ctrl-space", .nextBackground),
     ]
 
     public static let defaultFloatRules: [FloatRule] = [
@@ -383,6 +414,14 @@ public struct Config: Equatable {
             if let v = number(m["font_size"], "menu.font_size", in: 8...72,
                               keeping: config.menu.fontSize, warnings: &config.warnings) {
                 config.menu.fontSize = v
+            }
+        }
+
+        if let t = root["theme"]?.tableValue, let raw = t["name"] {
+            if let v = raw.stringValue {
+                config.theme.name = v.trimmingCharacters(in: .whitespaces)
+            } else {
+                config.warnings.append("theme.name: must be a name in quotes, using no theme")
             }
         }
 

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -40,8 +40,43 @@ default_split_ratio    = 1.0
 # 0 = even, 1 = favour the new window, 2 = favour the existing one.
 split_bias             = 0
 
+[theme]
+# An Omarchy theme, by name. Empty is toe's own colours — the [border] and [menu] values below —
+# which is what this file has always been, and what it stays until you choose otherwise. Those
+# defaults are Tokyo Night's palette already, resolved the way walker resolves it, so nothing
+# looks unthemed while this is empty.
+#
+# A theme wins outright. With a name set here, the *colour* keys in [border] and [menu] are not
+# consulted at all; the sizes still are — width, angle, radius, opacity, font_size. Omarchy's own
+# theme template sets col.active_border and nothing else, so a theme is exactly that much: the
+# focused border takes the accent, flat, and the quick menu takes the background, the foreground
+# and the accent.
+#
+# SUPER+SPACE > Style > Theme is where you get one. toe ships no themes: a theme is somebody
+# else's work, and the list you choose from is what is in ~/.config/toe/themes plus what Omarchy
+# publishes. Choosing one you have not got downloads it from Omarchy into that folder — palette
+# and pictures — and then sets it, so a theme you fetched and a theme you copied in by hand are
+# the same thing afterwards.
+#
+# That download is the only time toe touches the network, along with the list of themes it fetches
+# when you open Style > Theme, at most once a day. Nothing at launch, no update check, no
+# telemetry; the only host it talks to is github.com. A machine that has never been online has no
+# themes to choose from, and the colours below.
+#
+# The menu rewrites this one line and leaves every other byte of this file alone, so picking a
+# theme there and editing it here are the same act. It refuses to write at all if the result would
+# not parse.
+#
+# A theme is a folder: ~/.config/toe/themes/<name>/colors.toml, in Omarchy's own format, plus an
+# optional backgrounds/ beside it. Nothing has to be registered — one appears in the menu the
+# moment you next open it, and saving its palette recolours the screen the way saving this file
+# does. Style > Background appears exactly when that theme has pictures, and SUPER+CTRL+SPACE
+# steps through them.
+name = ""
+
 [border]
-# Highlights the focused window. Omarchy's col.active_border gradient.
+# Highlights the focused window. Omarchy's col.active_border gradient — and what you see when no
+# theme is set above, since a theme replaces both stops with one flat accent.
 enabled      = true
 width        = 2
 active_start = "#33ccffee"
@@ -96,7 +131,9 @@ prevent_hiding = true
 # ~/.local/state/toe/session.json and put back when toe starts again, so restarting it costs you
 # nothing. Windows are matched on the id the window server gave them, so this is exact rather
 # than a guess; a reboot voids those ids and the file is discarded unread. Set false to start
-# from an empty workspace every time and keep toe off disk.
+# from an empty workspace every time and keep the *layout* off disk. It is not a blanket switch:
+# the theme's current background is remembered in the same directory either way, since that is a
+# choice you made rather than a window arrangement toe worked out for you.
 restore_session = true
 
 [bar]
@@ -110,7 +147,9 @@ persistent_workspaces = 5
 # tree rather than the level you are on, and each hit says which submenu it came from.
 # These are its theme's tokens: Omarchy's default (Tokyo Night) resolved the way walker's
 # stylesheet resolves them — background, foreground (which is also the border), and the accent
-# the selected row's text takes.
+# the selected row's text takes. Which is to say these three are already a theme: setting
+# [theme] name = "tokyo-night" above leaves this block looking exactly as it does now, and only
+# the border moves. The three are ignored while a theme is set; the sizes below are not.
 background = "#1a1b26"
 foreground = "#a9b1d6"
 accent     = "#7aa2f7"
@@ -197,6 +236,17 @@ font_size  = 18
 # takes ⌥Space and ⌥K away from typing ` ` and ˚ for as long as toe runs.
 "super-space"   = "menu"
 "super-k"       = "keybindings"
+# Omarchy's background key. SUPER+CTRL+SPACE is what its bindings.conf gives to backgrounds —
+# there it opens the picker, which here is Style › Background in the menu above, so the key does
+# the thing the menu cannot: step to the next picture without stopping to choose one. Does
+# nothing until the current theme has a backgrounds/ folder with something in it.
+#
+# The one binding here with a macOS shortcut behind it: ⌃⌥Space is "select next input source",
+# and while that is a symbolic hotkey — resolved inside the window server, ahead of anything toe
+# can register — it is switched off unless you have two or more input sources. If you do, and
+# this key changes your keyboard instead of your wallpaper, that is why; move it, or turn the
+# shortcut off in System Settings › Keyboard › Keyboard Shortcuts › Input Sources.
+"super-ctrl-space" = "nextbackground"
 
 # ── Launch ────────────────────────────────────────────────────────────────────
 # AppleScript's `new window` reuses the running instance, so the window opens on the current

--- a/Sources/ToeCore/Dispatch/Command.swift
+++ b/Sources/ToeCore/Dispatch/Command.swift
@@ -25,6 +25,15 @@ public enum Command: Equatable {
     /// keys — so two cases would give `dispatch` two arms with one body between them.
     case menu(MenuPage)
     case quit
+    /// An Omarchy theme, by slug — `omarchy-theme-set`. Empty clears it and hands your own
+    /// `[border]` and `[menu]` colours back, which is why the argument is the one in the parser
+    /// that may be missing: `theme none` would be wrong, since `none` is a directory somebody
+    /// could legitimately name.
+    case theme(String)
+    /// A picture from the current theme's `backgrounds/`, by file name.
+    case background(String)
+    /// `omarchy-theme-bg-next`.
+    case nextBackground
 }
 
 public extension Command {
@@ -97,6 +106,22 @@ public enum CommandParser {
         case "swapsplit":                   return .swapSplit
         case "reload":                      return .reload
         case "quit", "exit":                return .quit
+
+        // Spelled after `omarchy-theme-set` and `omarchy-theme-bg-next`.
+        //
+        // `theme` is the one verb here whose argument may be absent, and it means *clear the
+        // theme* rather than being an error — see `Command.theme`. It is also the one that
+        // slugifies its argument at the door rather than at the far end, so that `theme "Tokyo
+        // Night"` copied out of an Omarchy config finds the same directory, and so that no
+        // un-slugified string can reach the code that writes this name back into your config.
+        case "theme":                       return .theme(Slug.make(argument))
+        // Not slugified: a background is a file name, with an extension and whatever case the
+        // photographer gave it.
+        case "background", "bg":
+            guard !argument.isEmpty else { throw CommandError.missingArgument(name) }
+            return .background(argument)
+        case "nextbackground", "bgnext", "background-next":
+            return .nextBackground
 
         // Spelled the way `omarchy-menu` and `omarchy-menu keybindings` are invoked, so a
         // binding can be read across from an Omarchy config without translating it.

--- a/Sources/ToeCore/Dispatch/CommandLabel.swift
+++ b/Sources/ToeCore/Dispatch/CommandLabel.swift
@@ -35,6 +35,14 @@ public enum CommandLabel {
             case .root:        return "Open the menu"
             case .keybindings: return "Show the keybindings"
             }
+        case .theme(let slug):
+            // Titled from the slug, because that is all a label has: toe ships no themes, so
+            // there is no table of names to look one up in, and a theme's directory name is the
+            // only thing true of it whether it is installed, merely available, or neither.
+            guard !slug.isEmpty else { return "Use your own colours" }
+            return "Theme: \(Slug.title(slug))"
+        case .background(let file):  return "Background: \(ellipsised(file))"
+        case .nextBackground:        return "Next background"
         }
     }
 

--- a/Sources/ToeCore/Menu/MenuModel.swift
+++ b/Sources/ToeCore/Menu/MenuModel.swift
@@ -15,6 +15,7 @@ public struct MenuItem: Equatable {
     /// moves rather than every test that mentions a row.
     public enum Icon: Equatable, Sendable {
         case gear, book, keyboard, pencil, power, toggleOn, toggleOff
+        case paintbrush, droplet, image
     }
 
     public indirect enum Action: Equatable {
@@ -22,6 +23,10 @@ public struct MenuItem: Equatable {
         case page(MenuPage)
         case run(Command)
         case toggleLoginItem
+        /// A row that says something and does nothing when you press it — "Fetching Omarchy's
+        /// themes…". The alternative was leaving the level looking like a short list rather than
+        /// an unfinished one, which is the sort of thing you stare at wondering if it is broken.
+        case note
     }
 
     public let title: String
@@ -64,13 +69,49 @@ public enum LoginItemState: Equatable, Sendable {
     case unavailable(String)
 }
 
+/// What the Style level needs to draw itself.
+///
+/// A value rather than four parameters, because it is threaded from the Coordinator through
+/// `QuickMenu` to here unchanged, and because it is rebuilt every time the menu opens — that is
+/// what makes a theme folder you created a moment ago appear without a reload.
+///
+/// Every field defaults to empty, and that is not a convenience for tests: it is what a machine
+/// that has never fetched anything actually has. The Theme level still draws — `Your own colours`
+/// is a real row, and it is the one that is current.
+public struct StyleMenu: Equatable {
+    /// Themes on disk — the ones that can be chosen without waiting for anything.
+    public var themes: [ThemeRef]
+    /// Themes Omarchy publishes that this machine does not have. Choosing one downloads it.
+    public var available: [RemoteTheme]
+    /// True while the catalogue is being fetched, so the level can say so rather than looking
+    /// like a list that happens to be short.
+    public var fetching: Bool
+    /// The theme in effect. nil is toe's own colours.
+    public var current: String?
+    /// The current theme's `backgrounds/`, in cycle order.
+    public var backgrounds: [String]
+    public var currentBackground: String?
+
+    public init(themes: [ThemeRef] = [], available: [RemoteTheme] = [], fetching: Bool = false,
+                current: String? = nil,
+                backgrounds: [String] = [], currentBackground: String? = nil) {
+        self.themes = themes
+        self.available = available
+        self.fetching = fetching
+        self.current = current
+        self.backgrounds = backgrounds
+        self.currentBackground = currentBackground
+    }
+}
+
 /// The menu's contents.
 ///
 /// Deliberately a function of the state it displays rather than a constant: a "Run on startup"
 /// row that shows a remembered value instead of launchd's is a row that will eventually lie.
 public enum MenuModel {
 
-    public static func root(loginItem: LoginItemState, bindings: [Binding]) -> [MenuItem] {
+    public static func root(loginItem: LoginItemState, bindings: [Binding],
+                            style: StyleMenu = StyleMenu()) -> [MenuItem] {
         var items: [MenuItem] = []
         // Configure can come out empty — neither of its rows is guaranteed — and a row that
         // leads into an empty level is worse than no row, so the parent goes with it.
@@ -81,8 +122,80 @@ public enum MenuModel {
         items.append(MenuItem(title: "Learn", icon: .book, action: .submenu([
             MenuItem(title: "Keybindings", icon: .keyboard, action: .page(.keybindings)),
         ])))
+        // Omarchy's own order — Learn, then Style — with Quit last by toe's rule. Unlike
+        // Configure, Style is never conditional: three themes ship, so the level it leads to
+        // cannot come out empty.
+        items.append(MenuItem(title: "Style", icon: .paintbrush, action: .submenu(MenuModel.style(style))))
         items.append(MenuItem(title: "Quit", icon: .power, action: .run(.quit)))
         return items
+    }
+
+    /// Omarchy's `Style` level, minus the parts toe has no analogue for.
+    public static func style(_ style: StyleMenu) -> [MenuItem] {
+        var rows = [MenuItem(title: "Theme", icon: .droplet, action: .submenu(themes(style)))]
+        // The Configure rule, one level down: a row that leads into an empty level is worse than
+        // no row. Background appears exactly when the current theme has pictures — which means
+        // when one was downloaded with it, or when you put some there yourself.
+        if !style.backgrounds.isEmpty {
+            rows.append(MenuItem(title: "Background", icon: .image,
+                                 action: .submenu(MenuModel.backgrounds(style))))
+        }
+        return rows
+    }
+
+    /// Every theme toe can see, with the one in effect marked.
+    ///
+    /// Marked with a value rather than by opening the level with the cursor already on it:
+    /// walker preselects, and matching that needs a new mutating entry point on `MenuState`. The
+    /// value column is how the startup toggle already shows its state, so this is the rule the
+    /// menu has rather than a new one.
+    public static func themes(_ style: StyleMenu) -> [MenuItem] {
+        var rows = style.themes.map { theme in
+            MenuItem(title: theme.name,
+                     value: theme.slug == style.current ? "current" : nil,
+                     action: .run(.theme(theme.slug)))
+        }
+
+        // Then what Omarchy publishes and this machine does not have. The size is the disclosure:
+        // these run from a third of a megabyte to nine, and a row that downloaded nine megabytes
+        // without having said so first would be a row that surprised you.
+        rows += style.available.map { theme in
+            MenuItem(title: theme.name,
+                     value: ByteSize.describe(theme.bytes),
+                     action: .run(.theme(theme.slug)))
+        }
+
+        // Said rather than left to be inferred from a short list. Deliberately after the themes
+        // and before the way out, which is where the rows it is waiting for will appear.
+        if style.fetching {
+            rows.append(MenuItem(title: "Fetching Omarchy's themes…", action: .note))
+        }
+
+        // Last rather than first, so the list reads as a list of themes. Short, because a value
+        // in the second column takes its width out of the title's.
+        rows.append(MenuItem(title: "Your own colours",
+                             value: style.current == nil ? "current" : nil,
+                             action: .run(.theme(""))))
+        return rows
+    }
+
+    /// The current theme's pictures, and the row that steps through them.
+    ///
+    /// Shaped exactly like the Theme level above: no icons, and the row that is an *action*
+    /// rather than a choice comes last, the way `Your own colours` does. Both rules are there
+    /// because a level reads as a list only when its rows line up — an icon on one row of four
+    /// indents that row's text past the other three, and it was the only row in the menu that
+    /// did it.
+    public static func backgrounds(_ style: StyleMenu) -> [MenuItem] {
+        var rows = style.backgrounds.map { file in
+            // The whole file name, extension and all: strip it and a folder holding city.jpg
+            // beside city.png gets two rows that say the same thing.
+            MenuItem(title: file,
+                     value: file == style.currentBackground ? "current" : nil,
+                     action: .run(.background(file)))
+        }
+        rows.append(MenuItem(title: "Next background", action: .run(.nextBackground)))
+        return rows
     }
 
     /// The Configure level. Also built on its own, by the menu, when throwing the startup toggle
@@ -149,8 +262,9 @@ public enum MenuModel {
     }
 
     /// The reading order of the README's table: what you do to the focus, then to a window, then
-    /// to a workspace, then to toe itself, and last the bindings that launch something — those
-    /// are the ones a user has replaced with their own, so they belong at the bottom.
+    /// to a workspace, then to how it all looks, then to toe itself, and last the bindings that
+    /// launch something — those are the ones a user has replaced with their own, so they belong
+    /// at the bottom.
     private static func rank(_ command: Command) -> Int {
         switch command {
         case .moveFocus:        return 0
@@ -160,9 +274,10 @@ public enum MenuModel {
         case .moveToWorkspace:  return 4
         case .workspace:        return 5
         case .killActive, .toggleFloating, .toggleSplit, .swapSplit: return 6
-        case .menu:             return 7
-        case .reload, .quit:    return 8
-        case .exec:             return 9
+        case .theme, .background, .nextBackground: return 7
+        case .menu:             return 8
+        case .reload, .quit:    return 9
+        case .exec:             return 10
         }
     }
 }

--- a/Sources/ToeCore/Menu/MenuState.swift
+++ b/Sources/ToeCore/Menu/MenuState.swift
@@ -121,6 +121,10 @@ public struct MenuState: Equatable {
             return .run(command)
         case .toggleLoginItem:
             return .toggleLoginItem
+        case .note:
+            // Pressing it does nothing, and `.none` is what the menu already does when there is
+            // nothing to do — the panel stays open on the row you are looking at.
+            return .none
         }
     }
 

--- a/Sources/ToeCore/Theme/Backgrounds.swift
+++ b/Sources/ToeCore/Theme/Backgrounds.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// The pictures a theme carries, and the order they are walked in.
+///
+/// Both halves live here together on purpose: the order the `Background` menu lists them in and
+/// the order `nextbackground` steps through are the same list, and the day those two drift apart
+/// is the day the menu says one thing and the key does another.
+public enum Backgrounds {
+
+    /// What macOS will actually put on a desktop. `webp` is on the list because Omarchy's own
+    /// backgrounds are mostly webp now and ImageIO has read them since Big Sur.
+    public static let extensions: Set<String> = [
+        "jpg", "jpeg", "png", "heic", "heif", "webp", "gif", "tif", "tiff", "bmp",
+    ]
+
+    /// The image files in a backgrounds directory, in cycle order.
+    ///
+    /// Sorted with a plain `sorted()` — codepoint order, the same choice `Config.parse` makes for
+    /// `[binds]`, and for the same reason: `localizedStandardCompare` would give two people with
+    /// the same folder a different cycle. Omarchy sorts with `sort -z`, which is also bytewise.
+    ///
+    /// The filter earns its place on `.DS_Store` alone, which turns up in every folder anyone has
+    /// opened in Finder and would otherwise become a wallpaper that will not load. Dotfiles go
+    /// with it, along with the `README` and `LICENSE` an Omarchy theme folder may bring.
+    public static func list(_ names: [String]) -> [String] {
+        names.filter { name in
+            guard !name.hasPrefix(".") else { return false }
+            let ext = (name as NSString).pathExtension.lowercased()
+            return extensions.contains(ext)
+        }
+        .sorted()
+    }
+
+    /// Upstream's own branding, which is in every theme's `backgrounds/` and is not a wallpaper
+    /// anybody wants on a toe desktop: `omarchy.png` in some themes, `omarchy.webp` in others, and
+    /// in both cases the OMARCHY wordmark on a flat ground.
+    ///
+    /// Filtered where a theme is *fetched* rather than where a folder is listed, deliberately. Not
+    /// fetching it is toe declining to put another project's wordmark on your screen; refusing to
+    /// list it would be toe overruling a file you had put there yourself, which is not its call.
+    /// So a downloaded theme never has one, and a folder you assembled by hand is shown whole.
+    public static func isUpstreamBranding(_ name: String) -> Bool {
+        (name as NSString).deletingPathExtension.lowercased() == "omarchy"
+    }
+
+    /// `omarchy-theme-bg-next`, exactly: find where you are, step one on, wrap at the end.
+    ///
+    /// A name that is not in the list gives the first — which is what happens when the theme has
+    /// changed under you, or the file has been deleted since it was chosen, and is better than
+    /// refusing to cycle because the memo is stale.
+    ///
+    /// Omarchy's empty case paints solid black; toe has no way to do that through
+    /// `setDesktopImageURL` without inventing an image, and no need to, because the `Background`
+    /// level is left out of the menu entirely when there is nothing in it.
+    public static func next(after current: String?, in files: [String]) -> String? {
+        guard !files.isEmpty else { return nil }
+        guard let current, let index = files.firstIndex(of: current) else { return files[0] }
+        return files[(index + 1) % files.count]
+    }
+}

--- a/Sources/ToeCore/Theme/Catalogue.swift
+++ b/Sources/ToeCore/Theme/Catalogue.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+/// One file that can be fetched.
+public struct RemoteFile: Codable, Equatable, Sendable {
+    public let name: String
+    public let bytes: Int
+
+    public init(name: String, bytes: Int) {
+        self.name = name
+        self.bytes = bytes
+    }
+}
+
+/// A theme that exists upstream but not on this machine.
+public struct RemoteTheme: Codable, Equatable, Sendable {
+    public let slug: String
+    public let name: String
+    public let backgrounds: [RemoteFile]
+
+    public init(slug: String, name: String, backgrounds: [RemoteFile]) {
+        self.slug = slug
+        self.name = name
+        self.backgrounds = backgrounds
+    }
+
+    /// What downloading it costs, palette included — near enough, since a palette is a rounding
+    /// error beside a photograph. This is the number the menu row shows, and the reason it shows
+    /// it is that the range runs from a third of a megabyte to nine.
+    public var bytes: Int { backgrounds.reduce(0) { $0 + $1.bytes } }
+}
+
+/// Every theme Omarchy publishes, as of the last time toe asked.
+public struct Catalogue: Codable, Equatable, Sendable {
+    public static let currentVersion = 1
+
+    public var version: Int
+    public var fetchedAt: Date
+    public var themes: [RemoteTheme]
+
+    public init(version: Int = Catalogue.currentVersion, fetchedAt: Date, themes: [RemoteTheme]) {
+        self.version = version
+        self.fetchedAt = fetchedAt
+        self.themes = themes
+    }
+
+    public func isStale(now: Date = Date(), maxAge: TimeInterval) -> Bool {
+        // A clock that has gone backwards — a restored machine, a corrected NTP step — reads as
+        // stale rather than as fresh for however long the skew lasts.
+        let age = now.timeIntervalSince(fetchedAt)
+        return age < 0 || age > maxAge
+    }
+}
+
+public enum CatalogueError: Error, CustomStringConvertible, Equatable {
+    case notJSON
+    case truncated
+    case empty
+
+    public var description: String {
+        switch self {
+        case .notJSON:   return "the theme list did not come back as JSON"
+        case .truncated: return "the theme list came back incomplete"
+        case .empty:     return "the theme list came back with no themes in it"
+        }
+    }
+}
+
+public extension Catalogue {
+
+    /// Reads GitHub's recursive tree listing.
+    ///
+    /// One request describes the whole repository — every path, every blob size — so the menu can
+    /// say what a theme costs to download without fetching anything first. That is the reason
+    /// this shape was chosen over the contents API, which would be one request per theme.
+    ///
+    /// Pure, and given a real 400 KB response in the selftest, because everything that can go
+    /// wrong here is a shape problem: a theme with no palette, a filename that is not a filename,
+    /// a listing that came back truncated.
+    static func parse(_ json: Data, fetchedAt: Date = Date()) throws -> Catalogue {
+        struct Tree: Decodable {
+            struct Entry: Decodable {
+                let path: String
+                let type: String
+                let size: Int?
+            }
+            let tree: [Entry]
+            let truncated: Bool?
+        }
+
+        guard let tree = try? JSONDecoder().decode(Tree.self, from: json) else {
+            throw CatalogueError.notJSON
+        }
+        // GitHub truncates a tree that is too large to serve. Half a catalogue is worse than
+        // none: it would look complete, and the themes missing from it would look nonexistent.
+        if tree.truncated == true { throw CatalogueError.truncated }
+
+        var palettes: Set<String> = []
+        var backgrounds: [String: [RemoteFile]] = [:]
+
+        for entry in tree.tree where entry.type == "blob" {
+            let parts = entry.path.split(separator: "/", omittingEmptySubsequences: false)
+                                  .map(String.init)
+            guard parts.count >= 3, parts[0] == "themes" else { continue }
+            // Through the slug, not taken as read: this is a name from the network that ends up
+            // as a directory under ~/.config/toe/themes, and a path component is the one thing it
+            // is allowed to be. A directory whose name is not already a slug is not a theme.
+            let slug = parts[1]
+            guard Slug.make(slug) == slug else { continue }
+
+            if parts.count == 3, parts[2] == "colors.toml" {
+                palettes.insert(slug)
+            } else if parts.count == 4, parts[2] == "backgrounds",
+                      isSafeFileName(parts[3]),
+                      !Backgrounds.isUpstreamBranding(parts[3]),
+                      Backgrounds.list([parts[3]]).count == 1 {
+                backgrounds[slug, default: []].append(
+                    RemoteFile(name: parts[3], bytes: entry.size ?? 0))
+            }
+        }
+
+        // A theme without a palette is not one toe can use — Omarchy has a few that describe
+        // themselves only through per-app config files it renders templates from, and toe has no
+        // analogue for any of those.
+        let themes = palettes.sorted().map { slug in
+            RemoteTheme(slug: slug, name: Slug.title(slug),
+                        backgrounds: (backgrounds[slug] ?? []).sorted { $0.name < $1.name })
+        }
+        guard !themes.isEmpty else { throw CatalogueError.empty }
+        return Catalogue(fetchedAt: fetchedAt, themes: themes)
+    }
+
+    /// Whether a name off the network may be written to disk.
+    ///
+    /// Deliberately a whitelist of shapes rather than a search for bad ones: this name is about to
+    /// be joined onto a directory path, and "does not contain `..`" is the kind of rule that is
+    /// one encoding trick away from being wrong. A separator, a dot-leading name, an empty one and
+    /// anything overlong are all simply not names toe will write.
+    static func isSafeFileName(_ name: String) -> Bool {
+        guard !name.isEmpty, name.count <= 128 else { return false }
+        guard !name.hasPrefix(".") else { return false }
+        guard !name.contains("/"), !name.contains("\\"), !name.contains("\0") else { return false }
+        guard name != ".", name != ".." else { return false }
+        return true
+    }
+}
+
+/// A byte count as a menu row shows it.
+public enum ByteSize {
+    public static func describe(_ bytes: Int) -> String {
+        guard bytes > 0 else { return "" }
+        let mb = Double(bytes) / 1_048_576
+        if mb >= 0.1 { return String(format: "%.1f MB", mb) }
+        let kb = max(1, Int((Double(bytes) / 1024).rounded()))
+        return "\(kb) KB"
+    }
+}

--- a/Sources/ToeCore/Theme/Config+Theme.swift
+++ b/Sources/ToeCore/Theme/Config+Theme.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+public extension Config {
+
+    /// The theme's colours, over the top of whatever the file said.
+    ///
+    /// Separate from `parse`, and deliberately: `parse` is pure text, and resolving a name to a
+    /// theme means looking in `~/.config/toe/themes` — so the config that comes out of `parse` is
+    /// always the file as written, and this is the one step that needs a disk to have been read.
+    /// It is also what keeps the selftest able to assert what the shipped config *says* while the
+    /// Coordinator asserts what it *does*.
+    ///
+    /// The theme wins outright. With `[theme] name` set, the colour keys in `[border]` and
+    /// `[menu]` are not consulted at all — not merged with, not warned about. Not merged, because
+    /// a merge would mean a theme that recoloured your border and not your menu depending on which
+    /// keys you happened to have written, which is a rule nobody could hold in their head. And not
+    /// warned about, because the config toe ships sets every one of those keys explicitly and the
+    /// menu writes `[theme] name` into that same file: a "this key is ignored" warning would fire
+    /// for every single user the first time they picked a theme, five deep in a tooltip. The
+    /// comment blocks in the file say it instead, where there is room to say it once and properly.
+    ///
+    /// What a theme does not touch: `width`, `angle`, `radius`, `enabled`, `opacity`, `font_size`
+    /// and the two menu widths. Those are sizes and behaviours, and `colors.toml` has nothing to
+    /// say about them — Omarchy's own theme template sets `col.active_border` and nothing else.
+    func applying(_ theme: Theme) -> Config {
+        var out = self
+
+        // Both stops the same, because Omarchy's border is one flat colour: its theme template
+        // renders `col.active_border = rgb(accent)` — `rgb`, not `rgba`, and not a gradient. The
+        // gradient is what toe looks like when you have *not* chosen a theme, and it is still
+        // there, untouched, for exactly that case. `angle` goes inert here rather than being
+        // cleared, so clearing the theme brings the sweep back the way you left it.
+        out.border.activeStart = theme.palette.accent
+        out.border.activeEnd = theme.palette.accent
+
+        // walker's own token mapping, the one MenuConfig's defaults were already derived from:
+        // @base is the background, @text is the foreground *and* the border, @selected-text is
+        // the accent. Setting `border` back to nil is what re-joins it to the foreground — a
+        // `menu.border` from the file would otherwise outlive the colours it was chosen against.
+        out.menu.background = theme.palette.background
+        out.menu.foreground = theme.palette.foreground
+        out.menu.accent = theme.palette.accent
+        out.menu.border = nil
+
+        // The resolved name, not the one the file spelled: the menu marks its current row by
+        // comparing against this, and `name = "Tokyo Night"` should still tick Tokyo Night.
+        out.theme.name = theme.slug
+        return out
+    }
+}

--- a/Sources/ToeCore/Theme/Palette.swift
+++ b/Sources/ToeCore/Theme/Palette.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+/// What went wrong reading a `colors.toml`.
+///
+/// Named keys rather than a single "bad theme", because the file is one a user may have written
+/// by hand and the menu bar tooltip is where they will read this.
+public enum PaletteError: Error, CustomStringConvertible, Equatable {
+    /// A key toe needs is not in the file.
+    case missing(String)
+    /// A key is there and is not a colour.
+    case notAColour(key: String, value: String)
+
+    public var description: String {
+        switch self {
+        case .missing(let key):
+            return "no \(key) in colors.toml"
+        case .notAColour(let key, let value):
+            return "\(key) = \"\(value)\" in colors.toml is not a colour"
+        }
+    }
+}
+
+/// A theme's colours — Omarchy's `themes/<name>/colors.toml`, mirrored key for key.
+///
+/// The key names are Omarchy's, and the file keeps its name, deliberately: a theme in
+/// `~/.config/toe/themes` is meant to be a folder copied straight across from an Omarchy install,
+/// backgrounds and all, and a format that is *nearly* theirs would be worse than either having
+/// their format or having an obviously different one.
+///
+/// Hex strings rather than `RGBA`, because `BorderConfig` and `MenuConfig` hold hex strings:
+/// keeping them as text means applying a theme is an assignment, and leaves `Hex.rgba` in the one
+/// place it already lives — the layer that draws.
+///
+/// Only three of these are read today. The rest are stored because the file is being mirrored and
+/// it costs nothing, so the day the workspace strip or the selected menu row wants a themed
+/// colour, `color4` is already here rather than being a second pass over everyone's themes.
+public struct Palette: Equatable, Sendable {
+
+    public var accent: String
+    public var background: String
+    public var foreground: String
+    public var cursor: String?
+    public var selectionForeground: String?
+    public var selectionBackground: String?
+    /// `color0` … `color15`, sixteen slots, nil where the file left one out.
+    public var terminal: [String?]
+
+    public init(accent: String, background: String, foreground: String,
+                cursor: String? = nil,
+                selectionForeground: String? = nil, selectionBackground: String? = nil,
+                terminal: [String?] = Array(repeating: nil, count: Palette.terminalSlots)) {
+        self.accent = accent
+        self.background = background
+        self.foreground = foreground
+        self.cursor = cursor
+        self.selectionForeground = selectionForeground
+        self.selectionBackground = selectionBackground
+        self.terminal = terminal
+    }
+
+    public static let terminalSlots = 16
+
+    public func color(_ index: Int) -> String? {
+        guard terminal.indices.contains(index) else { return nil }
+        return terminal[index]
+    }
+
+    /// Every colour this palette actually carries, keyed the way the file keys them — so a test
+    /// can assert they all parse without naming each one, and a warning can name the one that
+    /// does not.
+    public var colours: [(key: String, value: String)] {
+        var out: [(String, String)] = [("accent", accent), ("background", background),
+                                       ("foreground", foreground)]
+        if let cursor { out.append(("cursor", cursor)) }
+        if let selectionForeground { out.append(("selection_foreground", selectionForeground)) }
+        if let selectionBackground { out.append(("selection_background", selectionBackground)) }
+        for (index, colour) in terminal.enumerated() {
+            if let colour { out.append(("color\(index)", colour)) }
+        }
+        return out
+    }
+}
+
+public extension Palette {
+
+    /// Reads a `colors.toml`.
+    ///
+    /// `accent`, `background` and `foreground` are required, because they are the three toe
+    /// actually paints with and a theme missing one of them would silently keep whatever colour
+    /// was there before. Everything else is optional.
+    ///
+    /// Every colour is checked through `Hex.rgba` here rather than at the far end, so a typo is
+    /// named while it still has a key beside it — `Hex.rgba` answers nil rather than substituting
+    /// a colour precisely so that this layer can do that.
+    static func parse(_ toml: String) throws -> Palette {
+        let table = try TOML.parse(toml)
+
+        func colour(_ key: String) throws -> String? {
+            guard let value = table[key] else { return nil }
+            guard let text = value.stringValue else {
+                throw PaletteError.notAColour(key: key, value: "\(value)")
+            }
+            guard Hex.rgba(text) != nil else {
+                throw PaletteError.notAColour(key: key, value: text)
+            }
+            return text
+        }
+
+        func required(_ key: String) throws -> String {
+            guard let value = try colour(key) else { throw PaletteError.missing(key) }
+            return value
+        }
+
+        return Palette(
+            accent: try required("accent"),
+            background: try required("background"),
+            foreground: try required("foreground"),
+            cursor: try colour("cursor"),
+            selectionForeground: try colour("selection_foreground"),
+            selectionBackground: try colour("selection_background"),
+            terminal: try (0..<Palette.terminalSlots).map { try colour("color\($0)") }
+        )
+    }
+}

--- a/Sources/ToeCore/Theme/Slug.swift
+++ b/Sources/ToeCore/Theme/Slug.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// A theme's name on disk.
+///
+/// Omarchy's `omarchy-theme-set` reduces a display name to a directory name with
+/// `tr '[:upper:]' '[:lower:]' | tr ' ' '-'`, and toe accepts the same spellings so that a
+/// `theme "Tokyo Night"` line read across from an Omarchy config finds the same directory.
+///
+/// What Omarchy does not need, and toe does: a slug arriving here has come from the config file
+/// or from a `[binds]` line, and it leaves in two directions — appended to `~/.config/toe/themes`
+/// as a path component, and written back into the user's own TOML between a pair of quotes. So
+/// anything outside `a-z0-9-` is *dropped* rather than escaped, which makes both of those safe by
+/// construction rather than by remembering: `../` and a bare `"` are simply not slug characters,
+/// and there is no second place that has to know it.
+public enum Slug {
+
+    /// Long enough for the longest theme name anyone has written; short enough that the result is
+    /// still a sane path component.
+    private static let limit = 64
+
+    public static func make(_ raw: String) -> String {
+        var out = ""
+        out.reserveCapacity(min(raw.count, limit))
+        for character in raw.lowercased() {
+            let mapped: Character?
+            switch character {
+            case "a"..."z", "0"..."9": mapped = character
+            case "_", "-":             mapped = "-"
+            // Every kind of whitespace, not just a space: a tab or a newline that has found its
+            // way into a name is still a word boundary, and turning it into one keeps two words
+            // from being welded together into a directory nobody meant to name.
+            case let c where c.isWhitespace: mapped = "-"
+            default:                   mapped = nil          // dropped, not escaped
+            }
+            guard let mapped else { continue }
+            // Collapse runs, so "Rose  Pine" and "rose--pine" are the same directory.
+            if mapped == "-", out.last == "-" { continue }
+            out.append(mapped)
+            if out.count == limit { break }
+        }
+        while out.hasSuffix("-") { out.removeLast() }
+        while out.hasPrefix("-") { out.removeFirst() }
+        return out
+    }
+
+    /// A directory name read back as something to put in a menu row: `catppuccin-latte` becomes
+    /// `Catppuccin Latte`. Only for themes found on disk, which have nothing but a directory name
+    /// to be titled from. The three toe ships carry their own display names instead, so what a
+    /// row says is a decision rather than the output of a string transform.
+    public static func title(_ slug: String) -> String {
+        slug.split(separator: "-")
+            .map { $0.prefix(1).uppercased() + $0.dropFirst() }
+            .joined(separator: " ")
+    }
+}

--- a/Sources/ToeCore/Theme/Theme.swift
+++ b/Sources/ToeCore/Theme/Theme.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// A theme that has been *found* — a name and nothing else.
+///
+/// Split from `Theme` on purpose. The theme list is rebuilt every time the menu opens, and a
+/// menu row needs only a name, so discovery stays a directory listing: someone who has copied a
+/// whole Omarchy theme collection into `~/.config/toe/themes` has ninety of these, and reading
+/// and parsing ninety `colors.toml` files to draw a list is the version of this that does not
+/// ship. Only the theme actually in effect is ever read.
+public struct ThemeRef: Equatable, Sendable {
+    public let slug: String
+    public let name: String
+
+    public init(slug: String, name: String) {
+        self.slug = slug
+        self.name = name
+    }
+}
+
+/// A theme, read.
+public struct Theme: Equatable, Sendable {
+    public let slug: String
+    public let name: String
+    public let palette: Palette
+
+    public init(slug: String, name: String, palette: Palette) {
+        self.slug = slug
+        self.name = name
+        self.palette = palette
+    }
+
+    public var ref: ThemeRef { ThemeRef(slug: slug, name: name) }
+}
+
+/// The theme list the menu draws.
+///
+/// toe ships no themes. It used to ship three as Swift literals, and the reason it does not is
+/// the same reason it ships no pictures: a theme is somebody else's work, and redistributing it
+/// inside a notarised app is an act toe would be performing rather than Omarchy. So the list is
+/// what you have on disk plus what Omarchy publishes, and downloading one is you fetching it
+/// from the source.
+///
+/// The consequence, stated because it is a real cost: a fresh install with no network has no
+/// themes to choose from until it has fetched the catalogue once. What it does have is toe's own
+/// colours, which are `[border]` and `[menu]` in your config — and those defaults are Tokyo
+/// Night's palette already, resolved through walker's tokens, so out of the box nothing looks
+/// unthemed.
+public enum Themes {
+
+    /// Everything the menu can offer: what is installed, then what is merely available.
+    ///
+    /// A theme you have beats the same theme upstream, and only appears once — otherwise
+    /// downloading Nord would leave you with two rows saying Nord, one of which would offer to
+    /// download it again. Installed themes keep the order the disk gave them (sorted by name);
+    /// the rest follow, so the list reads as "yours, then everything else".
+    public static func merged(installed: [ThemeRef],
+                              available: [RemoteTheme]) -> (installed: [ThemeRef],
+                                                            available: [RemoteTheme]) {
+        let have = Set(installed.map(\.slug))
+        return (installed.sorted { $0.name.lowercased() < $1.name.lowercased() },
+                available.filter { !have.contains($0.slug) })
+    }
+}

--- a/Sources/ToeCore/Theme/ThemeWriter.swift
+++ b/Sources/ToeCore/Theme/ThemeWriter.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+/// Sets `[theme] name` in a config file without disturbing anything else in it.
+///
+/// Line surgery rather than a parse and a re-serialise, deliberately. This is the user's own
+/// file: their comments, their alignment, their ordering, and — per the header of the shipped
+/// config — a file they are told to treat as code. A round trip through `TOML.parse` would hand
+/// back something they did not write, with the comments gone. So the value between the quotes is
+/// the only thing that moves, and every other byte comes out the way it went in.
+///
+/// The cost of that choice is that this cannot see everything a TOML parser can. `["theme"]` is
+/// legal and is the *same table* as `[theme]`; so is a header split oddly across whitespace, and
+/// `[theme]` can appear inside a comment or a string where it means nothing at all. The two
+/// recognisable shapes are handled below; the rest is covered by the caller re-parsing this
+/// function's output and refusing to write when it does not say what it was asked to say. That
+/// guard is what turns a case this gets wrong from *your config is broken* into *toe declined to
+/// edit your config, and said so in the log*.
+public enum ThemeWriter {
+
+    /// The theme's name is slugified on the way in, so nothing this returns can break the file it
+    /// is going into: a slug has no quote, no bracket and no newline in it by construction, which
+    /// is a stronger guarantee than escaping and one that only has to hold in one place.
+    public static func settingTheme(_ name: String, in toml: String) -> String {
+        let slug = Slug.make(name)
+
+        // Split on "\n" and rejoin on "\n", never on newlines generally: `TOML.parse` normalises
+        // CRLF on the way in, but this writes a file back, and silently converting a file someone
+        // saved from Windows would be a diff they never asked for. A trailing "\r" simply rides
+        // along at the end of its line — and lands in the tail that `replacingName` preserves.
+        var lines = toml.components(separatedBy: "\n")
+
+        var inTheme = false
+        var themeHeader: Int?
+        var replaced = false
+
+        for index in lines.indices {
+            let trimmed = lines[index].trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty || trimmed.hasPrefix("#") { continue }
+
+            if let header = tableName(trimmed) {
+                inTheme = (header == "theme")
+                if inTheme, themeHeader == nil { themeHeader = index }
+                continue
+            }
+            if inTheme, !replaced, let rewritten = replacingName(in: lines[index], with: slug) {
+                lines[index] = rewritten
+                replaced = true
+            }
+        }
+
+        if replaced { return lines.joined(separator: "\n") }
+
+        let crlf = lines.contains { $0.hasSuffix("\r") }
+        let ending = crlf ? "\r" : ""
+
+        if let header = themeHeader {
+            lines.insert("name = \"\(slug)\"" + ending, at: header + 1)
+            return lines.joined(separator: "\n")
+        }
+
+        // Appended at the end rather than inserted anywhere tidier, because a table header
+        // terminates the table before it: an append can never land in the middle of somebody's
+        // `[binds]` or `[[float]]`, and an insert can. Configs written before themes existed take
+        // this path exactly once, and every later change takes the replace path above.
+        // A carriage return belongs at the *end* of the line it terminates, before the newline.
+        // Writing `"\n" + ending` put it at the start of the next one instead, which fed a stray
+        // CR and a LF-only blank line into a file this whole type exists to preserve byte for
+        // byte — and the obvious `contains("[theme]\r\n")` assertion passed either way.
+        var out = toml
+        // Asked of the bytes, not of `hasSuffix("\n")`. CR-LF is a *single* Swift `Character`, so
+        // a file ending in one has no `Character` equal to "\n" at the end and `hasSuffix` answers
+        // false — which quietly added a second blank line to every CRLF file. Same trap
+        // `TOML.parse` carries a comment about, one type over.
+        if !out.isEmpty, out.utf8.last != UInt8(ascii: "\n") { out += ending + "\n" }
+        out += "\(ending)\n[theme]\(ending)\nname = \"\(slug)\"\(ending)\n"
+        return out
+    }
+
+    /// The table a header line names, or nil if the line is not a header.
+    ///
+    /// `[[float]]` answers with a name that cannot be `theme`, which is what makes an array of
+    /// tables count as *leaving* the theme table rather than being ignored inside it.
+    private static func tableName(_ trimmed: String) -> String? {
+        guard trimmed.hasPrefix("[") else { return nil }
+        if trimmed.hasPrefix("[[") {
+            guard trimmed.contains("]]") else { return nil }
+            return "[[array]]"                      // never equal to a bare key
+        }
+        guard let close = trimmed.firstIndex(of: "]") else { return nil }
+        var inner = String(trimmed[trimmed.index(after: trimmed.startIndex)..<close])
+            .trimmingCharacters(in: .whitespaces)
+        // `["theme"]` is the same table as `[theme]`, and it is the shape most likely to be
+        // written by a generator rather than by hand.
+        for quote in ["\"", "'"] where inner.hasPrefix(quote) && inner.hasSuffix(quote) && inner.count >= 2 {
+            inner = String(inner.dropFirst().dropLast())
+        }
+        return inner
+    }
+
+    /// `name = "old"  # comment` becomes `name = "new"  # comment`, and anything that is not a
+    /// `name` assignment is left alone.
+    ///
+    /// Everything before the value and everything after it is copied through untouched, which is
+    /// what keeps a column of aligned `=` aligned and a trailing comment attached to the line it
+    /// was written on.
+    private static func replacingName(in line: String, with slug: String) -> String? {
+        let chars = Array(line)
+        var i = 0
+
+        func skipSpaces() { while i < chars.count, chars[i] == " " || chars[i] == "\t" { i += 1 } }
+
+        skipSpaces()
+        guard i < chars.count else { return nil }
+
+        var key = ""
+        if chars[i] == "\"" || chars[i] == "'" {
+            let quote = chars[i]
+            i += 1
+            while i < chars.count, chars[i] != quote { key.append(chars[i]); i += 1 }
+            guard i < chars.count else { return nil }
+            i += 1
+        } else {
+            while i < chars.count, chars[i].isLetter || chars[i].isNumber
+                    || chars[i] == "_" || chars[i] == "-" {
+                key.append(chars[i]); i += 1
+            }
+        }
+        guard key == "name" else { return nil }
+
+        skipSpaces()
+        guard i < chars.count, chars[i] == "=" else { return nil }
+        i += 1
+        skipSpaces()
+        let valueStart = i
+
+        // Where the old value ends. A quoted value ends at its closing quote; anything else —
+        // a number, a bare word, a config in the middle of being edited — ends at whitespace or
+        // at the `#` that starts a comment. Either way the tail is preserved verbatim.
+        if i < chars.count, chars[i] == "\"" || chars[i] == "'" {
+            let quote = chars[i]
+            i += 1
+            while i < chars.count, chars[i] != quote {
+                if chars[i] == "\\", i + 1 < chars.count { i += 1 }
+                i += 1
+            }
+            guard i < chars.count else { return nil }       // unterminated: leave it well alone
+            i += 1
+        } else {
+            while i < chars.count, chars[i] != "#", !chars[i].isWhitespace { i += 1 }
+        }
+
+        return String(chars[0..<valueStart]) + "\"\(slug)\"" + String(chars[i...])
+    }
+}

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -876,6 +876,8 @@ h.test("the shipped default config parses cleanly") { t in
     t.equal(binding("super-space")?.command, .menu(.root), "SUPER+SPACE opens the quick menu")
     t.equal(binding("super-space")?.keyCode, 0x31, "space key code")
     t.equal(binding("super-k")?.command, .menu(.keybindings), "SUPER+K lists the bindings")
+    t.equal(binding("super-ctrl-space")?.command, .nextBackground,
+            "SUPER+CTRL+SPACE is the key Omarchy gives to backgrounds")
     t.equal(c.menu.background, "#1a1b26", "the menu ships Omarchy's Tokyo Night background")
 
     let arrows = ["super-left", "super-right", "super-up", "super-down"]
@@ -984,12 +986,25 @@ h.test("the escape hatches are bound even when the config forgets them") { t in
     t.equal(binding(clash, .killActive)?.source, "super-shift-q", "and stays yours")
     t.equal(binding(clash, .reload)?.source, "super-shift-r", "the others still land")
 
-    // The shipped config binds both itself, so nothing should be duplicated.
+    // The shipped config binds them itself, so nothing should be duplicated.
     let shipped = try Config.parse(Config.defaultTOML)
-    for command in [Command.quit, .reload] {
+    for command in [Command.quit, .reload, .nextBackground] {
         t.equal(shipped.bindings.filter { $0.command == command }.count, 1,
                 "the shipped config binds \(command) exactly once")
     }
+
+    // The one entry on the list that is not an escape hatch. It is there for the same reason the
+    // others are — a config is never rewritten, so a key added later reaches nobody who already
+    // had one — and it obeys the same two rules, which is what makes it something you can take
+    // back rather than something done to you.
+    t.equal(binding(old, .nextBackground)?.source, "super-ctrl-space",
+            "a config written before backgrounds existed still gets the key")
+    let moved = try Config.parse("[binds]\n\"super-b\" = \"nextbackground\"\n")
+    t.equal(binding(moved, .nextBackground)?.source, "super-b", "binding it elsewhere takes the key back")
+    t.equal(moved.bindings.filter { $0.command == .nextBackground }.count, 1, "and not twice")
+    let taken = try Config.parse("[binds]\n\"super-ctrl-space\" = \"killactive\"\n")
+    t.equal(binding(taken, .nextBackground), nil, "and a key you already use is left alone")
+    t.equal(binding(taken, .killActive)?.source, "super-ctrl-space", "still doing what you asked")
 }
 
 h.test("nan and infinity are refused rather than reaching the layout") { t in
@@ -1710,15 +1725,15 @@ h.test("an empty query is one level at a time, with no paths") { t in
     m.type("z")
     t.equal(m.visible.count, 0, "nothing matches")
     m.backspace()
-    t.equal(m.visible.map(\.title), ["Configure", "Learn", "Quit"], "the level comes back")
+    t.equal(m.visible.map(\.title), ["Configure", "Learn", "Style", "Quit"], "the level comes back")
     t.expect(m.visible.allSatisfy { $0.subtitle == nil },
              "and the paths go away with the search that needed them")
 }
 
 h.test("the rows lead where the menu says they do") { t in
     var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 10)
-    t.equal(m.visible.map(\.title), ["Configure", "Learn", "Quit"], "the whole menu, bare minimum")
-    t.equal(m.visible.map(\.leadsOn), [true, true, false], "two lead on, Quit acts")
+    t.equal(m.visible.map(\.title), ["Configure", "Learn", "Style", "Quit"], "the whole menu, bare minimum")
+    t.equal(m.visible.map(\.leadsOn), [true, true, true, false], "three lead on, Quit acts")
     m.type("quit")
     t.equal(m.activate(), .run(.quit), "and Quit dispatches rather than descending")
 
@@ -1774,7 +1789,7 @@ h.test("the Edit configuration row is your binding, not toe's idea of an editor"
     t.equal(MenuModel.root(loginItem: .unavailable("needs /Applications"),
                            bindings: try Config.parse("[binds]\n\"super-enter\" = \"exec open -a Ghostty\"\n").bindings)
                 .map(\.title),
-            ["Learn", "Quit"],
+            ["Learn", "Style", "Quit"],
             "and with the startup row gone as well, Configure has nothing left to hold")
 
     // The row is there even when the startup toggle cannot be.
@@ -1786,7 +1801,7 @@ h.test("the Edit configuration row is your binding, not toe's idea of an editor"
 h.test("Configure goes with the startup row, being all that was left in it") { t in
     let m = MenuState(root: MenuModel.root(loginItem: .unavailable("needs /Applications"), bindings: []),
                       visibleRows: 10)
-    t.equal(m.visible.map(\.title), ["Learn", "Quit"],
+    t.equal(m.visible.map(\.title), ["Learn", "Style", "Quit"],
             "a row that leads into an empty level is worse than no row")
 
     var searching = MenuState(root: MenuModel.root(loginItem: .unavailable("needs /Applications"), bindings: []),
@@ -1865,6 +1880,7 @@ h.test("every command has a label a reader could use") { t in
         .killActive, .toggleFloating, .toggleSplit, .swapSplit,
         .exec("open -a Safari"), .reload, .quit,
         .menu(.root), .menu(.keybindings),
+        .theme("gruvbox"), .theme(""), .background("city.jpg"), .nextBackground,
     ]
     for command in all {
         let label = CommandLabel.describe(command)
@@ -1873,6 +1889,13 @@ h.test("every command has a label a reader could use") { t in
     }
     t.equal(CommandLabel.describe(.moveFocus(.left)), "Move focus left", "a sample of the prose")
     t.equal(CommandLabel.describe(.menu(.keybindings)), "Show the keybindings", "and the new one")
+    t.equal(CommandLabel.describe(.theme("gruvbox")), "Theme: Gruvbox",
+            "a theme toe ships is named the way it names itself")
+    t.equal(CommandLabel.describe(.theme("rose-pine")), "Theme: Rose Pine",
+            "and one of yours is titled from its directory, which is all it has")
+    t.equal(CommandLabel.describe(.theme("")), "Use your own colours",
+            "clearing the theme reads as what it does, not as an empty name")
+    t.equal(CommandLabel.describe(.nextBackground), "Next background", "and the cycle")
 }
 
 h.test("the binding that opens the config is named rather than spelled out") { t in
@@ -2029,6 +2052,561 @@ h.test("menu commands parse in both spellings") { t in
     t.equal(try CommandParser.parse("menu keys"), .menu(.keybindings), "and its abbreviation")
     t.expect((try? CommandParser.parse("menu wardrobe")) == nil,
              "an unknown page is an error rather than quietly the root menu")
+}
+
+// MARK: - Themes
+
+/// Omarchy's themes/tokyo-night/colors.toml, verbatim. Pasted rather than summarised, because
+/// what is being asserted is that toe reads *their* file — a paraphrase would pass while the real
+/// thing failed.
+let tokyoNightColors = """
+accent = "#7aa2f7"
+cursor = "#c0caf5"
+foreground = "#a9b1d6"
+background = "#1a1b26"
+selection_foreground = "#c0caf5"
+selection_background = "#7aa2f7"
+
+color0 = "#32344a"
+color1 = "#f7768e"
+color2 = "#9ece6a"
+color3 = "#e0af68"
+color4 = "#7aa2f7"
+color5 = "#ad8ee6"
+color6 = "#449dab"
+color7 = "#787c99"
+color8 = "#444b6a"
+color9 = "#ff7a93"
+color10 = "#b9f27c"
+color11 = "#ff9e64"
+color12 = "#7da6ff"
+color13 = "#bb9af7"
+color14 = "#0db9d7"
+color15 = "#acb0d0"
+"""
+
+/// Two themes to test against, built here rather than taken from toe. toe ships none: a theme is
+/// somebody else's work, and the list you choose from is what you have on disk plus what Omarchy
+/// publishes. So the fixtures below are exactly that — a theme somebody downloaded.
+let tokyoNight = Theme(slug: "tokyo-night", name: "Tokyo Night",
+                       palette: try! Palette.parse(tokyoNightColors))
+let gruvbox = Theme(slug: "gruvbox", name: "Gruvbox",
+                    palette: Palette(accent: "#7daea3", background: "#282828",
+                                     foreground: "#d4be98"))
+
+h.test("an Omarchy colors.toml is read key for key") { t in
+    guard let p = try? Palette.parse(tokyoNightColors) else {
+        return t.expect(false, "the shipped Tokyo Night palette should parse")
+    }
+    t.equal(p.accent, "#7aa2f7", "accent is what the border takes")
+    t.equal(p.background, "#1a1b26", "background is walker's @base")
+    t.equal(p.foreground, "#a9b1d6", "foreground is walker's @text")
+    t.equal(p.cursor, "#c0caf5", "the keys toe does not paint with are kept anyway")
+    t.equal(p.color(6), "#449dab", "color0…color15 land in order")
+    t.equal(p.color(15), "#acb0d0", "including the last one")
+    t.equal(p.color(16), nil, "and nothing past it")
+    t.equal(p.terminal.compactMap { $0 }.count, 16, "all sixteen terminal colours land")
+}
+
+h.test("a theme missing a colour toe paints with is refused rather than guessed at") { t in
+    t.equal(try? Palette.parse("background = \"#000000\"\nforeground = \"#ffffff\"") , nil,
+            "no accent is not a theme")
+    do {
+        _ = try Palette.parse("background = \"#000000\"\nforeground = \"#ffffff\"")
+        t.expect(false, "it should have thrown")
+    } catch {
+        t.equal(error as? PaletteError, .missing("accent"), "and it names the key that is absent")
+    }
+    do {
+        _ = try Palette.parse("accent = \"blue\"\nbackground = \"#000\"\nforeground = \"#fff\"")
+        t.expect(false, "it should have thrown")
+    } catch {
+        t.equal(error as? PaletteError, .notAColour(key: "accent", value: "blue"),
+                "a colour that will not parse is named with what was there, as Hex.rgba's nil intends")
+    }
+}
+
+// MARK: - The catalogue
+
+/// A cut-down GitHub tree listing, in the shape the real one comes back in. Everything awkward is
+/// in here on purpose: a theme with no palette, a directory that is not a slug, a file that is not
+/// a picture, and a name that must never reach the filesystem.
+let treeJSON = Data("""
+{"sha":"x","truncated":false,"tree":[
+  {"path":"themes","mode":"040000","type":"tree","sha":"a"},
+  {"path":"themes/gruvbox","mode":"040000","type":"tree","sha":"b"},
+  {"path":"themes/gruvbox/colors.toml","mode":"100644","type":"blob","sha":"c","size":511},
+  {"path":"themes/gruvbox/backgrounds/1-the-backwater.jpg","mode":"100644","type":"blob","sha":"d","size":4127598},
+  {"path":"themes/gruvbox/backgrounds/5-leaves.jpg","mode":"100644","type":"blob","sha":"e","size":443959},
+  {"path":"themes/gruvbox/README.md","mode":"100644","type":"blob","sha":"f","size":10},
+  {"path":"themes/tokyo-night/colors.toml","mode":"100644","type":"blob","sha":"g","size":500},
+  {"path":"themes/tokyo-night/backgrounds/0-winding-road.webp","mode":"100644","type":"blob","sha":"h","size":653482},
+  {"path":"themes/tokyo-night/backgrounds/.DS_Store","mode":"100644","type":"blob","sha":"i","size":6148},
+  {"path":"themes/tokyo-night/backgrounds/omarchy.webp","mode":"100644","type":"blob","sha":"m","size":716},
+  {"path":"themes/gruvbox/backgrounds/omarchy.png","mode":"100644","type":"blob","sha":"n","size":900},
+  {"path":"themes/no-palette/backgrounds/x.jpg","mode":"100644","type":"blob","sha":"j","size":1},
+  {"path":"themes/Not A Slug/colors.toml","mode":"100644","type":"blob","sha":"k","size":1},
+  {"path":"bin/omarchy-theme-set","mode":"100755","type":"blob","sha":"l","size":900}
+]}
+""".utf8)
+
+h.test("one request describes every theme Omarchy publishes") { t in
+    guard let c = try? Catalogue.parse(treeJSON) else {
+        return t.expect(false, "the tree listing should parse")
+    }
+    // A theme with no colors.toml is not one toe can use: Omarchy has a few that describe
+    // themselves only through per-app templates, and toe renders none of those.
+    t.equal(c.themes.map(\.slug), ["gruvbox", "tokyo-night"],
+            "themes with a palette, in a stable order, and nothing outside themes/")
+    t.equal(c.themes.first?.name, "Gruvbox", "titled from the directory name")
+    t.equal(c.themes.first?.backgrounds.map(\.name), ["1-the-backwater.jpg", "5-leaves.jpg"],
+            "pictures only — a README beside them is not one")
+    t.equal(c.themes.last?.backgrounds.map(\.name), ["0-winding-road.webp"],
+            "and neither is the .DS_Store that every folder collects")
+    // Every theme upstream carries the OMARCHY wordmark in its backgrounds folder, under one of
+    // two extensions. It is not a wallpaper anybody wants on a toe desktop, so it is not fetched
+    // and does not count towards what the row says a theme costs.
+    t.equal(c.themes.flatMap { $0.backgrounds.map(\.name) }.contains { $0.hasPrefix("omarchy.") },
+            false, "and the wordmark is left where it is")
+    // The size is what the menu row shows, and the whole reason this shape was chosen over one
+    // request per theme.
+    t.equal(c.themes.first?.bytes, 4127598 + 443959,
+            "a theme knows what it costs to download, the wordmark excluded")
+    t.equal(ByteSize.describe(c.themes.first?.bytes ?? 0), "4.4 MB", "as the row says it")
+}
+
+h.test("upstream's wordmark is not fetched, but yours is still listed") { t in
+    for name in ["omarchy.png", "omarchy.webp", "OMARCHY.PNG"] {
+        t.equal(Backgrounds.isUpstreamBranding(name), true, "\(name) is branding, not a wallpaper")
+    }
+    for name in ["1-the-backwater.jpg", "omarchy-cityscape.jpg", "my-omarchy.png"] {
+        t.equal(Backgrounds.isUpstreamBranding(name), false, "\(name) is not")
+    }
+    // Filtered where a theme is fetched, not where a folder is listed: declining to download
+    // another project's wordmark is toe's call, and overruling a file you put there yourself is
+    // not.
+    t.equal(Backgrounds.list(["omarchy.png", "a.jpg"]), ["a.jpg", "omarchy.png"],
+            "a folder you assembled by hand is shown whole")
+}
+
+h.test("a directory that is not a slug is not a theme") { t in
+    guard let c = try? Catalogue.parse(treeJSON) else {
+        return t.expect(false, "the tree listing should parse")
+    }
+    // `Not A Slug` has a colors.toml and is still refused. This name would become a directory
+    // under ~/.config/toe/themes, and a path component is the only thing it is allowed to be.
+    t.equal(c.themes.contains { $0.name.contains("Not A Slug") }, false, "refused, not repaired")
+    t.equal(c.themes.count, 2, "and it is not silently slugified into one either")
+}
+
+h.test("a listing that came back incomplete is refused outright") { t in
+    // GitHub truncates a tree too large to serve. Half a catalogue is worse than none: it would
+    // look complete, and the themes missing from it would look as though they did not exist.
+    let truncated = Data(#"{"truncated":true,"tree":[]}"#.utf8)
+    do { _ = try Catalogue.parse(truncated); t.expect(false, "it should have thrown") }
+    catch { t.equal(error as? CatalogueError, .truncated, "and says so") }
+
+    do { _ = try Catalogue.parse(Data("not json".utf8)); t.expect(false, "it should have thrown") }
+    catch { t.equal(error as? CatalogueError, .notJSON, "as does a body that is not JSON at all") }
+
+    do { _ = try Catalogue.parse(Data(#"{"tree":[]}"#.utf8)); t.expect(false, "it should have thrown") }
+    catch { t.equal(error as? CatalogueError, .empty, "and one with no themes in it") }
+}
+
+h.test("a name off the network is checked by shape, not searched for tricks") { t in
+    // A whitelist, because "does not contain .." is the kind of rule that is one encoding trick
+    // away from being wrong. These names are about to be joined onto a directory path.
+    for bad in ["", ".", "..", "../evil", "a/b", "a\\b", ".hidden", String(repeating: "z", count: 200)] {
+        t.equal(Catalogue.isSafeFileName(bad), false, "'\(bad)' is not a name toe will write")
+    }
+    for good in ["1-the-backwater.jpg", "0-winding-road.webp", "a b c.png"] {
+        t.equal(Catalogue.isSafeFileName(good), true, "'\(good)' is")
+    }
+}
+
+h.test("a catalogue goes stale, and a clock that jumped reads as stale too") { t in
+    let now = Date()
+    let fresh = Catalogue(fetchedAt: now.addingTimeInterval(-60), themes: [])
+    t.equal(fresh.isStale(now: now, maxAge: 3600), false, "a minute old is fresh")
+    t.equal(fresh.isStale(now: now, maxAge: 30), true, "and past the age it is not")
+    // A restored machine or a corrected clock can put the stamp in the future. Refetching is the
+    // cheap answer; treating it as fresh would wedge the list until the skew passed.
+    let future = Catalogue(fetchedAt: now.addingTimeInterval(3600), themes: [])
+    t.equal(future.isStale(now: now, maxAge: 86400), true, "a stamp in the future is not fresh")
+}
+
+h.test("a byte count reads the way a menu row needs it to") { t in
+    t.equal(ByteSize.describe(4571557), "4.4 MB", "megabytes to one place")
+    t.equal(ByteSize.describe(330000), "0.3 MB", "including under one")
+    t.equal(ByteSize.describe(511), "1 KB", "and kilobytes below that")
+    t.equal(ByteSize.describe(0), "", "nothing at all for nothing")
+}
+
+// MARK: - Themes
+
+h.test("a theme name is slugified the way Omarchy slugifies it") { t in
+    t.equal(Slug.make("Tokyo Night"), "tokyo-night", "lowercased, spaces to hyphens")
+    t.equal(Slug.make("CATPPUCCIN"), "catppuccin", "however it was shouted")
+    t.equal(Slug.make("rose_pine"), "rose-pine", "an underscore is a hyphen")
+    t.equal(Slug.make("Rose  Pine"), "rose-pine", "and runs collapse")
+    t.equal(Slug.make("  gruvbox  "), "gruvbox", "trimmed at both ends")
+    t.equal(Slug.make(""), "", "nothing stays nothing — that is how a theme is cleared")
+    // The reason the filter exists: this value becomes a path component under
+    // ~/.config/toe/themes AND a string literal inside the user's own config.
+    t.equal(Slug.make("../../.ssh"), "ssh", "a path cannot be walked out of")
+    t.equal(Slug.make("/etc/passwd"), "etcpasswd", "and a leading slash is not a slug character")
+    t.equal(Slug.make("a\" b [x]"), "a-b-x", "nor is a quote or a bracket")
+    t.expect(Slug.make(String(repeating: "z", count: 200)).count <= 64, "and it cannot run away")
+}
+
+h.test("a directory name reads back as a title") { t in
+    t.equal(Slug.title("catppuccin-latte"), "Catppuccin Latte", "hyphens are spaces again")
+    t.equal(Slug.title("gruvbox"), "Gruvbox", "one word is capitalised")
+    t.equal(Slug.title(""), "", "and nothing is nothing")
+}
+
+h.test("a theme you have is not also offered for download") { t in
+    let installed = [ThemeRef(slug: "gruvbox", name: "Gruvbox"),
+                     ThemeRef(slug: "rose-pine", name: "Rose Pine")]
+    let available = [RemoteTheme(slug: "gruvbox", name: "Gruvbox", backgrounds: []),
+                     RemoteTheme(slug: "nord", name: "Nord",
+                                 backgrounds: [RemoteFile(name: "a.jpg", bytes: 4_300_000)])]
+    let (have, offer) = Themes.merged(installed: installed, available: available)
+    t.equal(have.map(\.slug), ["gruvbox", "rose-pine"], "yours, sorted by name")
+    // Otherwise downloading Nord would leave two rows saying Nord, one offering to fetch it again.
+    t.equal(offer.map(\.slug), ["nord"], "and only what you have not got")
+    t.equal(offer.first?.bytes, 4_300_000, "carrying what it would cost")
+
+    let (none, all) = Themes.merged(installed: [], available: available)
+    t.equal(none.isEmpty, true, "a machine that has fetched nothing has nothing installed")
+    t.equal(all.count, 2, "and is offered everything")
+}
+
+h.test("toe's own colours are Tokyo Night already, so that theme only moves the border") { t in
+    guard let c = try? Config.parse(Config.defaultTOML) else {
+        return t.expect(false, "the shipped config parses")
+    }
+    let themed = c.applying(tokyoNight)
+    // The payoff, and the reason a fresh install with no themes at all still looks themed:
+    // MenuConfig's defaults were derived from this very palette through walker's token mapping,
+    // so applying Tokyo Night must be a no-op on the menu. If this fails, one of the two drifted.
+    t.equal(themed.menu, c.menu, "the menu is already Tokyo Night, to the byte")
+    t.equal(themed.border.activeStart, "#7aa2f7", "and the border takes the accent")
+    t.equal(themed.border.activeEnd, "#7aa2f7", "at both stops")
+    t.equal(themed.theme.name, "tokyo-night", "the resolved slug is what the menu marks with")
+}
+
+h.test("a theme takes both border stops, because Omarchy's border is flat") { t in
+    let c = Config()
+    for theme in [tokyoNight, gruvbox] {
+        let themed = c.applying(theme)
+        t.equal(themed.border.activeStart, theme.palette.accent, "\(theme.slug) start")
+        t.equal(themed.border.activeEnd, theme.palette.accent, "\(theme.slug) end")
+        t.equal(themed.menu.background, theme.palette.background, "\(theme.slug) menu background")
+        t.equal(themed.menu.foreground, theme.palette.foreground, "\(theme.slug) menu foreground")
+        t.equal(themed.menu.accent, theme.palette.accent, "\(theme.slug) menu accent")
+        t.equal(themed.menu.border, nil, "\(theme.slug) rejoins the border to the foreground")
+    }
+}
+
+h.test("a theme leaves every size and behaviour alone") { t in
+    guard let c = try? Config.parse(Config.defaultTOML) else {
+        return t.expect(false, "the shipped config parses")
+    }
+    let themed = c.applying(gruvbox)
+    t.equal(themed.border.width, c.border.width, "border width")
+    t.equal(themed.border.angle, c.border.angle, "the sweep angle survives, inert, for when the theme is cleared")
+    t.equal(themed.border.radius, c.border.radius, "corner radius")
+    t.equal(themed.border.enabled, c.border.enabled, "and whether there is a border at all")
+    t.equal(themed.menu.opacity, c.menu.opacity, "menu opacity")
+    t.equal(themed.menu.width, c.menu.width, "menu width")
+    t.equal(themed.menu.listWidth, c.menu.listWidth, "list width")
+    t.equal(themed.menu.fontSize, c.menu.fontSize, "font size")
+    t.equal(themed.bindings.count, c.bindings.count, "and it is not a config reload")
+}
+
+h.test("the theme wins over the colour keys, and says nothing about it") { t in
+    let text = """
+    [theme]
+    name = "gruvbox"
+
+    [border]
+    active_start = "#111111"
+    active_end   = "#222222"
+
+    [menu]
+    background = "#333333"
+    """
+    guard let c = try? Config.parse(text) else { return t.expect(false, "it parses") }
+    t.equal(c.border.activeStart, "#111111", "parse reads the file as written")
+    let themed = c.applying(gruvbox)
+    t.equal(themed.border.activeStart, "#7daea3", "and applying overrules it outright")
+    t.equal(themed.menu.background, "#282828", "menu colours too")
+    // Not a merge and not a warning: the config toe ships sets all of these, so a warning here
+    // would fire for everybody the first time they picked a theme.
+    t.equal(c.warnings, [], "and nothing is warned about")
+}
+
+h.test("no theme is today's behaviour, exactly") { t in
+    guard let c = try? Config.parse(Config.defaultTOML) else {
+        return t.expect(false, "the shipped config parses")
+    }
+    t.equal(c.theme.name, "", "the shipped config names no theme")
+    t.equal(c.border.activeStart, "#33ccffee", "so the gradient is untouched")
+    t.equal(c.border.activeEnd, "#00ff99ee", "at both ends")
+}
+
+h.test("a theme name that is not a name is refused rather than used") { t in
+    guard let c = try? Config.parse("[theme]\nname = 3\n") else {
+        return t.expect(false, "it still parses")
+    }
+    t.equal(c.theme.name, "", "a number is not a theme")
+    t.expect(c.warnings.contains { $0.contains("theme.name") }, "and it is named in the tooltip")
+}
+
+// MARK: - Writing the theme back
+
+h.test("setting a theme moves one line and leaves every other byte") { t in
+    let before = Config.defaultTOML
+    let after = ThemeWriter.settingTheme("gruvbox", in: before)
+    let a = before.components(separatedBy: "\n"), b = after.components(separatedBy: "\n")
+    t.equal(a.count, b.count, "no line is added or removed")
+    let changed = zip(a, b).filter { $0 != $1 }
+    t.equal(changed.count, 1, "and exactly one is different")
+    guard let c = try? Config.parse(after) else { return t.expect(false, "the result parses") }
+    t.equal(c.theme.name, "gruvbox", "as the theme that was asked for")
+    t.equal(c.warnings, [], "with nothing to warn about")
+}
+
+h.test("a config written before themes existed grows the table at the end") { t in
+    for source in ["[general]\ngaps_in = 5\n", "[general]\ngaps_in = 5"] {
+        let after = ThemeWriter.settingTheme("catppuccin", in: source)
+        guard let c = try? Config.parse(after) else {
+            return t.expect(false, "it parses whether or not the file ended in a newline")
+        }
+        t.equal(c.theme.name, "catppuccin", "the theme is set")
+        t.equal(c.gaps.inner, 5, "and what was already there is still there")
+    }
+    t.equal(try? Config.parse(ThemeWriter.settingTheme("gruvbox", in: "")).theme.name, "gruvbox",
+            "an empty file is a config with only a theme in it")
+}
+
+h.test("a name key in another table is not the theme's") { t in
+    let source = """
+    [theme]
+    name = "tokyo-night"
+
+    [[float]]
+    app = "com.apple.finder"
+    title = "Copy"
+    """
+    let after = ThemeWriter.settingTheme("gruvbox", in: source)
+    guard let c = try? Config.parse(after) else { return t.expect(false, "it parses") }
+    t.equal(c.theme.name, "gruvbox", "the theme moved")
+    t.expect(after.contains("app = \"com.apple.finder\""), "and the float rule did not")
+    // A `name` before any header at all is the root table, which is not [theme] either.
+    let rooted = ThemeWriter.settingTheme("gruvbox", in: "name = \"keep me\"\n[theme]\nname = \"x\"\n")
+    t.expect(rooted.hasPrefix("name = \"keep me\""), "a key above every header is left alone")
+}
+
+h.test("a comment beside the theme name survives being retuned") { t in
+    let after = ThemeWriter.settingTheme("gruvbox", in: "[theme]\nname   = \"tokyo-night\"   # mine\n")
+    t.equal(after, "[theme]\nname   = \"gruvbox\"   # mine\n",
+            "the alignment and the comment are both the user's, not ours")
+}
+
+h.test("a theme table with no name in it yet gains one") { t in
+    let after = ThemeWriter.settingTheme("gruvbox", in: "[theme]\n# nothing here yet\n[border]\nwidth = 2\n")
+    guard let c = try? Config.parse(after) else { return t.expect(false, "it parses") }
+    t.equal(c.theme.name, "gruvbox", "inserted under the header it belongs to")
+    t.equal(c.border.width, 2, "and not in the table below it")
+}
+
+h.test("clearing the theme is setting it to nothing") { t in
+    let after = ThemeWriter.settingTheme("", in: "[theme]\nname = \"gruvbox\"\n")
+    t.equal(after, "[theme]\nname = \"\"\n", "which is what hands your own colours back")
+}
+
+h.test("setting the same theme twice writes the same bytes") { t in
+    let once = ThemeWriter.settingTheme("gruvbox", in: Config.defaultTOML)
+    t.equal(ThemeWriter.settingTheme("gruvbox", in: once), once, "so a repeat is not a file change")
+}
+
+h.test("a config saved with Windows line endings keeps them") { t in
+    let source = "[theme]\r\nname = \"tokyo-night\"\r\n[border]\r\nwidth = 2\r\n"
+    let after = ThemeWriter.settingTheme("gruvbox", in: source)
+    t.equal(after, "[theme]\r\nname = \"gruvbox\"\r\n[border]\r\nwidth = 2\r\n",
+            "TOML.parse normalises CRLF on the way in; writing a file back must not")
+    t.equal(try? Config.parse(after).theme.name, "gruvbox", "and it still parses")
+    // Asserted whole rather than with `contains`, which passed while the writer was emitting
+    // "\n\r" — the carriage return landing at the head of the next line instead of the tail of
+    // its own, leaving a stray CR in a file this is meant to preserve byte for byte.
+    t.equal(ThemeWriter.settingTheme("gruvbox", in: "[general]\r\ngaps_in = 5\r\n"),
+            "[general]\r\ngaps_in = 5\r\n\r\n[theme]\r\nname = \"gruvbox\"\r\n",
+            "a table appended to a CRLF file is CRLF throughout, and nothing else is")
+    t.equal(ThemeWriter.settingTheme("gruvbox", in: "[general]\r\ngaps_in = 5"),
+            "[general]\r\ngaps_in = 5\r\n\r\n[theme]\r\nname = \"gruvbox\"\r\n",
+            "including when the file did not end in one")
+    t.equal(ThemeWriter.settingTheme("gruvbox", in: "[general]\ngaps_in = 5\n"),
+            "[general]\ngaps_in = 5\n\n[theme]\nname = \"gruvbox\"\n",
+            "and a Unix file gains no carriage returns from having the option")
+}
+
+h.test("a header is still the theme table however it is spelled") { t in
+    for header in ["[theme]", "[ theme ]", "[\"theme\"]"] {
+        let after = ThemeWriter.settingTheme("gruvbox", in: "\(header)\nname = \"x\"\n")
+        t.equal(try? Config.parse(after).theme.name, "gruvbox", "\(header) is the theme table")
+    }
+    // A header inside a comment is not a header.
+    let commented = ThemeWriter.settingTheme("gruvbox", in: "# [theme]\nname = \"keep\"\n")
+    t.expect(commented.contains("name = \"keep\""), "a commented-out header opens nothing")
+}
+
+h.test("a theme name can never break the file it is written into") { t in
+    let hostile = ThemeWriter.settingTheme("a\" b [x]\nname = \"evil", in: Config.defaultTOML)
+    guard let c = try? Config.parse(hostile) else {
+        return t.expect(false, "whatever went in, what comes out is a config")
+    }
+    t.equal(c.theme.name, "a-b-x-name-evil", "because a slug has no quote, bracket or newline in it")
+}
+
+h.test("the theme commands parse in Omarchy's spellings") { t in
+    t.equal(try? CommandParser.parse("theme gruvbox"), .theme("gruvbox"), "plain")
+    t.equal(try? CommandParser.parse("theme, gruvbox"), .theme("gruvbox"), "Hyprland's comma")
+    t.equal(try? CommandParser.parse("theme Tokyo Night"), .theme("tokyo-night"),
+            "a display name read across from an Omarchy config finds the same directory")
+    // The one verb whose argument may be missing, because clearing the theme has to be sayable
+    // and `theme none` would collide with a directory somebody could name.
+    t.equal(try? CommandParser.parse("theme"), .theme(""), "and bare means your own colours back")
+    t.equal(try? CommandParser.parse("bg city.jpg"), .background("city.jpg"), "a background by name")
+    t.equal(try? CommandParser.parse("background City.JPG"), .background("City.JPG"),
+            "not slugified — it is a file name, with an extension and a case of its own")
+    t.expect((try? CommandParser.parse("background")) == nil, "which does have to be given")
+    for spelling in ["nextbackground", "bgnext", "background-next"] {
+        t.equal(try? CommandParser.parse(spelling), .nextBackground, "\(spelling) cycles")
+    }
+}
+
+h.test("the background cycle is the one Omarchy walks") { t in
+    let files = ["0-a.jpg", "1-b.png", "2-c.webp"]
+    t.equal(Backgrounds.next(after: "0-a.jpg", in: files), "1-b.png", "one step on")
+    t.equal(Backgrounds.next(after: "2-c.webp", in: files), "0-a.jpg", "and it wraps at the end")
+    t.equal(Backgrounds.next(after: nil, in: files), "0-a.jpg", "nothing current starts at the first")
+    t.equal(Backgrounds.next(after: "gone.jpg", in: files), "0-a.jpg",
+            "and so does a name that is no longer there, rather than refusing to cycle")
+    t.equal(Backgrounds.next(after: "only.jpg", in: ["only.jpg"]), "only.jpg", "one file cycles to itself")
+    t.equal(Backgrounds.next(after: nil, in: []), nil, "and an empty folder has no next")
+}
+
+h.test("a backgrounds folder is filtered and sorted the same way twice") { t in
+    let listed = Backgrounds.list([
+        "2-b.PNG", ".DS_Store", "README.md", "0-a.jpg", "1-c.webp", "LICENSE", ".hidden.jpg",
+    ])
+    t.equal(listed, ["0-a.jpg", "1-c.webp", "2-b.PNG"],
+            "pictures only, in codepoint order so two machines agree — and the extension's case "
+            + "does not decide whether it is one")
+    t.equal(Backgrounds.list(listed), listed, "and listing the list again changes nothing")
+    // The order the menu draws and the order the key walks are the same list, by construction.
+    t.equal(Backgrounds.next(after: listed.last, in: listed), listed.first,
+            "so cycling and listing cannot drift apart")
+}
+
+// MARK: - The Style menu
+
+h.test("Style is always at the root, because it is how you get a theme at all") { t in
+    let m = MenuState(root: MenuModel.root(loginItem: .unavailable("needs /Applications"),
+                                           bindings: []), visibleRows: 10)
+    // Unlike Configure, which goes when both its rows are unavailable, Style stays even on a
+    // machine with no themes and no network: it is the level you go to *to* get one, so leaving
+    // it out exactly when it is most needed would be the wrong way round.
+    t.equal(m.visible.map(\.title), ["Learn", "Style", "Quit"], "still there with nothing behind it")
+    t.equal(MenuModel.style(StyleMenu()).map(\.title), ["Theme"],
+            "holding the theme list, and no Background row until there are pictures")
+}
+
+h.test("Background is left out when there are no images") { t in
+    // The Configure-when-empty rule, one level down — and the usual case, since toe ships no
+    // pictures of its own.
+    t.equal(MenuModel.style(StyleMenu()).count, 1, "nothing to show, so no row leading to it")
+    let withPictures = StyleMenu(current: "gruvbox", backgrounds: ["a.jpg", "b.jpg"])
+    t.equal(MenuModel.style(withPictures).map(\.title), ["Theme", "Background"], "and it appears with them")
+}
+
+h.test("the theme you are on is marked, and so is having none") { t in
+    let have = [ThemeRef(slug: "tokyo-night", name: "Tokyo Night"),
+                ThemeRef(slug: "gruvbox", name: "Gruvbox")]
+    let themed = MenuModel.themes(StyleMenu(themes: have, current: "gruvbox"))
+    t.equal(themed.map(\.title), ["Tokyo Night", "Gruvbox", "Your own colours"],
+            "what is installed, then the way back out")
+    t.equal(themed.filter { $0.value == "current" }.map(\.title), ["Gruvbox"], "exactly one is marked")
+    t.equal(themed.first?.action, .run(.theme("tokyo-night")), "and a row runs the theme command")
+
+    let bare = MenuModel.themes(StyleMenu(themes: have))
+    t.equal(bare.filter { $0.value == "current" }.map(\.title), ["Your own colours"],
+            "no theme is a state the list can show, not an absence of state")
+    t.equal(bare.last?.action, .run(.theme("")), "and choosing it clears the name")
+}
+
+h.test("what you have leads, what you could have follows, with its price on it") { t in
+    let rows = MenuModel.themes(StyleMenu(
+        themes: [ThemeRef(slug: "rose-pine", name: "Rose Pine")],
+        available: [RemoteTheme(slug: "nord", name: "Nord",
+                                backgrounds: [RemoteFile(name: "a.jpg", bytes: 4_300_000)]),
+                    RemoteTheme(slug: "everforest", name: "Everforest", backgrounds: [])],
+        current: "rose-pine"))
+    t.equal(rows.map(\.title), ["Rose Pine", "Nord", "Everforest", "Your own colours"],
+            "installed first, then what Omarchy publishes")
+    t.equal(rows.first?.value, "current", "the one you are on is marked")
+    // The size is the disclosure: these run from a third of a megabyte to nine, and a row that
+    // fetched nine megabytes without saying so first would be a row that surprised you.
+    t.equal(rows[1].value, "4.1 MB", "and a download says what it costs")
+    t.equal(rows[2].value, "", "one with no pictures costs nothing worth printing")
+    // One command either way: choosing a theme is the same act whether or not you have it yet.
+    t.equal(rows[1].action, .run(.theme("nord")), "and is chosen the same way as one you have")
+}
+
+h.test("an empty list says it is fetching rather than looking short") { t in
+    let rows = MenuModel.themes(StyleMenu(fetching: true))
+    t.equal(rows.map(\.title), ["Fetching Omarchy's themes…", "Your own colours"],
+            "said, not left to be inferred from a list with nothing in it")
+    t.equal(rows.first?.leadsOn, false, "it does not lead anywhere")
+    var m = MenuState(root: rows, visibleRows: 10)
+    t.equal(m.activate(), MenuOutcome.none, "and pressing it does nothing, leaving the menu up")
+    t.equal(MenuModel.themes(StyleMenu()).map(\.title), ["Your own colours"],
+            "and once it is not fetching, a bare list is just bare")
+}
+
+h.test("the Background level is shaped like the Theme level above it") { t in
+    let rows = MenuModel.backgrounds(StyleMenu(current: "gruvbox",
+                                               backgrounds: ["city.jpg", "city.png"],
+                                               currentBackground: "city.png"))
+    t.equal(rows.map(\.title), ["city.jpg", "city.png", "Next background"],
+            "the choices, then the action — as Your own colours comes after the themes")
+    t.equal(rows.last?.action, .run(.nextBackground), "and that last row is the one that cycles")
+    t.equal(rows.compactMap(\.icon).count, 0,
+            "no icons: one icon among four rows indents that row's text past the rest")
+    t.equal(MenuModel.themes(StyleMenu()).compactMap(\.icon).count, 0, "as the theme list has none")
+    t.equal(rows.first { $0.title == "city.png" }?.value, "current", "with the one on screen marked")
+    t.equal(rows.first?.value, nil, "and only that one")
+    t.expect(rows.first?.title.hasSuffix(".jpg") == true,
+             "the extension stays, or two files would give two rows saying the same word")
+}
+
+h.test("a theme can be found by typing its name from the root") { t in
+    let style = StyleMenu(themes: [ThemeRef(slug: "gruvbox", name: "Gruvbox")])
+    var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: [], style: style),
+                      visibleRows: 10)
+    m.type("gruv")
+    t.equal(m.visible.map(\.title), ["Gruvbox"], "two levels down, without going there")
+    t.equal(m.visible.first?.subtitle, "Style › Theme", "and it says where it was found")
+    t.equal(m.activate(), .run(.theme("gruvbox")), "ready to act on")
+
+    var picture = MenuState(root: MenuModel.root(loginItem: .off, bindings: [],
+                                                 style: StyleMenu(current: "gruvbox",
+                                                                  backgrounds: ["city.jpg"])),
+                            visibleRows: 10)
+    picture.type("city")
+    t.equal(picture.activate(), .run(.background("city.jpg")), "a picture is reachable the same way")
 }
 
 exit(h.report())

--- a/Sources/toe/ConfigFile.swift
+++ b/Sources/toe/ConfigFile.swift
@@ -1,0 +1,94 @@
+import Darwin
+import Foundation
+
+/// Writes the config file back.
+///
+/// toe reads your config; it writes it in exactly one place, for exactly one key — the theme the
+/// quick menu just picked. Everything about this is arranged so that a menu click cannot cost you
+/// a file you wrote by hand.
+enum ConfigFile {
+
+    /// Replaces the file's contents, atomically, following a symlink rather than replacing it.
+    ///
+    /// The symlink is the whole reason this is not `Data.write(to:options:.atomic)`. Keeping
+    /// `~/.config/toe/toe.toml` as a link into a dotfiles repository is deliberately supported —
+    /// `Coordinator.permissionWarning` uses `stat` and not `lstat` for precisely that reason — and
+    /// an atomic write renames a temporary file over the *path*, which would quietly replace the
+    /// link with a regular file and orphan the copy in the repository. So the link is resolved
+    /// first and the rename happens over the real file, inside the real file's own directory,
+    /// which is also what keeps the rename on one filesystem.
+    ///
+    /// The rename does replace the inode, so a config kept as a *hard* link loses the link. A
+    /// symlink is what the README documents, and there is no way to be atomic and keep an inode
+    /// at the same time.
+    ///
+    /// Returns false and logs on any failure; the caller then leaves the file alone.
+    @discardableResult
+    static func write(_ text: String, to url: URL) -> Bool {
+        let target = url.resolvingSymlinksInPath()
+
+        // Only ever a regular file. Cheap, and it is the check that keeps a link left somewhere
+        // odd from turning a menu click into an overwrite of something that is not a config.
+        var info = stat()
+        guard lstat(target.path, &info) == 0 else {
+            Log.error("config write: \(target.path): \(String(cString: strerror(errno)))")
+            return false
+        }
+        guard info.st_mode & S_IFMT == S_IFREG else {
+            Log.error("config write: \(target.path) is not a regular file, leaving it alone")
+            return false
+        }
+
+        // The mode it already has, not one of ours. A config checked out of a dotfiles repository
+        // is often 0644, and silently chmodding a file inside somebody's git repository would
+        // show up as a diff they did not make. `permissionWarning` is what tells them when a mode
+        // is actually dangerous; that division of labour stays.
+        let mode = info.st_mode & 0o777
+
+        guard let data = text.data(using: .utf8) else { return false }
+        let temporary = target.deletingLastPathComponent()
+            .appendingPathComponent(".\(target.lastPathComponent).\(getpid()).tmp")
+
+        // O_EXCL and the mode in the one call, so the file can never exist for an instant with
+        // permissions it should not have — `writeDefaultConfigIfMissing` spells out the same
+        // reasoning for the file it creates on first run.
+        let fd = open(temporary.path, O_WRONLY | O_CREAT | O_EXCL, mode)
+        guard fd >= 0 else {
+            Log.error("config write: \(temporary.path): \(String(cString: strerror(errno)))")
+            return false
+        }
+
+        func abandon(_ what: String) -> Bool {
+            Log.error("config write: \(what): \(String(cString: strerror(errno)))")
+            close(fd)
+            unlink(temporary.path)
+            return false
+        }
+
+        var written = 0
+        let ok: Bool = data.withUnsafeBytes { buffer -> Bool in
+            guard let base = buffer.baseAddress else { return false }
+            while written < buffer.count {
+                let n = Darwin.write(fd, base + written, buffer.count - written)
+                if n < 0 {
+                    if errno == EINTR { continue }
+                    return false
+                }
+                if n == 0 { return false }
+                written += n
+            }
+            return true
+        }
+        guard ok else { return abandon("writing \(temporary.lastPathComponent)") }
+        guard fsync(fd) == 0 else { return abandon("flushing \(temporary.lastPathComponent)") }
+        close(fd)
+
+        guard rename(temporary.path, target.path) == 0 else {
+            let reason = String(cString: strerror(errno))
+            unlink(temporary.path)
+            Log.error("config write: renaming over \(target.path): \(reason)")
+            return false
+        }
+        return true
+    }
+}

--- a/Sources/toe/ConfigWatcher.swift
+++ b/Sources/toe/ConfigWatcher.swift
@@ -5,20 +5,43 @@ import Foundation
 /// The parent directory is watched as well as the file itself: most editors save atomically
 /// by writing a temporary file and renaming it over the original, which silently kills a
 /// watch bound only to the original file descriptor.
+///
+/// Also pointed at `~/.config/toe/themes`, where the target is a directory rather than a file
+/// and an entry appearing in it is a write to the directory itself — so there the parent watch
+/// is switched off, because the parent is `~/.config/toe` and would fire this watcher on every
+/// save of `toe.toml` as well. That directory's own existence is watched by the config watcher
+/// already, which is what lets a themes folder created after toe started still be picked up.
 final class ConfigWatcher {
 
     private let url: URL
+    private let watchesParent: Bool
+    private let events: DispatchSource.FileSystemEvent
     private var fileSource: DispatchSourceFileSystemObject?
     private var directorySource: DispatchSourceFileSystemObject?
     private var debounce: DispatchWorkItem?
 
     var onChange: (() -> Void)?
 
-    init(url: URL) { self.url = url }
+    /// - Parameter events: what counts as a change. `.attrib` is in the default because the
+    ///   config file is also checked for its permissions, and it is deliberately *out* of the one
+    ///   the theme watches pass: a palette's timestamps are not its colours, and asking to hear
+    ///   about them means hearing about toe's own read of the file it just reloaded for.
+    init(url: URL, watchesParent: Bool = true,
+         events: DispatchSource.FileSystemEvent = [.write, .extend, .attrib, .delete, .rename]) {
+        self.url = url
+        self.watchesParent = watchesParent
+        self.events = events
+    }
 
     func start() {
-        watchDirectory()
+        if watchesParent { watchDirectory() }
         watchFile()
+    }
+
+    func stop() {
+        debounce?.cancel()
+        fileSource?.cancel(); fileSource = nil
+        directorySource?.cancel(); directorySource = nil
     }
 
     private func watchFile() {
@@ -30,7 +53,7 @@ final class ConfigWatcher {
 
         let source = DispatchSource.makeFileSystemObjectSource(
             fileDescriptor: fd,
-            eventMask: [.write, .extend, .attrib, .delete, .rename],
+            eventMask: events,
             queue: .main)
 
         source.setEventHandler { [weak self] in

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -18,6 +18,43 @@ final class Coordinator: WindowTrackerDelegate {
     private let status = StatusItem()
     private let quickMenu = QuickMenu()
     private var watcher: ConfigWatcher?
+    /// Watches `~/.config/toe/themes`, so a theme folder appearing or going away is noticed
+    /// without waiting for anything else to happen. Optional and re-checked on every reload,
+    /// because that directory need not exist — most installs never make one.
+    private var themeWatcher: ConfigWatcher?
+    /// Watches the *current* theme's `colors.toml`, the one file whose contents can change what
+    /// is on screen. Two watchers rather than one because a write inside `themes/rose-pine/` is
+    /// not a write to `themes/` — directory notifications do not travel up — and one watcher per
+    /// installed theme would mean ninety file descriptors to catch edits to eighty-nine palettes
+    /// nothing is drawing with.
+    private var paletteWatcher: ConfigWatcher?
+    private var watchedPalette: String?
+
+    /// Every theme toe can see: the three it ships, merged with whatever is in the themes
+    /// directory. Rebuilt on every reload *and* every time the menu opens, which is what makes a
+    /// folder created a moment ago show up without a reload.
+    private var themes: [ThemeRef] = []
+    /// What Omarchy publishes and this machine has not got. Fetched lazily — see `ThemeCatalogue`.
+    private let available = ThemeCatalogue()
+    /// What a download is doing. Separate from `warnings`, which is replaced wholesale on every
+    /// reload, and from `runtimeWarnings`, which is for things that have gone wrong: this is
+    /// progress, and it clears itself when it finishes.
+    ///
+    /// Two strings because two surfaces show it and they have different room. `bar` goes in the
+    /// menu bar strip, which is where you will actually see it; `note` goes in the tooltip
+    /// behind it, which has room to say it properly.
+    private var progress: (bar: String, note: String)?
+    /// The current theme's pictures, in cycle order, and where in that cycle we are.
+    private var backgrounds: [String] = []
+    private var currentBackground: String?
+    /// The theme whose picture is on screen, so that changing theme puts a matching one up and a
+    /// plain reload does not touch what you are looking at.
+    private var pictureFrom: String?
+    private let wallpaper = Wallpaper()
+    /// The bytes of the config last loaded, so the same file arriving three times over — the
+    /// directory write, the rename, and the reload a theme pick asks for directly — costs one
+    /// reload rather than three. See `loadConfig(force:)`.
+    private var loadedText: String?
 
     private var config = Config.makeDefault()
     private var warnings: [String] = []
@@ -77,8 +114,15 @@ final class Coordinator: WindowTrackerDelegate {
         // Same reasoning, same shape: the reveal-desktop preference is the window server's, not
         // toe's, so a copy that was killed rather than quit may have left it switched off.
         WallpaperClick.repairAfterUncleanExit()
+        // Not the same thing as those two — the desktop picture is not given back on the way out
+        // — but the note of what was there before toe touched it is read at the same point, so a
+        // theme picked in a run that was killed is still reversible in this one. See `Wallpaper`.
+        wallpaper.repairAfterUncleanExit()
         writeDefaultConfigIfMissing()
-        loadConfig()
+        loadConfig(force: true)
+
+        // Starting and finishing both change what the menu bar should say.
+        available.onChange = { [weak self] in self?.refreshStatus() }
 
         watcher = ConfigWatcher(url: Coordinator.configURL)
         watcher?.onChange = { [weak self] in self?.loadConfig() }
@@ -240,18 +284,35 @@ final class Coordinator: WindowTrackerDelegate {
         return nil
     }
 
-    private func loadConfig() {
+    /// - Parameter force: reload even when the file has not changed. The watcher fires two or
+    ///   three times for a single save — once for the directory write, once for the rename — and
+    ///   a theme pick reloads directly as well as being seen by the watcher a beat later. A reload
+    ///   is not free: it clears `desired` and re-writes every window's frame over Accessibility.
+    ///   So the same bytes twice running are ignored, except when something asked for a reload on
+    ///   purpose: `SUPER`+`SHIFT`+`R`, startup, and a palette edit, where `toe.toml` itself has
+    ///   not changed at all.
+    private func loadConfig(force: Bool = false) {
         let text = (try? String(contentsOf: Coordinator.configURL, encoding: .utf8)) ?? Config.defaultTOML
+        guard force || text != loadedText else {
+            // The bytes are the same, so there is nothing to re-apply — but the watches still
+            // have to be re-checked, because *making* `~/.config/toe/themes` is a write to
+            // `~/.config/toe` and changes not one byte of `toe.toml`. Returning above this line
+            // is what left the themes watch unarmed until the next real config edit.
+            applyThemeWatch()
+            return
+        }
         let newConfig: Config
         do {
             newConfig = try Config.parse(text)
         } catch {
             // Keep running on the last good config — a typo must never cost you your keyboard.
             warnings = ["\(Coordinator.configURL.lastPathComponent) \(error)"]
+            loadedText = nil          // so that saving a fix always reloads, unchanged or not
             refreshStatus()
             Log.error("config error, keeping the previous config: \(error)")
             return
         }
+        loadedText = text
 
         config = newConfig
         warnings = newConfig.warnings
@@ -259,25 +320,297 @@ final class Coordinator: WindowTrackerDelegate {
             warnings.append(warning)
         }
 
-        let rejected = hotkeys.register(newConfig.bindings)
+        // The theme is resolved between parsing and the fan-out below, because resolving a name
+        // needs the disk and `Config.parse` is pure text. Everything after this point therefore
+        // reads `config` and not `newConfig` — `newConfig` is the file as written, `config` is
+        // the file with its theme applied, and they differ in exactly the colours. Do not tidy
+        // these back to `newConfig`.
+        applyTheme(to: newConfig)
+        applyThemeWatch()
+
+        let rejected = hotkeys.register(config.bindings)
         warnings += rejected.map { "\($0.source): already claimed by another app" }
 
-        workspaces.options = newConfig.dwindle
-        workspaces.gaps = newConfig.gaps
-        workspaces.floatingSize = newConfig.floating
-        tracker.floatRules = newConfig.floatRules
-        border.apply(newConfig.border)
-        status.persistentWorkspaces = newConfig.bar.persistentWorkspaces
+        workspaces.options = config.dwindle
+        workspaces.gaps = config.gaps
+        workspaces.floatingSize = config.floating
+        tracker.floatRules = config.floatRules
+        border.apply(config.border)
+        status.persistentWorkspaces = config.bar.persistentWorkspaces
         applyDockSwipeSetting()
         applyMiscSettings()
         applySessionSetting()
 
         refreshStatus()
-        Log.info("config loaded: \(newConfig.bindings.count) binding(s), \(warnings.count) warning(s)")
+        Log.info("config loaded: \(config.bindings.count) binding(s), \(warnings.count) warning(s)")
         for warning in warnings { Log.error("config: \(warning)") }
         desired.removeAll()
         corrections.removeAll()          // gaps may have changed; re-write every frame
         apply(refocus: false)
+    }
+
+    // MARK: - Themes
+
+    /// Turns `[theme] name` into colours.
+    ///
+    /// The list is rebuilt here as well as at menu-open time, because it is what the unknown-name
+    /// warning lists as the alternatives, and because a theme directory that appeared since the
+    /// last reload should be resolvable now rather than after another one.
+    private func applyTheme(to parsed: Config) {
+        themes = ThemeStore.installed()
+
+        let wanted = Slug.make(parsed.theme.name)
+        if wanted.isEmpty {
+            // Un-choosing the theme is the moment the picture is actually withdrawn, so it is the
+            // moment it goes back — not on quit. `Wallpaper` says why at length.
+            //
+            // Asked of the disk rather than of `backgrounds`/`currentBackground`, which are both
+            // empty on the first load of every run: pick a theme, quit, clear the name by hand,
+            // start again, and an in-memory test would find nothing to give back and leave the
+            // old theme's picture up for good. The memo on disk is what survives the restart.
+            if BackgroundStore.load() != nil { wallpaper.restore() }
+            backgrounds = []
+            currentBackground = nil
+            pictureFrom = nil
+            BackgroundStore.clear()
+            return
+        }
+
+        switch ThemeStore.theme(named: wanted) {
+        case .success(let theme):
+            config = parsed.applying(theme)
+        case .failure(let error):
+            // The name the *file* spelled goes in the warning, so the tooltip quotes the user's
+            // own words back at them — but it must not survive in `config`, because
+            // `config.theme.name` is joined onto a path in three places below and `Slug.make`
+            // guarantees a safe path component only for the value it returns, not for the raw
+            // text it was given. `name = "../evil"` slugs to `evil`, fails to resolve, and would
+            // otherwise leave the raw `../evil` to be walked out of the themes directory.
+            // What to suggest depends on what there is. "try " followed by nothing is what this
+            // said on a machine with no themes installed — which is every machine that has not
+            // downloaded one yet, and so exactly the machine most in need of being told where to
+            // go. A name that is merely not downloaded yet gets told that specifically, because
+            // it is a different problem from a name that is wrong.
+            let advice: String
+            if available.themes.contains(where: { $0.slug == wanted }) {
+                advice = "Style › Theme can fetch it"
+            } else if !themes.isEmpty {
+                advice = "try " + themes.map(\.slug).joined(separator: ", ")
+            } else {
+                advice = "Style › Theme is where you get one"
+            }
+            warnings.append("theme.name: \(error) — \(advice)")
+            config.theme.name = ""
+            backgrounds = []
+            currentBackground = nil
+            pictureFrom = nil
+            wallpaper.forget()
+            return
+        }
+
+        // `applying` put the *resolved* slug here, so every path built from it below is a
+        // single safe component by construction.
+        backgrounds = ThemeStore.backgrounds(named: config.theme.name)
+        // A remembered name that is no longer in the folder reads as nothing current, which
+        // `Backgrounds.next` turns into starting from the first.
+        currentBackground = BackgroundStore.load().flatMap { backgrounds.contains($0) ? $0 : nil }
+
+        // Changing theme puts up one of the new theme's pictures, as `omarchy-theme-set` does by
+        // calling `omarchy-theme-bg-next` on its way out — a theme that came with backgrounds and
+        // left the old one on screen would be half-applied.
+        //
+        // Only when the theme actually changed, though. This runs on every reload, and re-setting
+        // the picture each time would fight anyone who had cycled to another one, and would put
+        // the wallpaper back every time you saved an unrelated line of your config.
+        //
+        // The one you had is preferred over the first, so a picture you cycled to survives a
+        // restart; setting it again is what primes `Wallpaper` to catch up a Space or a display
+        // that has not seen it, and costs nothing when it is already up — `reapply` reads back
+        // before it writes.
+        let changed = pictureFrom != config.theme.name
+        pictureFrom = config.theme.name
+        guard changed else { return }
+        guard let picture = currentBackground ?? backgrounds.first else {
+            // The new theme brings no pictures, so toe stops having an opinion about the
+            // wallpaper rather than going on catching Spaces up with the last theme's.
+            wallpaper.forget()
+            return
+        }
+        setBackground(picture)
+    }
+
+    /// Arms the two theme watches, and re-points the palette one when the theme changes.
+    ///
+    /// Re-checked on every reload rather than only at startup, because creating
+    /// `~/.config/toe/themes` is itself a write to `~/.config/toe`, which the config watcher
+    /// already sees — so making the folder is enough to arm this without restarting toe.
+    ///
+    /// Both call `loadConfig(force:)`: neither a palette edit nor a theme folder appearing
+    /// changes a byte of `toe.toml`, so the unchanged-bytes early-out would otherwise swallow
+    /// them both.
+    private func applyThemeWatch() {
+        themeWatcher = watch(ThemeStore.directory, existing: themeWatcher)
+
+        // The current theme only. Its palette is the one whose edits can change what is on
+        // screen; the rest are edits to colours nothing is drawing with.
+        // Re-pointed when the theme changes, and also when a theme that had no palette file of
+        // its own grows one, which is why a nil watcher is retried rather than remembered as
+        // absent.
+        let wanted = config.theme.name.isEmpty ? nil : config.theme.name
+        if wanted != watchedPalette {
+            paletteWatcher?.stop()
+            paletteWatcher = nil
+            watchedPalette = wanted
+        }
+        guard let wanted else { return }
+        // The palette *file*, with its directory watched alongside it — the same shape as the
+        // watch on `toe.toml`, and for the same two reasons. A kqueue on a directory reports an
+        // entry being added, removed or renamed, so an editor that saves in place by truncating
+        // `colors.toml` would never be seen by a watch on the folder; and an editor that saves
+        // atomically by renaming a temporary file over it kills a watch bound only to the
+        // original descriptor, which is what the parent watch is for.
+        paletteWatcher = watch(ThemeStore.directory.appendingPathComponent(wanted)
+                                 .appendingPathComponent("colors.toml"),
+                               isDirectory: false, existing: paletteWatcher)
+    }
+
+    /// A watch that is started when its target is there and dropped when it is not.
+    private func watch(_ url: URL, isDirectory wantsDirectory: Bool = true,
+                       existing: ConfigWatcher?) -> ConfigWatcher? {
+        var isDirectory: ObjCBool = false
+        let exists = FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
+        guard exists, isDirectory.boolValue == wantsDirectory else {
+            existing?.stop()
+            return nil
+        }
+        if let existing { return existing }
+        let watcher = ConfigWatcher(url: url, watchesParent: !wantsDirectory,
+                                    events: [.write, .extend, .delete, .rename])
+        watcher.onChange = { [weak self] in self?.loadConfig(force: true) }
+        watcher.start()
+        return watcher
+    }
+
+    /// What the Style level of the menu is looking at, read fresh every time it opens.
+    ///
+    /// This is also the only place toe ever reaches the network, and it does not wait for it: the
+    /// level draws from the catalogue already on disk, the request runs behind it, and what it
+    /// finds is there the next time you look. `refreshIfStale` does nothing unless the list is
+    /// missing or a day old.
+    private func styleMenu() -> StyleMenu {
+        available.refreshIfStale()
+        let (installed, offer) = Themes.merged(installed: ThemeStore.installed(),
+                                               available: available.themes)
+        themes = installed
+        let current = config.theme.name.isEmpty ? nil : config.theme.name
+        if let current { backgrounds = ThemeStore.backgrounds(named: current) }
+        return StyleMenu(themes: installed, available: offer,
+                         fetching: available.isFetching,
+                         current: current,
+                         backgrounds: backgrounds, currentBackground: currentBackground)
+    }
+
+    /// Writes the theme into your config rather than holding it in memory, so it survives a
+    /// restart and turns up in the file you version — and so that picking one here and editing
+    /// the line by hand are the same act, producing the same reload.
+    private func setTheme(_ slug: String) {
+        // A theme you have not got is fetched first and set when it arrives, so choosing one from
+        // the list does the same thing whether or not it happens to be on this machine already.
+        // That is the only way one list of themes makes sense rather than two.
+        if !slug.isEmpty, !themes.contains(where: { $0.slug == slug }),
+           let remote = available.themes.first(where: { $0.slug == slug }) {
+            return download(remote)
+        }
+        guard slug.isEmpty || themes.contains(where: { $0.slug == slug }) else {
+            // Refused rather than written: putting a name that resolves to nothing into somebody
+            // else's file, on their behalf, is worse than a log line they can go and read.
+            Log.error("theme: there is no theme called '\(slug)'")
+            return
+        }
+        guard let text = try? String(contentsOf: Coordinator.configURL, encoding: .utf8) else {
+            Log.error("theme: \(Coordinator.configURL.lastPathComponent) could not be read")
+            return
+        }
+        let proposed = ThemeWriter.settingTheme(slug, in: text)
+        guard proposed != text else { return }
+
+        // The writer works a line at a time and cannot see everything a parser can — `["theme"]`
+        // is the same table as `[theme]`, and a header inside a string is not a header at all. So
+        // its own output is parsed back before it is committed, which turns every case it gets
+        // wrong from a config that will not load into a config that was left alone.
+        guard let check = try? Config.parse(proposed), Slug.make(check.theme.name) == slug else {
+            Log.error("theme: declined to edit \(Coordinator.configURL.lastPathComponent) — "
+                      + "the result would not have said what it was asked to say")
+            return
+        }
+        guard ConfigFile.write(proposed, to: Coordinator.configURL) else { return }
+        // Immediately, so the screen changes now; the watcher's echo 150 ms later sees the same
+        // bytes and early-outs.
+        loadConfig(force: true)
+    }
+
+    /// Fetches a theme, then sets it — the menu having already closed, as it does for any row.
+    ///
+    /// The progress goes to the menu bar item's tooltip, which is the only surface toe has for
+    /// saying something while nothing is on screen. Nine megabytes over a slow connection is long
+    /// enough that silence would read as nothing having happened.
+    private func download(_ theme: RemoteTheme) {
+        guard progress == nil else {
+            Log.error("themes: already fetching something")
+            return
+        }
+        progress = (bar: theme.name, note: "Fetching \(theme.name)…")
+        refreshStatus()
+
+        ThemeDownloader.fetch(theme, into: ThemeStore.directory,
+                              progress: { [weak self] step in
+                                  self?.progress = Coordinator.describe(step)
+                                  self?.refreshStatus()
+                              },
+                              completion: { [weak self] result in
+            guard let self else { return }
+            self.progress = nil
+            switch result {
+            case .success:
+                Log.info("themes: fetched \(theme.slug)")
+                // Into `setTheme` rather than straight into the config: the download is a step on
+                // the way to the same act, so it ends up in the same place, with the same write
+                // and the same reload.
+                self.themes = ThemeStore.installed()
+                self.setTheme(theme.slug)
+            case .failure(let why):
+                self.runtimeWarnings.append("\(theme.name) could not be fetched: \(why)")
+                Log.error("themes: \(theme.slug): \(why)")
+                self.refreshStatus()
+            }
+        })
+    }
+
+    /// A download step as the two surfaces want it.
+    ///
+    /// The fraction is left off while the palette is being fetched — one small file, before there
+    /// is a count worth showing — so the bar reads `⟳ Gruvbox` for a moment and then starts
+    /// counting. A theme with no pictures never gets a fraction at all, which is right: there is
+    /// nothing to count.
+    private static func describe(_ step: ThemeDownloader.Progress)
+    -> (bar: String, note: String) {
+        guard step.total > 0, step.done > 0 else {
+            return (bar: step.theme, note: "Fetching \(step.theme)…")
+        }
+        return (bar: "\(step.theme) \(step.done)/\(step.total)",
+                note: "Fetching \(step.theme) — picture \(step.done) of \(step.total)…")
+    }
+
+    private func setBackground(_ file: String) {
+        // Only ever a name out of the enumerated list, so a string from a config file cannot be
+        // joined onto a directory as a path of its own.
+        guard backgrounds.contains(file), !config.theme.name.isEmpty else {
+            Log.error("background: '\(file)' is not one of the current theme's")
+            return
+        }
+        wallpaper.set(ThemeStore.background(named: file, in: config.theme.name))
+        currentBackground = file
+        BackgroundStore.save(file)
     }
 
     /// Starts and stops the dock swipe tap as the config flips, on every reload as well as at
@@ -346,9 +679,18 @@ final class Coordinator: WindowTrackerDelegate {
     }
 
     private func refreshStatus() {
+        // `progress` leads, because it is the thing happening now and the other two are things
+        // that have already gone wrong. It is the only line here that goes away by itself.
+        // A download wins the strip if both are happening: it is the long one, and the one you
+        // asked for. The catalogue is kept out of `progress` itself because that doubles as the
+        // one-download-at-a-time latch, and a list refresh must not hold it.
+        let showing = progress ?? (available.isFetching
+                                   ? (bar: "themes", note: "Fetching Omarchy's themes…")
+                                   : nil)
         status.update(workspaces: workspaceStates(),
-                      warnings: warnings + runtimeWarnings,
-                      accessibilityGranted: AXIsProcessTrusted())
+                      warnings: [showing?.note].compactMap { $0 } + warnings + runtimeWarnings,
+                      accessibilityGranted: AXIsProcessTrusted(),
+                      progress: showing?.bar)
     }
 
     /// What the strip in the menu bar title draws. This runs on every focus change and every
@@ -478,6 +820,10 @@ final class Coordinator: WindowTrackerDelegate {
         desired.removeAll()
         corrections.removeAll()
         apply(refocus: false)
+        // After the layout, never before: a display appearing is a moment the windows have to be
+        // put somewhere, and the desktop picture is cosmetic. `reapply` is a no-op unless a
+        // screen is actually showing something else.
+        wallpaper.reapply()
     }
 
     /// Nothing about the layout has changed — only what is stacked over the focused window,
@@ -496,6 +842,11 @@ final class Coordinator: WindowTrackerDelegate {
     /// because the window now in front may be a fullscreen one it must not draw over.
     func activeSpaceChanged() {
         updateBorder()
+        // With *Displays have separate Spaces* on — the macOS default — a desktop picture is set
+        // per Space and not per screen, so a Space that has not been visited since the theme
+        // changed is still showing the old one. `reapply` checks before it writes, which is what
+        // makes this affordable on a callback that fires every time you change Space.
+        wallpaper.reapply()
     }
 
     // MARK: - Applying the layout
@@ -862,15 +1213,34 @@ final class Coordinator: WindowTrackerDelegate {
             try? process.run()
 
         case .reload:
-            loadConfig()
+            // Forced: this key is pressed precisely when something needs to happen — most often
+            // to re-tile a window an app has pushed out of place — and `toe.toml` will not have
+            // changed, so the unchanged-bytes early-out would make it do nothing at all.
+            loadConfig(force: true)
 
         case .menu(let page):
+            // `styleMenu()` re-reads the themes directory here rather than relying on the last
+            // reload, which is what makes a theme folder you created a moment ago appear the
+            // first time you look. It is a directory listing; nothing is opened.
             quickMenu.toggle(page: page, config: config,
-                             usable: workspaces.monitor(id: workspaces.focusedMonitorID)?.usable)
+                             usable: workspaces.monitor(id: workspaces.focusedMonitorID)?.usable,
+                             style: styleMenu())
 
         case .quit:
             shutDown()
             NSApp.terminate(nil)
+
+        case .theme(let slug):
+            setTheme(slug)
+
+        case .background(let file):
+            setBackground(file)
+
+        case .nextBackground:
+            guard let next = Backgrounds.next(after: currentBackground, in: backgrounds) else {
+                return
+            }
+            setBackground(next)
         }
     }
 }

--- a/Sources/toe/ThemeCatalogue.swift
+++ b/Sources/toe/ThemeCatalogue.swift
@@ -1,0 +1,131 @@
+import Foundation
+import ToeCore
+
+/// Where toe fetches themes from, and the only host it ever talks to.
+///
+/// Named in one place so there is one answer to "what does this thing contact". toe makes no
+/// other network request of any kind: no telemetry, no update check, nothing at launch. The
+/// catalogue is fetched when you open `Style › Theme` and at most once a day, and a theme is
+/// downloaded only when you choose it.
+enum Upstream {
+    /// The numeric id rather than `basecamp/omarchy`, because the repository has been renamed
+    /// once already and an id does not move.
+    static let repository = "994093166"
+    static let branch = "master"
+
+    static var tree: URL {
+        URL(string: "https://api.github.com/repositories/\(repository)/git/trees/\(branch)?recursive=1")!
+    }
+
+    static func file(theme slug: String, _ path: String) -> URL {
+        URL(string: "https://raw.githubusercontent.com/basecamp/omarchy/\(branch)/themes/\(slug)/\(path)")!
+    }
+
+    /// Every host toe is allowed to end up talking to. Checked after redirects rather than
+    /// before, because the check that matters is where the bytes actually came from.
+    static let allowedHosts: Set<String> = ["api.github.com", "raw.githubusercontent.com",
+                                            "codeload.github.com", "objects.githubusercontent.com"]
+}
+
+/// The list of themes Omarchy publishes, fetched and remembered.
+///
+/// Cached next to the session, and read from there on the way up, so the list survives a restart
+/// and works offline once it has been fetched once. A refresh never blocks anything: the menu
+/// opens on the cache it already has, the request runs behind it, and what it finds is there the
+/// next time you look.
+final class ThemeCatalogue {
+
+    static let url = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".local/state/toe/catalogue.json")
+
+    /// A day. The list changes when Omarchy adds a theme, which is not often, and the cost of
+    /// being a day behind is one theme you cannot see yet.
+    static let maxAge: TimeInterval = 24 * 60 * 60
+    /// The tree of a repository this size is about 400 KB. Ten is not a limit anyone will meet;
+    /// it is there so a redirect to something enormous cannot be read into memory.
+    private static let sizeLimit = 10 << 20
+
+    private(set) var catalogue: Catalogue?
+    private(set) var isFetching = false
+    /// Set when a fetch failed, so the next look tries again rather than waiting out the day.
+    private var lastFailed = false
+
+    /// Called on the main queue when the list changes.
+    var onChange: (() -> Void)?
+
+    init() {
+        catalogue = Self.load()
+    }
+
+    var themes: [RemoteTheme] { catalogue?.themes ?? [] }
+
+    /// Fetches the list if it is missing or a day old. Cheap and safe to call on every menu open.
+    func refreshIfStale() {
+        guard !isFetching else { return }
+        if let catalogue, !catalogue.isStale(maxAge: Self.maxAge), !lastFailed { return }
+        isFetching = true
+        onChange?()
+
+        var request = URLRequest(url: Upstream.tree)
+        request.timeoutInterval = 15
+        // GitHub refuses an unidentified client on some paths and rate-limits by IP; saying who
+        // this is costs nothing and makes the request explicable at the far end.
+        request.setValue("toe (macOS window manager)", forHTTPHeaderField: "User-Agent")
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+
+        URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.isFetching = false
+                defer { self.onChange?() }
+
+                if let error {
+                    self.lastFailed = true
+                    Log.error("themes: could not fetch the list: \(error.localizedDescription)")
+                    return
+                }
+                guard let http = response as? HTTPURLResponse, http.statusCode == 200,
+                      let host = response?.url?.host, Upstream.allowedHosts.contains(host),
+                      let data, data.count <= Self.sizeLimit
+                else {
+                    self.lastFailed = true
+                    let code = (response as? HTTPURLResponse)?.statusCode ?? 0
+                    Log.error("themes: could not fetch the list (HTTP \(code))")
+                    return
+                }
+                do {
+                    let fresh = try Catalogue.parse(data)
+                    self.catalogue = fresh
+                    self.lastFailed = false
+                    Self.save(fresh)
+                    Log.info("themes: \(fresh.themes.count) available from Omarchy")
+                } catch {
+                    self.lastFailed = true
+                    Log.error("themes: \(error)")
+                }
+            }
+        }.resume()
+    }
+
+    // MARK: - The cache
+
+    private static func load() -> Catalogue? {
+        guard let data = try? Data(contentsOf: url), data.count <= sizeLimit else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let catalogue = try? decoder.decode(Catalogue.self, from: data),
+              catalogue.version == Catalogue.currentVersion
+        else { return nil }
+        return catalogue
+    }
+
+    private static func save(_ catalogue: Catalogue) {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        guard let data = try? encoder.encode(catalogue) else { return }
+        try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                                 withIntermediateDirectories: true)
+        try? data.write(to: url, options: .atomic)
+    }
+}

--- a/Sources/toe/ThemeDownloader.swift
+++ b/Sources/toe/ThemeDownloader.swift
@@ -1,0 +1,187 @@
+import Foundation
+import ToeCore
+
+/// Fetches one theme from Omarchy into `~/.config/toe/themes/<name>/`.
+///
+/// Everything here is written on the assumption that the bytes are hostile, because they came off
+/// the network and they are being written next to a config file that runs shell commands. Three
+/// rules do the work, and all three are whitelists rather than checks for bad input:
+///
+///  - the directory is `Slug.make`'s output, so it is one path component and cannot be anything
+///    else;
+///  - every file name comes from the catalogue and has been through `Catalogue.isSafeFileName`
+///    *and* the image-extension filter, and is joined onto the folder rather than trusted as a
+///    path;
+///  - the palette is parsed before anything is moved into place, so a theme that would not have
+///    loaded never becomes a theme you have.
+///
+/// It assembles into a temporary directory and moves the finished thing into place, so a download
+/// that fails halfway leaves nothing behind — the failure mode being avoided is a half-theme that
+/// looks installed and is missing the picture the cycle is pointing at.
+enum ThemeDownloader {
+
+    /// No single background in Omarchy is past 4 MB. This is not a policy about how big a
+    /// wallpaper may be; it is a ceiling so a redirect to something enormous cannot fill a disk.
+    private static let fileLimit = 64 << 20
+    private static let paletteLimit = 64 << 10
+    private static let timeout: TimeInterval = 60
+
+    enum Failure: Error, CustomStringConvertible {
+        case network(String)
+        case badPalette(String)
+        case couldNotWrite(String)
+
+        var description: String {
+            switch self {
+            case .network(let what):      return what
+            case .badPalette(let why):    return "its colours would not parse — \(why)"
+            case .couldNotWrite(let why): return why
+            }
+        }
+    }
+
+    /// How far along a download is.
+    ///
+    /// A name and two numbers rather than a sentence, because two surfaces show this and they
+    /// want different lengths: the menu bar has room for `Gruvbox 3/6` and the tooltip behind it
+    /// has room to say it properly. Building the sentence here would have forced both to use it.
+    struct Progress {
+        let theme: String
+        /// Files finished. Zero while the palette is being fetched — the step that has no
+        /// meaningful fraction, being one small file before the count is even known to matter.
+        let done: Int
+        let total: Int
+    }
+
+    /// Downloads `theme` and calls back on the main queue with where it landed.
+    static func fetch(_ theme: RemoteTheme,
+                      into directory: URL,
+                      progress: @escaping (Progress) -> Void,
+                      completion: @escaping (Result<Void, Failure>) -> Void) {
+        let slug = Slug.make(theme.slug)
+        guard slug == theme.slug, !slug.isEmpty else {
+            return completion(.failure(.couldNotWrite("'\(theme.slug)' is not a theme name")))
+        }
+
+        DispatchQueue.global(qos: .utility).async {
+            let result = fetchSynchronously(theme, slug: slug, into: directory, progress: progress)
+            DispatchQueue.main.async { completion(result) }
+        }
+    }
+
+    private static func fetchSynchronously(_ theme: RemoteTheme, slug: String, into directory: URL,
+                                           progress: @escaping (Progress) -> Void)
+    -> Result<Void, Failure> {
+        let staging = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("toe-theme-\(slug)-\(UUID().uuidString)")
+        let pictures = staging.appendingPathComponent("backgrounds")
+        defer { try? FileManager.default.removeItem(at: staging) }
+
+        do {
+            try FileManager.default.createDirectory(at: pictures, withIntermediateDirectories: true,
+                                                    attributes: [.posixPermissions: 0o700])
+        } catch {
+            return .failure(.couldNotWrite(error.localizedDescription))
+        }
+
+        // The palette first: if it will not parse there is no point fetching nine megabytes of
+        // photographs to go with it.
+        let total = theme.backgrounds.count
+        DispatchQueue.main.async {
+            progress(Progress(theme: theme.name, done: 0, total: total))
+        }
+        let paletteData: Data
+        switch get(Upstream.file(theme: slug, "colors.toml"), limit: paletteLimit) {
+        case .success(let data): paletteData = data
+        case .failure(let why):  return .failure(why)
+        }
+        guard let text = String(data: paletteData, encoding: .utf8) else {
+            return .failure(.badPalette("it is not text"))
+        }
+        do {
+            _ = try Palette.parse(text)
+        } catch {
+            return .failure(.badPalette("\(error)"))
+        }
+        do {
+            try paletteData.write(to: staging.appendingPathComponent("colors.toml"))
+        } catch {
+            return .failure(.couldNotWrite(error.localizedDescription))
+        }
+
+        for (index, picture) in theme.backgrounds.enumerated() {
+            // Checked again here rather than trusted from the catalogue. The catalogue is a cache
+            // — it is a file on disk that something else could have written — and this is the
+            // moment a name becomes a path.
+            guard Catalogue.isSafeFileName(picture.name),
+                  !Backgrounds.isUpstreamBranding(picture.name),
+                  Backgrounds.list([picture.name]).count == 1 else { continue }
+
+            // `index + 1`, and reported before the fetch rather than after: the number names the
+            // picture being fetched, so it reads as "picture 1 of 2" while that is what is
+            // happening, and ends on 2 of 2 rather than stopping at 1.
+            DispatchQueue.main.async {
+                progress(Progress(theme: theme.name, done: index + 1, total: total))
+            }
+            switch get(Upstream.file(theme: slug, "backgrounds/\(picture.name)"), limit: fileLimit) {
+            case .success(let data):
+                // `appendingPathComponent` on a name that has been through both filters above:
+                // no separator, no leading dot, a known image extension.
+                try? data.write(to: pictures.appendingPathComponent(picture.name))
+            case .failure(let why):
+                // One missing picture is not worth losing the theme over — the palette is the
+                // part that changes what you see.
+                Log.error("themes: \(theme.slug)/\(picture.name): \(why)")
+            }
+        }
+
+        // Into place in one move, so a theme is either there whole or not there.
+        let destination = directory.appendingPathComponent(slug)
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true,
+                                                    attributes: [.posixPermissions: 0o700])
+            if FileManager.default.fileExists(atPath: destination.path) {
+                // Re-downloading an existing theme replaces it. Anything you put in its
+                // backgrounds folder yourself goes with it, which is why the menu only offers
+                // this for themes you do not already have.
+                try FileManager.default.removeItem(at: destination)
+            }
+            try FileManager.default.moveItem(at: staging, to: destination)
+        } catch {
+            return .failure(.couldNotWrite(error.localizedDescription))
+        }
+        return .success(())
+    }
+
+    /// One synchronous GET, on a queue where blocking is the point.
+    private static func get(_ url: URL, limit: Int) -> Result<Data, Failure> {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = timeout
+        request.setValue("toe (macOS window manager)", forHTTPHeaderField: "User-Agent")
+
+        let semaphore = DispatchSemaphore(value: 0)
+        var outcome: Result<Data, Failure> = .failure(.network("no answer"))
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            defer { semaphore.signal() }
+            if let error { return outcome = .failure(.network(error.localizedDescription)) }
+            guard let http = response as? HTTPURLResponse else {
+                return outcome = .failure(.network("no answer"))
+            }
+            // After redirects, not before: what matters is where the bytes came from.
+            guard let host = response?.url?.host, Upstream.allowedHosts.contains(host) else {
+                return outcome = .failure(.network("redirected off github.com"))
+            }
+            guard http.statusCode == 200 else {
+                return outcome = .failure(.network("HTTP \(http.statusCode)"))
+            }
+            guard let data, data.count <= limit else {
+                return outcome = .failure(.network("the answer was too large"))
+            }
+            outcome = .success(data)
+        }.resume()
+
+        _ = semaphore.wait(timeout: .now() + timeout + 5)
+        return outcome
+    }
+}

--- a/Sources/toe/ThemeStore.swift
+++ b/Sources/toe/ThemeStore.swift
@@ -1,0 +1,107 @@
+import Foundation
+import ToeCore
+
+/// Reads `~/.config/toe/themes` — the themes you have added, and the pictures the one in effect
+/// carries.
+///
+/// The disk half of the split ToeCore keeps everywhere else: `Theme` and `Palette` are the shapes
+/// and the parsing, this is the directory walking, exactly as `Session` is to `SessionStore`.
+///
+/// A theme is a folder and nothing has to be registered: `<name>/colors.toml` in Omarchy's own
+/// format, optionally `<name>/backgrounds/`. That is deliberately the same shape as an Omarchy
+/// theme directory, so one can be copied across whole — and it is the shape `ThemeDownloader`
+/// writes into, so a theme toe fetched and a theme you copied in are the same thing afterwards,
+/// with nothing to tell them apart and nothing that treats them differently.
+enum ThemeStore {
+
+    static let directory = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".config/toe/themes")
+
+    /// Twenty-two hex strings is a few hundred bytes. Anything past this is not a palette, and
+    /// it is read before it is trusted — `SessionStore.sizeLimit`'s reasoning, one file over.
+    private static let sizeLimit = 64 << 10
+
+    /// What is there, by name only.
+    ///
+    /// Opens nothing. This is called every time the quick menu opens — which is what makes a
+    /// folder you created a second ago appear without a reload — and someone who has copied an
+    /// Omarchy theme collection across has ninety of them. Reading and parsing ninety
+    /// `colors.toml` files to draw a list is the version of this that does not ship; only the
+    /// theme actually in effect is ever read, by `theme(named:)` below.
+    static func installed() -> [ThemeRef] {
+        let names = (try? FileManager.default.contentsOfDirectory(
+            at: directory, includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles])) ?? []
+
+        return names.compactMap { url in
+            guard (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+            else { return nil }
+            // Through the slug rather than taken as read: this name came off a filesystem, and
+            // everything downstream — the config line it is written into, the path it is joined
+            // back onto — expects a slug. A directory whose name is not one is not a theme.
+            let slug = Slug.make(url.lastPathComponent)
+            guard slug == url.lastPathComponent else { return nil }
+            return ThemeRef(slug: slug, name: Slug.title(slug))
+        }
+    }
+
+    /// The one theme that is actually in effect, read now.
+    ///
+    /// A broken `colors.toml` is discovered when you *choose* that theme rather than when you
+    /// merely have it, which is the better direction: you hear about the theme you picked, not
+    /// about the eighteen you did not.
+    static func theme(named slug: String) -> Result<Theme, Error> {
+        let file = directory.appendingPathComponent(slug).appendingPathComponent("colors.toml")
+        // Read, not mapped. `SessionStore` maps `session.json` because it can run to a megabyte;
+        // a palette is twenty-two hex strings. And mapping this one is actively wrong: the file
+        // is watched, `loadConfig` reads it with the watch already armed, and the mapping trips
+        // NOTE_ATTRIB on the vnode — so the read re-fires the watch that caused it and toe reloads
+        // its config six times a second for as long as a theme is set. `toe.toml` escapes the same
+        // trap only by being read with a plain `String(contentsOf:)`.
+        if let data = try? Data(contentsOf: file) {
+            guard data.count <= sizeLimit else {
+                return .failure(ThemeStoreError.tooLarge(slug))
+            }
+            guard let text = String(data: data, encoding: .utf8) else {
+                return .failure(ThemeStoreError.notText(slug))
+            }
+            do {
+                return .success(Theme(slug: slug, name: Slug.title(slug),
+                                      palette: try Palette.parse(text)))
+            } catch {
+                return .failure(error)
+            }
+        }
+        return .failure(ThemeStoreError.noSuchTheme(slug))
+    }
+
+    /// `<name>/backgrounds`, in cycle order.
+    ///
+    /// Whatever is in the folder, whether it arrived by download or because you put it there.
+    static func backgrounds(named slug: String) -> [String] {
+        guard !slug.isEmpty else { return [] }
+        let folder = directory.appendingPathComponent(slug).appendingPathComponent("backgrounds")
+        let names = (try? FileManager.default.contentsOfDirectory(atPath: folder.path)) ?? []
+        return Backgrounds.list(names)
+    }
+
+    static func background(named file: String, in slug: String) -> URL {
+        directory.appendingPathComponent(slug)
+            .appendingPathComponent("backgrounds")
+            .appendingPathComponent(file)
+    }
+}
+
+enum ThemeStoreError: Error, CustomStringConvertible {
+    case noSuchTheme(String)
+    case tooLarge(String)
+    case notText(String)
+
+    var description: String {
+        switch self {
+        case .noSuchTheme(let slug): return "there is no theme called '\(slug)'"
+        case .tooLarge(let slug):    return "\(slug)/colors.toml is too large to be a palette"
+        case .notText(let slug):     return "\(slug)/colors.toml is not UTF-8 text"
+        }
+    }
+}

--- a/Sources/toe/UI/MenuFont.swift
+++ b/Sources/toe/UI/MenuFont.swift
@@ -17,8 +17,8 @@ import ToeCore
 enum MenuFont {
 
     private static let familyName = "JetBrainsMono Nerd Font"
-    /// `nf-fa-gear`. Any patch level that has the Font Awesome block has all six below, so one
-    /// probe answers for the set.
+    /// `nf-fa-gear`. Any patch level that has the Font Awesome block has every glyph below, so
+    /// one probe answers for the set.
     private static let probe: Unicode.Scalar = "\u{F013}"
 
     /// nil once resolution has run and found nothing — see `family(size:)`.
@@ -103,6 +103,9 @@ enum MenuFont {
         case .power:     return "\u{F011}"   // nf-fa-power_off
         case .toggleOn:  return "\u{F205}"   // nf-fa-toggle_on
         case .toggleOff: return "\u{F204}"   // nf-fa-toggle_off
+        case .paintbrush: return "\u{F1FC}"  // nf-fa-paint_brush
+        case .droplet:   return "\u{F043}"   // nf-fa-tint
+        case .image:     return "\u{F03E}"   // nf-fa-picture_o
         }
     }
 
@@ -117,6 +120,9 @@ enum MenuFont {
         case .power:     return "power"
         case .toggleOn:  return "switch.2"
         case .toggleOff: return "switch.2"
+        case .paintbrush: return "paintbrush"
+        case .droplet:   return "drop"
+        case .image:     return "photo"
         }
     }
 }

--- a/Sources/toe/UI/QuickMenu.swift
+++ b/Sources/toe/UI/QuickMenu.swift
@@ -35,6 +35,10 @@ final class QuickMenu {
     private var state: MenuState?
     private var page: MenuPage = .root
     private var config = Config()
+    /// Handed in at every open rather than held, for the same reason `LoginItem.state()` is read
+    /// there: the menu is a function of what is true when you look at it, and a theme folder that
+    /// appeared a second ago should be in the list.
+    private var style = StyleMenu()
     private var usable: Box?
     private var metrics = MenuMetrics(lineHeight: 22)
     /// Guards the close path against itself: ordering the panel out resigns key, which is one of
@@ -81,13 +85,14 @@ final class QuickMenu {
 
     /// The hotkey. A second press closes: `RegisterEventHotKey` intercepts ahead of the key
     /// window, so `SUPER`+`SPACE` reaches this rather than typing a space into the filter.
-    func toggle(page: MenuPage, config: Config, usable: Box?) {
+    func toggle(page: MenuPage, config: Config, usable: Box?, style: StyleMenu = StyleMenu()) {
         if isVisible, page == self.page {
             close()
             return
         }
         self.config = config
         self.usable = usable
+        self.style = style
         open(page: page)
     }
 
@@ -106,7 +111,7 @@ final class QuickMenu {
 
         let items = page == .keybindings
             ? MenuModel.keybindings(config.bindings, superKey: config.superKey)
-            : MenuModel.root(loginItem: LoginItem.state(), bindings: config.bindings)
+            : MenuModel.root(loginItem: LoginItem.state(), bindings: config.bindings, style: style)
         state = MenuState(root: items, visibleRows: 10)
 
         frontmostAtOpen = NSWorkspace.shared.frontmostApplication?.processIdentifier

--- a/Sources/toe/UI/StatusItem.swift
+++ b/Sources/toe/UI/StatusItem.swift
@@ -20,6 +20,8 @@ final class StatusItem: NSObject {
     var onOpenMenu: (() -> Void)?
 
     private var accessibilityGranted = false
+    /// What is being fetched, if anything — see `update(workspaces:warnings:…)`.
+    private var progress: String?
 
     /// waybar's `persistent-workspaces` — how many workspaces keep a slot when empty.
     var persistentWorkspaces = WorkspaceStrip.defaultPersistent
@@ -88,9 +90,15 @@ final class StatusItem: NSObject {
     }
 
     /// Cheap: only the title strip is recomputed, from the little the strip reads.
+    ///
+    /// - Parameter progress: what is being fetched, if anything. It goes in the strip rather than
+    ///   only in the tooltip because a tooltip needs you to already suspect something is
+    ///   happening and go looking — and the one moment this matters is a nine-megabyte download
+    ///   running with the menu closed and nothing else on screen to say so.
     func update(workspaces: [WorkspaceStrip.State], warnings: [String],
-                accessibilityGranted: Bool) {
+                accessibilityGranted: Bool, progress: String? = nil) {
         self.accessibilityGranted = accessibilityGranted
+        self.progress = progress
         item.button?.attributedTitle = title(for: workspaces)
 
         // The focused workspace is drawn as a square rather than a digit, so the title on
@@ -133,7 +141,26 @@ final class StatusItem: NSObject {
             stripItems.append(item)
             stripWidths.append(Double(width(of: item)))
         }
+        // After the workspaces, never instead of them: what workspace you are on is the thing
+        // this item exists to tell you, and a download must not take that away for a minute.
+        // No entry goes into `stripItems`, so the click targets are unchanged and clicking the
+        // progress opens the menu like clicking anywhere else on the item.
+        if let progress {
+            strip.append(spacer)
+            strip.append(progressPiece(progress))
+        }
         return strip
+    }
+
+    /// `⟳ Gruvbox 3/6`, in the same dimmed grey an unfocused workspace takes.
+    ///
+    /// Static rather than animated: an animation needs a timer running for as long as the
+    /// download, and the step count already moves often enough to read as alive. The glyph is
+    /// there so a glance finds it without reading the words.
+    private func progressPiece(_ text: String) -> NSAttributedString {
+        NSAttributedString(string: "⟳ " + text, attributes: [
+            .font: font, .foregroundColor: NSColor.secondaryLabelColor,
+        ])
     }
 
     /// A fixed `gap` of empty space, kerned rather than padded so its width is exactly known.

--- a/Sources/toe/UI/Wallpaper.swift
+++ b/Sources/toe/UI/Wallpaper.swift
@@ -1,0 +1,196 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import ToeCore
+
+/// The desktop picture, set from the current theme's `backgrounds/`.
+///
+/// **Why this is journalled but not restored on quit.** `SymbolicHotkeys` and `WallpaperClick`
+/// both hand their setting back in `shutDown()`, because toe *borrows* those: you never asked for
+/// `Ctrl`+`↑` to stop working, toe switched it off to do its job, and it owes it back. A desktop
+/// picture is the other kind — you walked into `Style › Background` and chose it. Putting it back
+/// on the way out would undo a decision, and `make run` restarts toe by `pkill` on every single
+/// dev cycle, so it would flicker back on every build.
+///
+/// So it is journalled the way CLAUDE.md asks — written down *before* the first change, and
+/// replayable after a `kill -9` — and given back when you clear the theme, which is the moment
+/// the choice is actually withdrawn. What outlives the process is remembered; what is given back
+/// is given back when it is un-chosen, not when toe stops running.
+final class Wallpaper {
+
+    private static let journalURL = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".local/state/toe/wallpaper")
+
+    /// What was on each display before toe first touched it, by the same display UUID
+    /// `SessionStore.monitorKey` derives — a `CGDirectDisplayID` is handed out per connection and
+    /// would name the wrong screen after a replug.
+    private var previous: [String: String] = [:]
+    private var didJournal = false
+
+    /// What toe last set, so a new display or a Space that has not seen it yet can be caught up.
+    private var current: URL?
+
+    // MARK: - Setting
+
+    func set(_ url: URL) {
+        journalIfNeeded()
+        current = url
+        apply(url)
+    }
+
+    /// A display appeared, or the Space changed under us.
+    ///
+    /// With *Displays have separate Spaces* on — the macOS default — `setDesktopImageURL(for:)`
+    /// applies to the current Space on that screen and not to the others, so switching Spaces
+    /// otherwise brings the old picture back. This is the same underlying fact as toe's
+    /// workspaces not being macOS Spaces.
+    func reapply() {
+        guard current != nil else { return }
+        // Before the write, not after — a display that has just appeared has a wallpaper of its
+        // own, and this is the only moment it can still be seen.
+        journalIfNeeded()
+        guard let current else { return }
+        apply(current)
+    }
+
+    private func apply(_ url: URL) {
+        for screen in NSScreen.screens {
+            // The read-back is what makes calling this from `screensChanged` and
+            // `activeSpaceChanged` free: setting a desktop picture is a synchronous trip into
+            // another process and costs tens of milliseconds, and both of those fire often.
+            guard NSWorkspace.shared.desktopImageURL(for: screen) != url else { continue }
+            do {
+                // No options, so whatever fill mode the user chose in System Settings survives.
+                try NSWorkspace.shared.setDesktopImageURL(url, for: screen, options: [:])
+            } catch {
+                Log.error("wallpaper: \(url.lastPathComponent): \(error.localizedDescription)")
+            }
+        }
+    }
+
+    // MARK: - Giving it back
+
+    /// Puts back what was there before toe first changed it. Called when the theme is cleared.
+    func restore() {
+        let saved = previous.isEmpty ? Self.readJournal() : previous
+        // Whatever is or is not restorable, toe is no longer choosing a picture: `current` has to
+        // be dropped either way, or the next Space switch would have `reapply` push the very
+        // picture that was just un-chosen onto a Space that never had it.
+        defer {
+            previous.removeAll()
+            current = nil
+            didJournal = false
+            Self.clearJournal()
+        }
+        guard !saved.isEmpty else { return }
+        for screen in NSScreen.screens {
+            guard let key = Self.key(for: screen), let path = saved[key] else { continue }
+            let url = URL(fileURLWithPath: path)
+            guard FileManager.default.fileExists(atPath: url.path) else { continue }
+            try? NSWorkspace.shared.setDesktopImageURL(url, for: screen, options: [:])
+        }
+    }
+
+    /// Stop catching displays and Spaces up, without putting anything back.
+    ///
+    /// For the theme that changed to one carrying no pictures of its own: the new theme has
+    /// nothing to say about the wallpaper, so toe stops having an opinion too. Without this,
+    /// `reapply` would go on spreading the *previous* theme's picture onto every Space visited
+    /// next — a picture from a theme you have already left.
+    func forget() {
+        current = nil
+    }
+
+    /// A `kill -9` between the journal and the change must leave a record that says too much
+    /// rather than one that says too little, so the journal is only read here — never cleared —
+    /// and what it holds is simply what was there before toe started meddling. Loading it at
+    /// startup means a theme picked in one run is still reversible in the next.
+    func repairAfterUncleanExit() {
+        guard previous.isEmpty else { return }
+        previous = Self.readJournal()
+    }
+
+    /// Notes what is on any display toe has not written down yet.
+    ///
+    /// Per display rather than once per process, and that is the whole point: a monitor plugged
+    /// in after a theme was set is one `reapply` will happily write to, and a once-only gate
+    /// would mean its own wallpaper was overwritten with nothing recorded to give back. A key
+    /// already present is never overwritten — the first thing toe saw on a display is the thing
+    /// it owes, not whatever toe itself put there afterwards.
+    private func journalIfNeeded() {
+        var added = false
+        for screen in NSScreen.screens {
+            guard let key = Self.key(for: screen), previous[key] == nil,
+                  let url = NSWorkspace.shared.desktopImageURL(for: screen) else { continue }
+            // Never record toe's own picture as the thing to give back.
+            guard url != current else { continue }
+            previous[key] = url.path
+            added = true
+        }
+        guard added else { return }
+        didJournal = true
+        Self.writeJournal(previous)                    // before the change, never after
+    }
+
+    // MARK: - The journal file
+
+    private static func key(for screen: NSScreen) -> String? {
+        guard let number = screen.deviceDescription[
+                NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber else { return nil }
+        return SessionStore.monitorKey(CGDirectDisplayID(number.uint32Value))
+    }
+
+    private static func writeJournal(_ entries: [String: String]) {
+        try? FileManager.default.createDirectory(at: journalURL.deletingLastPathComponent(),
+                                                 withIntermediateDirectories: true)
+        // One display per line, tab-separated — a path can hold anything but a tab and a newline,
+        // and this file is read by the same code that wrote it.
+        let text = entries.sorted { $0.key < $1.key }
+            .map { "\($0.key)\t\($0.value)" }
+            .joined(separator: "\n")
+        try? text.write(to: journalURL, atomically: true, encoding: .utf8)
+    }
+
+    private static func readJournal() -> [String: String] {
+        guard let text = try? String(contentsOf: journalURL, encoding: .utf8) else { return [:] }
+        var out: [String: String] = [:]
+        for line in text.components(separatedBy: "\n") {
+            let parts = line.components(separatedBy: "\t")
+            guard parts.count == 2, !parts[0].isEmpty, !parts[1].isEmpty else { continue }
+            out[parts[0]] = parts[1]
+        }
+        return out
+    }
+
+    private static func clearJournal() {
+        try? FileManager.default.removeItem(at: journalURL)
+    }
+}
+
+/// Which picture is current, remembered next to `session.json`.
+///
+/// Not a journal — see `Wallpaper`: this is a choice to remember, not a setting to give back. The
+/// file *name* only, never a path, so it re-resolves against whichever theme is current and a name
+/// that is no longer there simply reads as "nothing current", which `Backgrounds.next` turns into
+/// starting from the first.
+enum BackgroundStore {
+
+    static let url = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".local/state/toe/background")
+
+    static func load() -> String? {
+        guard let text = try? String(contentsOf: url, encoding: .utf8) else { return nil }
+        let name = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return name.isEmpty ? nil : name
+    }
+
+    static func save(_ name: String) {
+        try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                                 withIntermediateDirectories: true)
+        try? name.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    static func clear() {
+        try? FileManager.default.removeItem(at: url)
+    }
+}

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -33,8 +33,43 @@ default_split_ratio    = 1.0
 # 0 = even, 1 = favour the new window, 2 = favour the existing one.
 split_bias             = 0
 
+[theme]
+# An Omarchy theme, by name. Empty is toe's own colours — the [border] and [menu] values below —
+# which is what this file has always been, and what it stays until you choose otherwise. Those
+# defaults are Tokyo Night's palette already, resolved the way walker resolves it, so nothing
+# looks unthemed while this is empty.
+#
+# A theme wins outright. With a name set here, the *colour* keys in [border] and [menu] are not
+# consulted at all; the sizes still are — width, angle, radius, opacity, font_size. Omarchy's own
+# theme template sets col.active_border and nothing else, so a theme is exactly that much: the
+# focused border takes the accent, flat, and the quick menu takes the background, the foreground
+# and the accent.
+#
+# SUPER+SPACE > Style > Theme is where you get one. toe ships no themes: a theme is somebody
+# else's work, and the list you choose from is what is in ~/.config/toe/themes plus what Omarchy
+# publishes. Choosing one you have not got downloads it from Omarchy into that folder — palette
+# and pictures — and then sets it, so a theme you fetched and a theme you copied in by hand are
+# the same thing afterwards.
+#
+# That download is the only time toe touches the network, along with the list of themes it fetches
+# when you open Style > Theme, at most once a day. Nothing at launch, no update check, no
+# telemetry; the only host it talks to is github.com. A machine that has never been online has no
+# themes to choose from, and the colours below.
+#
+# The menu rewrites this one line and leaves every other byte of this file alone, so picking a
+# theme there and editing it here are the same act. It refuses to write at all if the result would
+# not parse.
+#
+# A theme is a folder: ~/.config/toe/themes/<name>/colors.toml, in Omarchy's own format, plus an
+# optional backgrounds/ beside it. Nothing has to be registered — one appears in the menu the
+# moment you next open it, and saving its palette recolours the screen the way saving this file
+# does. Style > Background appears exactly when that theme has pictures, and SUPER+CTRL+SPACE
+# steps through them.
+name = ""
+
 [border]
-# Highlights the focused window. Omarchy's col.active_border gradient.
+# Highlights the focused window. Omarchy's col.active_border gradient — and what you see when no
+# theme is set above, since a theme replaces both stops with one flat accent.
 enabled      = true
 width        = 2
 active_start = "#33ccffee"
@@ -89,7 +124,9 @@ prevent_hiding = true
 # ~/.local/state/toe/session.json and put back when toe starts again, so restarting it costs you
 # nothing. Windows are matched on the id the window server gave them, so this is exact rather
 # than a guess; a reboot voids those ids and the file is discarded unread. Set false to start
-# from an empty workspace every time and keep toe off disk.
+# from an empty workspace every time and keep the *layout* off disk. It is not a blanket switch:
+# the theme's current background is remembered in the same directory either way, since that is a
+# choice you made rather than a window arrangement toe worked out for you.
 restore_session = true
 
 [bar]
@@ -103,7 +140,9 @@ persistent_workspaces = 5
 # tree rather than the level you are on, and each hit says which submenu it came from.
 # These are its theme's tokens: Omarchy's default (Tokyo Night) resolved the way walker's
 # stylesheet resolves them — background, foreground (which is also the border), and the accent
-# the selected row's text takes.
+# the selected row's text takes. Which is to say these three are already a theme: setting
+# [theme] name = "tokyo-night" above leaves this block looking exactly as it does now, and only
+# the border moves. The three are ignored while a theme is set; the sizes below are not.
 background = "#1a1b26"
 foreground = "#a9b1d6"
 accent     = "#7aa2f7"
@@ -190,6 +229,17 @@ font_size  = 18
 # takes ⌥Space and ⌥K away from typing ` ` and ˚ for as long as toe runs.
 "super-space"   = "menu"
 "super-k"       = "keybindings"
+# Omarchy's background key. SUPER+CTRL+SPACE is what its bindings.conf gives to backgrounds —
+# there it opens the picker, which here is Style › Background in the menu above, so the key does
+# the thing the menu cannot: step to the next picture without stopping to choose one. Does
+# nothing until the current theme has a backgrounds/ folder with something in it.
+#
+# The one binding here with a macOS shortcut behind it: ⌃⌥Space is "select next input source",
+# and while that is a symbolic hotkey — resolved inside the window server, ahead of anything toe
+# can register — it is switched off unless you have two or more input sources. If you do, and
+# this key changes your keyboard instead of your wallpaper, that is why; move it, or turn the
+# shortcut off in System Settings › Keyboard › Keyboard Shortcuts › Input Sources.
+"super-ctrl-space" = "nextbackground"
 
 # ── Launch ────────────────────────────────────────────────────────────────────
 # AppleScript's `new window` reuses the running instance, so the window opens on the current


### PR DESCRIPTION
Ports Omarchy's `Style › Theme` level to toe's quick menu.

A theme is Omarchy's `colors.toml`, key for key: the focused border takes the accent — **flat**, as their `hyprland.conf.tpl` renders it with `rgb(...)` and not a gradient — and the quick menu takes the background, the foreground and the accent. The mapping was already there: `[menu]`'s shipped `#1a1b26` / `#a9b1d6` / `#7aa2f7` *are* Tokyo Night's palette resolved through walker's tokens, so with no theme set toe already looks like one. There is a selftest asserting exactly that, which pins the palette, the token mapping and `applying` in one line.

## toe ships no themes

A theme is somebody else's work — palettes and photographs with no stated licence anywhere upstream — and bundling them inside a notarised app on a Homebrew cask would be toe redistributing them rather than Omarchy. One of them is a Studio Ghibli character; several are Omarchy's own branding.

So `Style › Theme` lists what is in `~/.config/toe/themes` plus what Omarchy publishes, with what each would cost, and choosing one you have not got downloads it:

```
Rose Pine
Everforest    0.3 MB
Kanagawa      2.1 MB
Gruvbox       9.2 MB
Your own colours
```

All nineteen rather than a chosen three, and 79 MB of pictures that never ship. Toe.app stays at 4.3 MB.

## The network, stated plainly

Two requests, both to github.com, both because you did something: the catalogue when you open `Style › Theme` (one recursive tree call, ~320 KB, cached and refreshed at most once a day), and a theme when you choose one. Nothing at launch, no update check, no telemetry. A machine that has never been online has no themes and toe's own colours.

The menu bar item says so while either runs — `⟳ Gruvbox 3/6`, after the workspaces rather than instead of them, because a nine-megabyte download happens with the menu closed and a tooltip needs you to already suspect something is happening.

Everything off the network is treated as hostile, being written next to a file that runs shell commands:

- the directory is `Slug.make`'s output, so it can only be one path component;
- filenames are whitelisted by shape rather than searched for `..`, which is one encoding trick away from being wrong;
- the palette is parsed before anything is moved into place;
- a theme is assembled in a temporary directory and moved in one step, so a failure halfway leaves nothing behind;
- upstream's own wordmark is not fetched — it is in every theme's `backgrounds/` and is not a wallpaper anybody wants.

## Writing the config

Picking a theme rewrites one line — `[theme] name` — with every other byte preserved, comments and alignment included, and the existing watcher reloads it. So picking one in the menu and editing the line by hand are the same act.

The write follows a symlink rather than replacing it, since keeping the config in a dotfiles repository is deliberately supported and an ordinary atomic write would turn the link into a regular file and orphan the repo copy. It keeps the mode the file already had, since a config checked out of a repository is often `0644`. And it parses its own output before committing it: a line-based edit cannot see everything a parser can — `["theme"]` is the same table as `[theme]` — so anything it would get wrong becomes *toe declined to edit your config* rather than a config that will not load.

## Also

- `SUPER`+`CTRL`+`SPACE` steps through a theme's backgrounds. That is the key Omarchy gives to backgrounds, where it opens the picker, which here is the menu's job. It is on `fallbackBindings` — the one entry there that is not an escape hatch — because a config is never rewritten and it would otherwise reach nobody who already had one. The rationale comment on that list has been rewritten as a bar rather than a rule, saying the answer is usually still no.
- The desktop picture is journalled the way CLAUDE.md asks and given back when the theme is **cleared**, not on quit: a symbolic hotkey is borrowed and owed back, a wallpaper you chose is not. `make run` pkills toe on every dev cycle, which is the practical proof.
- `activeSpaceChanged` re-applies it, because with *Displays have separate Spaces* on, `setDesktopImageURL(for:)` is per Space and not per screen.

## Testing

812 assertions (from 618), all in ToeCore. The largest groups are the config writer and the catalogue parser, both pure and both given real inputs — a verbatim Omarchy `colors.toml`, and a tree listing in the shape the real one comes back in with a theme that has no palette, a directory that is not a slug, a `README.md` beside the pictures and a name that must never reach the filesystem.

The network path was verified against the live repo with the shipped source: catalogue HTTP 200, 323 KB, 19 themes parsed with correct sizes; a real download of Everforest, palette parsed, progress `0/1 → 1/1`. The symlink-safe write was verified separately — link survives, far file changes, mode `0644` preserved, a fifo refused.