### PR TITLE
Auto-hide the Dock while toe runs, and give it back on quit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,11 +92,14 @@ border: the border panel is `.canJoinAllSpaces` + `.fullScreenAuxiliary`, so it 
 across a fullscreen Space unless something stops it. With *Displays have separate Spaces* on (the
 macOS default) "is anything fullscreen" is never the right question — scope it to a display.
 
-**State that outlives the process.** Symbolic hotkeys (`CGSSetSymbolicHotKeyEnabled`) and the
-wallpaper-click preference are the window server's, not toe's, so a `kill -9` during development
-would leave `Ctrl`+`↑` dead with nothing to explain why. Both are journalled to
+**State that outlives the process.** Symbolic hotkeys (`CGSSetSymbolicHotKeyEnabled`), the
+wallpaper-click preference and the Dock's auto-hide (`CoreDockSetAutoHideEnabled`) belong to the
+window server or the Dock, not to toe, so a `kill -9` during development would leave `Ctrl`+`↑`
+dead — or the Dock hiding itself — with nothing to explain why. All three are journalled to
 `~/.local/state/toe/` *before* the change is made and replayed in reverse at startup. If you add
-another such global toggle, follow that pattern.
+another such global toggle, follow that pattern. `CoreDock*` is also the one place toe reaches a
+symbol through `dlsym` instead of declaring it: unexported from every header, and a link-time
+dependency on it would turn its removal into a launch failure.
 
 **The session snapshot** (`~/.local/state/toe/session.json`) is keyed on `CGWindowID` plus
 `kern.boottime`, and is restored *before* the tracker starts. A stale snapshot is discarded unread

--- a/README.md
+++ b/README.md
@@ -221,6 +221,23 @@ removing the key again, so a setting you never set is not left holding a value y
 A reveal you had already switched off yourself is left alone. `misc.disable_wallpaper_click = false`
 hands the click back.
 
+**The Dock.** A visible Dock is a strip of screen — around 70 points — that `NSScreen.visibleFrame`
+stops short of, so the layout gives up one edge of every display to something a tiling user
+reaches with `SUPER`+`SPACE` instead. toe turns on "Automatically hide and show the Dock" while it
+runs, which hands the strip back and leaves the Dock one mouse-to-the-edge away. Not through the
+preference: `com.apple.dock`'s `autohide` is what System Settings writes, but the Dock reads its
+own only at launch, so a write needs a `killall -HUP Dock` — which restarts the Dock and blinks
+out every badge and running-app dot. `CoreDockSetAutoHideEnabled` does the whole job instead, the
+Dock animates away, and the preference is updated underneath so System Settings agrees. It is
+exported by HIServices but declared in no public header, so toe looks it up with `dlsym` rather
+than naming it: a declaration would be a link-time dependency, and the day the symbol goes toe
+should lose this one feature rather than stop launching. `NSApplication`'s `.autoHideDock`
+presentation option is the tempting public answer and does not work here — presentation options
+hold only while the application is *active*, and toe is an `.accessory` that is never frontmost.
+This outlives the process too, so it is journalled to `~/.local/state/toe/dock-autohide` first,
+exactly as the two above are. A Dock you already auto-hide yourself is left alone.
+`misc.autohide_dock = false` leaves the Dock where you have it.
+
 **The quick menu.** The menu bar item is the workspace strip and nothing else, which is faithful
 to waybar and leaves toe with nowhere to *show* you anything: the bindings above are the whole
 interface, and a Homebrew user has no way to discover one of them. Omarchy has the surface that

--- a/Sources/ToeCore/Config/Config.swift
+++ b/Sources/ToeCore/Config/Config.swift
@@ -109,6 +109,9 @@ public struct MiscConfig: Equatable {
     /// off-screen stash alike, and macOS decides that inside WindowManager rather than from an
     /// event any tap could swallow — so it is switched off through its preference instead.
     public var disableWallpaperClick: Bool = true
+    /// A visible Dock is a strip of screen the tiles never get, for something `SUPER`+`SPACE`
+    /// reaches instead. Switched on through `CoreDockSetAutoHideEnabled` — see `DockAutoHide`.
+    public var autohideDock: Bool = true
     /// `⌘H` takes an application's windows out of the layout with no way to reach them again.
     public var preventHiding: Bool = true
     /// Whether the layout is written to disk and put back on the next launch. See
@@ -438,6 +441,13 @@ public struct Config: Equatable {
                     config.misc.disableWallpaperClick = v
                 } else {
                     config.warnings.append("misc.disable_wallpaper_click: must be true or false, using \(config.misc.disableWallpaperClick)")
+                }
+            }
+            if let raw = m["autohide_dock"] {
+                if let v = raw.boolValue {
+                    config.misc.autohideDock = v
+                } else {
+                    config.warnings.append("misc.autohide_dock: must be true or false, using \(config.misc.autohideDock)")
                 }
             }
             if let raw = m["prevent_hiding"] {

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -122,6 +122,13 @@ disable_expose_shortcuts = true
 # "Click wallpaper to show desktop") and puts it back the way it found it when it quits.
 disable_wallpaper_click = true
 
+# The Dock takes a strip of screen off one edge that the tiles never get — around 70 points on a
+# default install, for something SUPER+SPACE reaches instead. toe turns on the setting System
+# Settings › Desktop & Dock calls "Automatically hide and show the Dock", which hands the strip
+# back and leaves the Dock one mouse-to-the-edge away, and turns it off again when it quits. A
+# Dock you already auto-hide yourself is left alone.
+autohide_dock = true
+
 # ⌘H and ⌘⌥H take an application's windows out of the layout without closing them — the tree
 # reflows around the gap and SUPER+arrows cannot reach them again, because they are no longer on
 # any workspace. toe puts a hidden application straight back.

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -924,24 +924,29 @@ h.test("dock swipe swallowing is configurable") { t in
 }
 
 h.test("the macOS behaviours toe takes over are configurable") { t in
-    let off = try Config.parse("[misc]\ndisable_expose_shortcuts = false\nprevent_hiding = false\ndisable_wallpaper_click = false\n")
+    let off = try Config.parse("[misc]\ndisable_expose_shortcuts = false\nprevent_hiding = false\ndisable_wallpaper_click = false\nautohide_dock = false\n")
     t.equal(off.misc.disableExposeShortcuts, false, "the Exposé shortcuts can be handed back")
     t.equal(off.misc.preventHiding, false, "hiding can be allowed")
     t.equal(off.misc.disableWallpaperClick, false, "the wallpaper click can be handed back")
+    t.equal(off.misc.autohideDock, false, "the Dock can be left showing")
     t.equal(off.warnings, [], "no warnings")
 
     let absent = try Config.parse("[general]\ngaps_in = 5\n")
     t.equal(absent.misc.disableExposeShortcuts, true, "omitting the table keeps the defaults")
     t.equal(absent.misc.preventHiding, true, "omitting the table keeps the defaults")
     t.equal(absent.misc.disableWallpaperClick, true, "omitting the table keeps the defaults")
+    t.equal(absent.misc.autohideDock, true, "omitting the table keeps the defaults")
 
-    let bad = try Config.parse("[misc]\nprevent_hiding = 1\ndisable_wallpaper_click = \"no\"\n")
+    let bad = try Config.parse("[misc]\nprevent_hiding = 1\ndisable_wallpaper_click = \"no\"\nautohide_dock = \"sometimes\"\n")
     t.equal(bad.misc.preventHiding, true, "a non-boolean keeps the default")
     t.equal(bad.misc.disableWallpaperClick, true, "a non-boolean keeps the default")
+    t.equal(bad.misc.autohideDock, true, "a non-boolean keeps the default")
     t.equal(bad.warnings.contains { $0.contains("misc.prevent_hiding") }, true,
             "and says so in the menu bar")
     t.equal(bad.warnings.contains { $0.contains("misc.disable_wallpaper_click") }, true,
             "and says so for the wallpaper click too")
+    t.equal(bad.warnings.contains { $0.contains("misc.autohide_dock") }, true,
+            "and for the Dock")
 }
 
 h.test("restoring the layout across a restart is configurable") { t in

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -114,9 +114,13 @@ final class Coordinator: WindowTrackerDelegate {
         // Same reasoning, same shape: the reveal-desktop preference is the window server's, not
         // toe's, so a copy that was killed rather than quit may have left it switched off.
         WallpaperClick.repairAfterUncleanExit()
-        // Not the same thing as those two — the desktop picture is not given back on the way out
-        // — but the note of what was there before toe touched it is read at the same point, so a
-        // theme picked in a run that was killed is still reversible in this one. See `Wallpaper`.
+        // And the third of them: the Dock's auto-hide setting is the Dock's own, so a copy that
+        // was killed rather than quit may have left the Dock hiding itself.
+        DockAutoHide.repairAfterUncleanExit()
+        // Not the same thing as those three — the desktop picture is not given back on the way
+        // out — but the note of what was there before toe touched it is read at the same point,
+        // so a theme picked in a run that was killed is still reversible in this one. See
+        // `Wallpaper`.
         wallpaper.repairAfterUncleanExit()
         writeDefaultConfigIfMissing()
         loadConfig(force: true)
@@ -646,6 +650,12 @@ final class Coordinator: WindowTrackerDelegate {
             WallpaperClick.restore()
         }
 
+        if config.misc.autohideDock {
+            DockAutoHide.enable()
+        } else {
+            DockAutoHide.restore()
+        }
+
         if config.misc.preventHiding {
             hideBlocker.start()
         } else {
@@ -1036,11 +1046,12 @@ final class Coordinator: WindowTrackerDelegate {
         // WindowServer, so it is taken down deliberately rather than left to process death.
         dockSwipes.stop()
         hideBlocker.stop()
-        // The two that would otherwise outlive toe: the window server keeps a symbolic hotkey
-        // switched off until something switches it back on, and the reveal-desktop preference is
-        // written to the user's settings.
+        // The three that would otherwise outlive toe: the window server keeps a symbolic hotkey
+        // switched off until something switches it back on, and the reveal-desktop and Dock
+        // auto-hide preferences are written to the user's settings.
         SymbolicHotkeys.restoreAll()
         WallpaperClick.restore()
+        DockAutoHide.restore()
     }
 
     private func unstashEverything() {

--- a/Sources/toe/DockAutoHide.swift
+++ b/Sources/toe/DockAutoHide.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+/// macOS's "Automatically hide and show the Dock", switched on for as long as toe runs.
+///
+/// A visible Dock is a strip of screen the tiles never get: `NSScreen.visibleFrame` stops short
+/// of it, so on a default install the layout gives up ~70 points of one edge to something a
+/// tiling user reaches for with `SUPER`+`SPACE` instead. Auto-hiding hands that strip back, and
+/// the Dock is still one mouse-to-the-edge away.
+///
+/// **Why not the preference.** `com.apple.dock`'s `autohide` key is the one System Settings ›
+/// Desktop & Dock writes, but unlike `WallpaperClick`'s — which WindowManager re-reads on every
+/// click — the Dock reads its own only at launch and on notification. Writing it needs a
+/// `killall -HUP Dock` to take effect, which restarts the Dock: badges, running-app dots and
+/// animation state all blink out. `CoreDockSetAutoHideEnabled` does the whole job instead — the
+/// Dock animates away immediately, the preference is updated underneath, and System Settings
+/// shows the new value. It is also what `NSApplication.setPresentationOptions(.autoHideDock)`
+/// cannot do: presentation options hold only while the application is *active*, and toe is an
+/// `.accessory` that is never frontmost.
+///
+/// **Why `dlsym` rather than a declaration.** `CoreDock*` is exported by HIServices but is in no
+/// public header, so naming it in Swift means declaring it ourselves — and a declaration is a
+/// link-time dependency: the day Apple drops the symbol, toe stops launching at all rather than
+/// stopping doing this one thing. Looked up at runtime, a missing symbol is a feature that
+/// quietly does nothing.
+///
+/// Like a symbolic hotkey, **this state outlives the process**, so it is handled the same way:
+/// journalled to disk *before* the change, and a journal found at startup is replayed, which is
+/// what repairs a crash, a force-quit or a logout.
+enum DockAutoHide {
+
+    /// `Boolean` in C is an `unsigned char`, not a `_Bool`. The two are passed and returned
+    /// identically for 0 and 1, but going through `UInt8` says which one is being called and
+    /// leaves no question about what a value outside that pair would mean.
+    private typealias GetAutoHide = @convention(c) () -> UInt8
+    private typealias SetAutoHide = @convention(c) (UInt8) -> Void
+
+    /// HIServices is not linked into toe, and `dlopen(nil, …)` only sees images already loaded —
+    /// so the framework is opened by name. Left open deliberately: a `dlclose` would invalidate
+    /// the pointers below, which are held for the life of the process.
+    private static let hiServices: UnsafeMutableRawPointer? = dlopen(
+        "/System/Library/Frameworks/ApplicationServices.framework/Frameworks/"
+            + "HIServices.framework/HIServices", RTLD_LAZY)
+
+    private static let getAutoHide: GetAutoHide? = symbol("CoreDockGetAutoHideEnabled")
+    private static let setAutoHide: SetAutoHide? = symbol("CoreDockSetAutoHideEnabled")
+
+    private static func symbol<T>(_ name: String) -> T? {
+        guard let hiServices, let address = dlsym(hiServices, name) else {
+            Log.error("dock: \(name) is missing — the Dock is left the way you have it")
+            return nil
+        }
+        return unsafeBitCast(address, to: T.self)
+    }
+
+    private static let journalURL = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".local/state/toe/dock-autohide")
+
+    /// What the setting was before toe touched it, and so what `restore` owes the user back.
+    /// One case, because `enable` returns early when auto-hiding is already on: there is then
+    /// nothing to take and nothing to give back, so `off` is the only value ever journalled.
+    /// It stays an enum for the parsing — a truncated or hand-edited journal is ignored rather
+    /// than read as a state to put back.
+    private enum Previous: String {
+        case off
+    }
+
+    private static var previous: Previous?
+
+    // MARK: - Applying
+
+    /// Turns auto-hiding on, remembering what was there. Idempotent, and a no-op when the user
+    /// hides the Dock themselves already.
+    ///
+    /// The read below is only safe because of *when* this is called. `CoreDockSetAutoHideEnabled`
+    /// messages the Dock rather than writing a value, and `CoreDockGetAutoHideEnabled` lags that
+    /// round trip by a few hundred milliseconds — so a read taken straight after a write reports
+    /// the old state. `applyMiscSettings` calls this at startup and on a config reload, where
+    /// nothing has just written, and `previous` short-circuits every call after the first. Anything
+    /// that wants to flip auto-hiding on demand — a binding, a menu row — must not re-read to find
+    /// out what it did; `previous` is the answer.
+    static func enable() {
+        guard previous == nil, let getAutoHide, let setAutoHide else { return }
+        guard getAutoHide() == 0 else { return }
+
+        // Journalled before the change, not after: a crash between the two must leave a record
+        // that says too much, never one that says too little.
+        previous = .off
+        writeJournal(.off)
+        setAutoHide(1)
+        // Nothing to relayout here. Auto-hiding changes `visibleFrame`, which macOS reports as a
+        // screen-parameters change, and `WindowTracker` already turns that into `screensChanged`.
+        Log.info("dock: auto-hide switched on")
+    }
+
+    /// Gives back exactly what `enable` took, and clears the journal. Safe to call twice.
+    static func restore() {
+        guard previous != nil else {
+            clearJournal()
+            return
+        }
+        setAutoHide?(0)
+        previous = nil
+        clearJournal()
+        Log.info("dock: auto-hide restored")
+    }
+
+    /// Replays a journal left behind by a toe that did not get to restore — a crash, a `kill -9`,
+    /// a logout. Call once at startup, before `enable`.
+    static func repairAfterUncleanExit() {
+        guard let text = try? String(contentsOf: journalURL, encoding: .utf8) else { return }
+        if Previous(rawValue: text.trimmingCharacters(in: .whitespacesAndNewlines)) != nil {
+            setAutoHide?(0)
+            Log.info("dock: repaired auto-hide after an unclean exit")
+        }
+        clearJournal()
+    }
+
+    // MARK: - The journal
+
+    private static func writeJournal(_ previous: Previous) {
+        try? FileManager.default.createDirectory(at: journalURL.deletingLastPathComponent(),
+                                                 withIntermediateDirectories: true)
+        try? previous.rawValue.write(to: journalURL, atomically: true, encoding: .utf8)
+    }
+
+    private static func clearJournal() {
+        try? FileManager.default.removeItem(at: journalURL)
+    }
+}

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -115,6 +115,13 @@ disable_expose_shortcuts = true
 # "Click wallpaper to show desktop") and puts it back the way it found it when it quits.
 disable_wallpaper_click = true
 
+# The Dock takes a strip of screen off one edge that the tiles never get — around 70 points on a
+# default install, for something SUPER+SPACE reaches instead. toe turns on the setting System
+# Settings › Desktop & Dock calls "Automatically hide and show the Dock", which hands the strip
+# back and leaves the Dock one mouse-to-the-edge away, and turns it off again when it quits. A
+# Dock you already auto-hide yourself is left alone.
+autohide_dock = true
+
 # ⌘H and ⌘⌥H take an application's windows out of the layout without closing them — the tree
 # reflows around the gap and SUPER+arrows cannot reach them again, because they are no longer on
 # any workspace. toe puts a hidden application straight back.


### PR DESCRIPTION
A visible Dock is a strip of screen the tiles never get — 74 points on this display — for
something `SUPER`+`SPACE` reaches instead. toe now turns on "Automatically hide and show the
Dock" while it runs, which hands the strip back and leaves the Dock one mouse-to-the-edge away.
`misc.autohide_dock = false` leaves the Dock where you have it.

On by default, as the rest of `[misc]` is.

## Why `CoreDock*` and not the preference

`com.apple.dock`'s `autohide` is what System Settings writes, but unlike `WallpaperClick`'s —
which WindowManager re-reads on every click — the Dock reads its own only at launch and on
notification. A write needs a `killall -HUP Dock`, which restarts the Dock and blinks out every
badge and running-app dot. `CoreDockSetAutoHideEnabled` does the whole job instead: the Dock
animates away, and the preference is updated underneath so System Settings agrees.

`NSApplication`'s `.autoHideDock` presentation option is the tempting public answer and cannot
work here — presentation options hold only while the application is *active*, and toe is an
`.accessory` that is never frontmost.

`CoreDock*` is exported by HIServices but declared in no public header, so it is looked up with
`dlsym` rather than declared. A declaration is a link-time dependency: the day Apple drops the
symbol, toe would stop launching rather than stop doing this one thing.

## The pattern it follows

This state outlives the process, so `DockAutoHide` is the same four members `WallpaperClick` has
— `enable`, `restore`, `repairAfterUncleanExit`, and a journal at
`~/.local/state/toe/dock-autohide` written *before* the change. Three call sites in
`Coordinator`, beside the two that were already there.

The layout needed nothing new: auto-hiding changes `visibleFrame`, macOS reports that as a
screen-parameters change, and `WindowTracker` already turns it into `screensChanged`.

## Verified on hardware, not only compiled

- Showing the Dock drops `visibleFrame` from 1410 to 1336 — **74 points** reclaimed.
- `didChangeScreenParametersNotification` fires in both directions, and `visibleFrame` is
  already updated by the time it arrives, so the relayout path is free.
- All four journal cases, by compiling `DockAutoHide.swift` into a scratch harness: normal
  enable/restore, a second `enable()` on a config reload, a Dock the user already auto-hides
  (nothing taken, nothing given back), an unclean exit repaired from the journal, and a
  hand-mangled journal ignored rather than obeyed.

One finding that only showed up under test and is now documented on `enable()`:
`CoreDockSetAutoHideEnabled` messages the Dock, and `CoreDockGetAutoHideEnabled` lags that round
trip by a few hundred milliseconds. Harmless where `enable()` is called from — startup and
config reload, with `previous` short-circuiting the rest — but anything that later flips
auto-hiding on demand must not re-read to find out what it did.

`make test` — 816 assertions pass. `make bundle` signs clean.