### PR TITLE
Follow Omarchy onto quattro, and report downloads in the quick menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,14 +305,24 @@ choose one. Nothing at launch, no update check, no telemetry. A machine that has
 has no themes to choose from and toe's own colours, which is the cost of not shipping other
 people's work.
 
-While either is running the menu bar item says so — `⟳ Gruvbox 3/6` after the workspaces, never
-instead of them — because a nine-megabyte download happens with the menu closed and the tooltip
-behind it needs you to already suspect something is happening.
+Both report themselves in the menu, on the row the wait belongs to. Picking a theme toe has not
+got is the one row that does not dismiss the panel: it stays open and that theme's own row fills
+left to right in the accent as the pictures arrive, its size giving way to `3/5`. The catalogue
+fetch is the `Fetching Omarchy's themes…` row, which now appears and gives way to the themes it
+was waiting for without the menu having to be closed and opened again.
+
+The menu bar says nothing about either — the strip is workspaces and the tooltip is things that
+have gone wrong. Escape or a click elsewhere closes the menu as always and the download carries
+on behind it; what you give up by dismissing it is watching, and what you get back is a menu bar
+that is not a second, worse copy of a list the menu draws properly.
 
 A theme is a folder: `~/.config/toe/themes/<name>/colors.toml` in Omarchy's own format, plus an
 optional `backgrounds/`. That is the same shape a theme directory copied straight out of an
 Omarchy install has, and the same shape the downloader writes, so a theme you fetched and one you
 put there yourself are the same thing afterwards with nothing that treats them differently.
+Omarchy 4 rewrote that file — named hues like `red` and `bright_cyan` where Omarchy 3 had
+`color0`…`color15`, a `mode`, and ramps of backgrounds and foregrounds — and both spellings are
+read, so a folder you copied across before the rewrite keeps working.
 Nothing is registered: a folder you add appears the moment you next open the menu, and saving its
 palette recolours the screen within about 150 ms the way saving `toe.toml` does.
 

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -67,11 +67,12 @@ split_bias             = 0
 # theme there and editing it here are the same act. It refuses to write at all if the result would
 # not parse.
 #
-# A theme is a folder: ~/.config/toe/themes/<name>/colors.toml, in Omarchy's own format, plus an
-# optional backgrounds/ beside it. Nothing has to be registered — one appears in the menu the
-# moment you next open it, and saving its palette recolours the screen the way saving this file
-# does. Style > Background appears exactly when that theme has pictures, and SUPER+CTRL+SPACE
-# steps through them.
+# A theme is a folder: ~/.config/toe/themes/<name>/colors.toml, in Omarchy's own format — either
+# spelling of it, the named hues Omarchy 4 writes or the numbered color0-color15 of Omarchy 3 —
+# plus an optional backgrounds/ beside it. Nothing has to be registered — one appears in the
+# menu the moment you next open it, and saving its palette recolours the screen the way saving
+# this file does. Style > Background appears exactly when that theme has pictures, and
+# SUPER+CTRL+SPACE steps through them.
 name = ""
 
 [border]

--- a/Sources/ToeCore/Dispatch/Command.swift
+++ b/Sources/ToeCore/Dispatch/Command.swift
@@ -53,6 +53,36 @@ public extension Command {
         guard case .exec(let line) = self else { return false }
         return line.contains(Config.fileName)
     }
+
+    /// Whether the quick menu stays up after running this.
+    ///
+    /// Every row used to dismiss the panel, which is right for almost all of them: `exec` brings
+    /// another application forward, `quit` tears the process down, and a window command acts on a
+    /// window you cannot see past the menu. Choosing a theme is the exception, and for two
+    /// reasons that arrived separately and point the same way.
+    ///
+    /// The first is that a theme you have not got has to be *fetched*, and the fetching is
+    /// reported by that row filling — so closing the menu would dismiss the only surface saying
+    /// anything about the slowest thing toe does.
+    ///
+    /// The second is that a theme recolours the menu itself. Picking one and staying put means
+    /// the panel restyles under the cursor, so arrowing down the list and pressing return is a
+    /// way of *looking* at themes rather than a commitment to one — which is what the list is
+    /// for. Closing on each pick made trying three themes three trips through
+    /// `SUPER`+`SPACE` › `Style` › `Theme`.
+    ///
+    /// `.theme("")` — `Your own colours` — is in here for the same reason: it is the way back,
+    /// and a way back you have to reopen the menu to use is not much of one.
+    ///
+    /// Backgrounds deliberately still close. A wallpaper is behind the panel rather than in it,
+    /// so there is nothing to restyle and nothing being fetched; the picture is the whole of what
+    /// changed, and the menu is what is in front of it.
+    var keepsMenuOpen: Bool {
+        switch self {
+        case .theme: return true
+        default:     return false
+        }
+    }
 }
 
 public enum CommandError: Error, CustomStringConvertible {

--- a/Sources/ToeCore/Menu/MenuLayout.swift
+++ b/Sources/ToeCore/Menu/MenuLayout.swift
@@ -112,6 +112,20 @@ public enum MenuLayout {
             w: width - contentInset(m) * 2, h: rowHeight(m))
     }
 
+    /// The filled part of a row that is showing progress — the whole row, cut off at `fraction`.
+    ///
+    /// The whole row and not an inset bar inside it, deliberately: at walker's row height there
+    /// is no room for a bar that is a control in its own right without the row becoming two
+    /// things stacked, and the row already has a shape the eye knows. So the row *is* the bar,
+    /// the way `child:selected` is already a wash across the whole of it.
+    ///
+    /// Clamped both ends, because the fraction arrives from arithmetic over a count that comes
+    /// off the network: a catalogue claiming a theme has -1 pictures should draw nothing, not a
+    /// rectangle running the other way out of the panel.
+    public static func progressFrame(inRow row: Box, fraction: Double) -> Box {
+        Box(x: row.x, y: row.y, w: row.w * min(1, max(0, fraction)), h: row.h)
+    }
+
     public static func iconFrame(inRow row: Box, _ m: MenuMetrics) -> Box {
         // Centred on the row as a whole, which is where the eye puts it when the row is two
         // lines tall — Omarchy's menu sets its icons the same way.

--- a/Sources/ToeCore/Menu/MenuModel.swift
+++ b/Sources/ToeCore/Menu/MenuModel.swift
@@ -36,19 +36,29 @@ public struct MenuItem: Equatable {
     public let icon: Icon?
     /// The second column: `on`/`off` for the login toggle, what it does for a keybinding row.
     public let value: String?
+    /// How full to draw the row, 0…1, or nil for the ordinary case of a row that is not doing
+    /// anything. Set on the theme being downloaded, and the reason a download is visible at all
+    /// now that the menu bar has stopped saying so.
+    ///
+    /// On `MenuItem` rather than on the theme rows specifically, because the drawing is generic:
+    /// `MenuView` fills whatever row carries this, so the next thing that takes time — and there
+    /// will be one — does not need a second way of showing it.
+    public let progress: Double?
     public let action: Action
 
     public init(title: String, subtitle: String? = nil, icon: Icon? = nil,
-                value: String? = nil, action: Action) {
+                value: String? = nil, progress: Double? = nil, action: Action) {
         self.title = title
         self.subtitle = subtitle
         self.icon = icon
         self.value = value
+        self.progress = progress
         self.action = action
     }
 
     public func with(subtitle: String?) -> MenuItem {
-        MenuItem(title: title, subtitle: subtitle, icon: icon, value: value, action: action)
+        MenuItem(title: title, subtitle: subtitle, icon: icon, value: value, progress: progress,
+                 action: action)
     }
 
     /// walker marks the rows that lead somewhere with a trailing `›`, right-aligned.
@@ -91,16 +101,21 @@ public struct StyleMenu: Equatable {
     /// The current theme's `backgrounds/`, in cycle order.
     public var backgrounds: [String]
     public var currentBackground: String?
+    /// The theme being fetched right now, if one is. Its row fills as the pictures arrive, which
+    /// is the whole of what toe says about a download since the menu bar stopped saying it.
+    public var downloading: ThemeDownload?
 
     public init(themes: [ThemeRef] = [], available: [RemoteTheme] = [], fetching: Bool = false,
                 current: String? = nil,
-                backgrounds: [String] = [], currentBackground: String? = nil) {
+                backgrounds: [String] = [], currentBackground: String? = nil,
+                downloading: ThemeDownload? = nil) {
         self.themes = themes
         self.available = available
         self.fetching = fetching
         self.current = current
         self.backgrounds = backgrounds
         self.currentBackground = currentBackground
+        self.downloading = downloading
     }
 }
 
@@ -160,9 +175,14 @@ public enum MenuModel {
         // these run from a third of a megabyte to nine, and a row that downloaded nine megabytes
         // without having said so first would be a row that surprised you.
         rows += style.available.map { theme in
-            MenuItem(title: theme.name,
-                     value: ByteSize.describe(theme.bytes),
-                     action: .run(.theme(theme.slug)))
+            // The one being fetched trades its size for a count and starts filling: the size was
+            // there to tell you what you were about to spend, and once you have spent it the
+            // question has become how much longer.
+            let download = style.downloading?.slug == theme.slug ? style.downloading : nil
+            return MenuItem(title: theme.name,
+                            value: download?.label ?? ByteSize.describe(theme.bytes),
+                            progress: download?.fraction,
+                            action: .run(.theme(theme.slug)))
         }
 
         // Said rather than left to be inferred from a short list. Deliberately after the themes

--- a/Sources/ToeCore/Menu/MenuState.swift
+++ b/Sources/ToeCore/Menu/MenuState.swift
@@ -144,6 +144,40 @@ public struct MenuState: Equatable {
         refilter(resettingSelection: false)
     }
 
+    /// Rebuilds every level from a fresh tree, leaving the user on the level and the row they
+    /// were on.
+    ///
+    /// `replaceLevel` is not enough for a menu that changes while you are looking at it: the rows
+    /// that move are two levels down from the root, and the caller would have to know which of
+    /// `MenuModel`'s builders made the level in front of you in order to call the right one. So
+    /// the whole tree is rebuilt and this walks back down it by title, which is a thing the state
+    /// already records for the breadcrumb.
+    ///
+    /// A level that cannot be re-entered — its row is gone, or stopped leading anywhere — stops
+    /// the walk and leaves you at the deepest level that still exists. That is a real case rather
+    /// than a defensive one: `Background` appears only while the current theme has pictures, so
+    /// changing to a theme with none takes the level you are standing in out from under you, and
+    /// surfacing one rung up is the answer that cannot show rows belonging to a theme you left.
+    public mutating func rebuild(root: [MenuItem]) {
+        var levels: [[MenuItem]] = [root]
+        var reached: [String] = []
+        for title in titles {
+            guard let item = levels[levels.count - 1].first(where: { $0.title == title }),
+                  case .submenu(let children) = item.action else { break }
+            levels.append(children)
+            reached.append(title)
+        }
+        stack = levels
+        titles = reached
+        // The selection is kept rather than reset, which is what makes the fill appear under the
+        // cursor instead of the list jumping to the top on every picture that lands. It is an
+        // index into a list whose rows can move — a finished download leaves `available` for
+        // `themes` — so `refilter` clamps it, and the row under the cursor afterwards may not be
+        // the row that was under it before. That is the same trade `replaceLevel` already makes
+        // for the startup toggle.
+        refilter(resettingSelection: false)
+    }
+
     // MARK: - Private
 
     /// Typing searches the whole tree below wherever you are, not the one level in front of you,

--- a/Sources/ToeCore/Theme/Catalogue.swift
+++ b/Sources/ToeCore/Theme/Catalogue.swift
@@ -31,7 +31,15 @@ public struct RemoteTheme: Codable, Equatable, Sendable {
 
 /// Every theme Omarchy publishes, as of the last time toe asked.
 public struct Catalogue: Codable, Equatable, Sendable {
-    public static let currentVersion = 1
+    /// Bumped to 2 when toe moved from Omarchy's `master` branch to `quattro`, which is a change
+    /// a cached listing cannot survive: Omarchy 4 re-encoded most of the backgrounds to webp and
+    /// renumbered them, and only nine of the fifty-nine filenames on `master` still exist. A
+    /// `catalogue.json` written against the old branch therefore names pictures that are gone,
+    /// and choosing one of those themes would 404 partway through the download rather than fail
+    /// in any way the menu could explain. `load()` discards a catalogue whose version is not this
+    /// one, so the bump is what makes that cache miss happen at once rather than whenever the
+    /// 24-hour staleness window next comes round.
+    public static let currentVersion = 2
 
     public var version: Int
     public var fetchedAt: Date

--- a/Sources/ToeCore/Theme/Palette.swift
+++ b/Sources/ToeCore/Theme/Palette.swift
@@ -27,31 +27,113 @@ public enum PaletteError: Error, CustomStringConvertible, Equatable {
 /// backgrounds and all, and a format that is *nearly* theirs would be worse than either having
 /// their format or having an obviously different one.
 ///
+/// **Two spellings of that file exist, and both are read.** Omarchy 4 (the `quattro` branch, which
+/// is where every release since v3.8.4 has come from) rewrote `colors.toml`: the sixteen
+/// `color0`…`color15` slots became named hues — `red`, `bright_cyan`, plus an `orange` and a
+/// `brown` that ANSI has no slot for — `cursor` went away, `selection_foreground` and
+/// `selection_background` became `selection` and `muted`, and a `mode` key and two ramps of
+/// backgrounds and foregrounds arrived. Omarchy 3's spelling is still read because the folders
+/// people already copied onto their disks are written in it, and a theme that stopped working
+/// because upstream moved on would be toe's bug, not theirs. The three keys toe actually paints
+/// with — `accent`, `background`, `foreground` — are spelled the same in both, which is why this
+/// change was a widening rather than a migration: nothing had to be translated to keep reading
+/// the old files, only looked for under a second name.
+///
+/// Their *values* mostly did not change either — `background` and `foreground` are identical in
+/// all nineteen themes that exist on both branches, and `accent` in eighteen of them. The
+/// exception is Kanagawa, whose accent Omarchy changed from `#7e9cd8` to `#dcd7ba` somewhere in
+/// the 4 series. That is an upstream theme edit rather than anything toe does, but it is the one
+/// case where following the new branch visibly recolours a border, and it is written down here so
+/// that the next person to notice it does not go looking for the bug in this file.
+///
 /// Hex strings rather than `RGBA`, because `BorderConfig` and `MenuConfig` hold hex strings:
 /// keeping them as text means applying a theme is an assignment, and leaves `Hex.rgba` in the one
 /// place it already lives — the layer that draws.
 ///
 /// Only three of these are read today. The rest are stored because the file is being mirrored and
 /// it costs nothing, so the day the workspace strip or the selected menu row wants a themed
-/// colour, `color4` is already here rather than being a second pass over everyone's themes.
+/// colour, `color4` — or `blue`, the same thing under Omarchy 4's name for it — is already here
+/// rather than being a second pass over everyone's themes.
 public struct Palette: Equatable, Sendable {
 
+    /// Whether the theme was drawn for a light desktop or a dark one — Omarchy 4's `mode`.
+    ///
+    /// Worth keeping even though nothing reads it yet, because it is the one thing in the file
+    /// that cannot be worked out from the colours with any confidence: five of the twenty-two
+    /// themes upstream are light, and `rose-pine` is one of them despite reading as a dark name.
+    public enum Mode: String, Equatable, Sendable {
+        case dark, light
+    }
+
+    // What toe paints with.
     public var accent: String
     public var background: String
     public var foreground: String
+
+    /// `mode` — Omarchy 4 only, and nil for a theme written in Omarchy 3's spelling.
+    public var mode: Mode?
+
+    // Omarchy 4's background ramp, darkest first.
+    public var darkerBackground: String?
+    public var darkBackground: String?
+    public var lighterBackground: String?
+
+    // Omarchy 4's foreground ramp, dimmest first.
+    public var darkForeground: String?
+    public var lightForeground: String?
+    public var brightForeground: String?
+
+    /// `selection` and `muted` — Omarchy 4's replacements for the `selection_*` pair.
+    public var selection: String?
+    public var muted: String?
+
+    // The two hues ANSI has no slot for, so they cannot live in `terminal`. Present in nineteen
+    // of the twenty-two themes upstream; the other three simply leave them out.
+    public var orange: String?
+    public var brown: String?
+
+    // Omarchy 3 only. Nothing in Omarchy 4's file corresponds to `cursor` at all, and mapping the
+    // `selection_*` pair onto `selection`/`muted` was rejected: they matched in three of nineteen
+    // themes, which is coincidence, not a mapping.
     public var cursor: String?
     public var selectionForeground: String?
     public var selectionBackground: String?
+
     /// `color0` … `color15`, sixteen slots, nil where the file left one out.
+    ///
+    /// Fed from whichever spelling the file used — see `ansiNames` for the mapping and for why
+    /// four of the slots are always nil under Omarchy 4.
     public var terminal: [String?]
 
     public init(accent: String, background: String, foreground: String,
+                mode: Mode? = nil,
+                darkerBackground: String? = nil,
+                darkBackground: String? = nil,
+                lighterBackground: String? = nil,
+                darkForeground: String? = nil,
+                lightForeground: String? = nil,
+                brightForeground: String? = nil,
+                selection: String? = nil,
+                muted: String? = nil,
+                orange: String? = nil,
+                brown: String? = nil,
                 cursor: String? = nil,
                 selectionForeground: String? = nil, selectionBackground: String? = nil,
                 terminal: [String?] = Array(repeating: nil, count: Palette.terminalSlots)) {
         self.accent = accent
         self.background = background
         self.foreground = foreground
+        self.mode = mode
+        self.darkerBackground = darkerBackground
+        self.darkBackground = darkBackground
+        self.lighterBackground = lighterBackground
+        self.darkForeground = darkForeground
+        self.lightForeground = lightForeground
+        self.brightForeground = brightForeground
+        self.selection = selection
+        self.muted = muted
+        self.orange = orange
+        self.brown = brown
         self.cursor = cursor
         self.selectionForeground = selectionForeground
         self.selectionBackground = selectionBackground
@@ -65,15 +147,56 @@ public struct Palette: Equatable, Sendable {
         return terminal[index]
     }
 
-    /// Every colour this palette actually carries, keyed the way the file keys them — so a test
-    /// can assert they all parse without naming each one, and a warning can name the one that
-    /// does not.
+    /// Which ANSI slot each of Omarchy 4's named hues is.
+    ///
+    /// Not a guess and not the ANSI table copied out of a manual: checked against all nineteen
+    /// themes Omarchy publishes on both `master` and `quattro`. Eleven of the twelve agree in
+    /// nineteen cases out of nineteen — `red` is `color1` and `bright_cyan` is `color14` in every
+    /// single theme — and that unanimity is the licence for reading one spelling as the other.
+    ///
+    /// `blue` is the twelfth, and agrees in eighteen. The exception is Retro 82, whose Omarchy 3
+    /// file put its orange accent `#faa968` in slot 4 and so had no blue in it at all; Omarchy 4
+    /// gives it a real one, `#3f8f8a`, and keeps the orange under `orange`. So the odd one out is
+    /// a theme upstream corrected, not a slot this mapping is unsure about.
+    ///
+    /// Slots 0, 7, 8 and 15 — ANSI's blacks and whites — are absent because Omarchy 4 publishes
+    /// no key that means them. `muted` lands on `color8` in eight of nineteen themes and
+    /// `lighter_background` on `color0` in six, and a mapping that is right a third of the time is
+    /// worse than a nil: nil is a slot a future caller can fall back from, and a wrong colour is
+    /// one it cannot.
+    public static let ansiNames: [Int: String] = [
+         1: "red",          2: "green",           3: "yellow",
+         4: "blue",         5: "magenta",         6: "cyan",
+         9: "bright_red",  10: "bright_green",   11: "bright_yellow",
+        12: "bright_blue", 13: "bright_magenta", 14: "bright_cyan",
+    ]
+
+    /// Every colour this palette actually carries, keyed the way `colors.toml` keys them — so a
+    /// test can assert they all parse without naming each one, and a warning can name the one
+    /// that does not.
+    ///
+    /// The terminal slots are listed under their numbered names whichever spelling they arrived
+    /// in, because the number is the thing that is stable: `color1` and `red` are one colour with
+    /// two names, and the palette no longer remembers which name the file on disk used.
     public var colours: [(key: String, value: String)] {
         var out: [(String, String)] = [("accent", accent), ("background", background),
                                        ("foreground", foreground)]
-        if let cursor { out.append(("cursor", cursor)) }
-        if let selectionForeground { out.append(("selection_foreground", selectionForeground)) }
-        if let selectionBackground { out.append(("selection_background", selectionBackground)) }
+        func add(_ key: String, _ value: String?) {
+            if let value { out.append((key, value)) }
+        }
+        add("darker_background", darkerBackground)
+        add("dark_background", darkBackground)
+        add("lighter_background", lighterBackground)
+        add("dark_foreground", darkForeground)
+        add("light_foreground", lightForeground)
+        add("bright_foreground", brightForeground)
+        add("selection", selection)
+        add("muted", muted)
+        add("orange", orange)
+        add("brown", brown)
+        add("cursor", cursor)
+        add("selection_foreground", selectionForeground)
+        add("selection_background", selectionBackground)
         for (index, colour) in terminal.enumerated() {
             if let colour { out.append(("color\(index)", colour)) }
         }
@@ -81,17 +204,46 @@ public struct Palette: Equatable, Sendable {
     }
 }
 
+/// Omarchy 4's names for the hues, for callers that would rather say `red` than remember that red
+/// is one. Reads across to whichever spelling the file used, so these answer for an Omarchy 3
+/// theme too.
+public extension Palette {
+    var red: String?            { color(1) }
+    var green: String?          { color(2) }
+    var yellow: String?         { color(3) }
+    var blue: String?           { color(4) }
+    var magenta: String?        { color(5) }
+    var cyan: String?           { color(6) }
+    var brightRed: String?      { color(9) }
+    var brightGreen: String?    { color(10) }
+    var brightYellow: String?   { color(11) }
+    var brightBlue: String?     { color(12) }
+    var brightMagenta: String?  { color(13) }
+    var brightCyan: String?     { color(14) }
+}
+
 public extension Palette {
 
-    /// Reads a `colors.toml`.
+    /// Reads a `colors.toml` in either of Omarchy's two spellings.
     ///
     /// `accent`, `background` and `foreground` are required, because they are the three toe
     /// actually paints with and a theme missing one of them would silently keep whatever colour
-    /// was there before. Everything else is optional.
+    /// was there before. Everything else is optional — which is also what makes reading both
+    /// spellings a matter of looking for more keys rather than of deciding which file this is:
+    /// the keys the other spelling does not have simply come back nil.
     ///
     /// Every colour is checked through `Hex.rgba` here rather than at the far end, so a typo is
     /// named while it still has a key beside it — `Hex.rgba` answers nil rather than substituting
     /// a colour precisely so that this layer can do that.
+    ///
+    /// Keys that are not read, deliberately: `hyprland_active_border`,
+    /// `hyprland_inactive_border`, `active_border_color` and `active_tab_background`, which a
+    /// handful of themes carry as per-app overrides. `hyprland_active_border` is the tempting one
+    /// — it is literally the border colour toe paints — and it is a Hyprland gradient string
+    /// rather than a colour: `"rgba(26a269ee) rgba(2ec27eee) 45deg"` in `hackerman`. Reading it as
+    /// a colour would throw `notAColour` and take three themes down with it, and reading it
+    /// properly would mean parsing Hyprland's gradient syntax to arrive at what `accent` already
+    /// says.
     static func parse(_ toml: String) throws -> Palette {
         let table = try TOML.parse(toml)
 
@@ -111,14 +263,39 @@ public extension Palette {
             return value
         }
 
+        // A `mode` that is neither `dark` nor `light` reads as nil rather than as an error: it is
+        // not a colour, nothing paints with it yet, and a third value arriving upstream should
+        // widen what toe knows rather than stop the theme from loading.
+        let mode = table["mode"]?.stringValue.flatMap(Mode.init(rawValue:))
+
+        // A numbered slot wins over the named hue where a file somehow has both — a hand-written
+        // palette, or one mid-conversion. `color0`…`color15` is the more specific statement of
+        // the two, since it names the slot rather than a colour that happens to sit in it.
+        let terminal = try (0..<Palette.terminalSlots).map { index -> String? in
+            if let numbered = try colour("color\(index)") { return numbered }
+            guard let name = Palette.ansiNames[index] else { return nil }
+            return try colour(name)
+        }
+
         return Palette(
             accent: try required("accent"),
             background: try required("background"),
             foreground: try required("foreground"),
+            mode: mode,
+            darkerBackground: try colour("darker_background"),
+            darkBackground: try colour("dark_background"),
+            lighterBackground: try colour("lighter_background"),
+            darkForeground: try colour("dark_foreground"),
+            lightForeground: try colour("light_foreground"),
+            brightForeground: try colour("bright_foreground"),
+            selection: try colour("selection"),
+            muted: try colour("muted"),
+            orange: try colour("orange"),
+            brown: try colour("brown"),
             cursor: try colour("cursor"),
             selectionForeground: try colour("selection_foreground"),
             selectionBackground: try colour("selection_background"),
-            terminal: try (0..<Palette.terminalSlots).map { try colour("color\($0)") }
+            terminal: terminal
         )
     }
 }

--- a/Sources/ToeCore/Theme/ThemeDownload.swift
+++ b/Sources/ToeCore/Theme/ThemeDownload.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// How far along the theme currently being fetched is, as the menu row drawing it needs it.
+///
+/// Lives here rather than in `ThemeDownloader` because this is the part with arithmetic in it —
+/// `BorderGeometry`'s reason for existing, applied again. The downloader reports what has
+/// arrived; turning that into a bar and a label is a decision, and a decision belongs where
+/// `make test` can reach it.
+///
+/// **Bytes, not files.** The first version of this counted finished files — a theme with seven
+/// pictures moved the bar in sevenths — and it was wrong in the way that mattered: the pictures
+/// run from ten kilobytes to four megabytes, so the bar jumped through the small ones and then
+/// sat still for as long as the largest took, which reads as a download that has stopped. The
+/// catalogue knows every picture's size, so the bar is spent bytes over total bytes and moves at
+/// something like the rate the download is actually going.
+public struct ThemeDownload: Equatable, Sendable {
+
+    /// Which theme, so the row that fills is the row you picked and not whichever one shares its
+    /// position in a list that has since been rebuilt.
+    public let slug: String
+    /// The picture being fetched, counting from one — so `fetching` and `total` read as "picture
+    /// 3 of 5", which is what the row's label says. Zero while the palette is being fetched,
+    /// before any picture is in flight.
+    public let fetching: Int
+    /// Pictures the catalogue said this theme has.
+    public let total: Int
+    /// Bytes accounted for: every picture already finished with, plus what has arrived of the one
+    /// in flight. "Finished with" rather than "successfully fetched" — a picture toe skipped or
+    /// failed on counts too, because the bar measures progress through the work rather than
+    /// bytes on the disk, and a bar that could never reach its end because one picture 404'd
+    /// would be the original complaint again in a rarer costume.
+    public let bytesDone: Int
+    /// What the catalogue said the pictures add up to. The palette is not in here: it is under a
+    /// kilobyte against megabytes of photographs, and giving it a share of the bar it could not
+    /// visibly fill only moved the arithmetic further from what the eye sees.
+    public let bytesTotal: Int
+
+    public init(slug: String, fetching: Int, total: Int, bytesDone: Int, bytesTotal: Int) {
+        self.slug = slug
+        self.fetching = max(0, fetching)
+        self.total = max(0, total)
+        self.bytesDone = max(0, bytesDone)
+        self.bytesTotal = max(0, bytesTotal)
+    }
+
+    /// 0…1, clamped.
+    ///
+    /// Clamped because both numbers come off the network: the catalogue's idea of a picture's
+    /// size is a cached claim about somebody else's repository, and the count of bytes received
+    /// is the transfer's own. They disagree by a little often and by a lot occasionally, and
+    /// neither a bar running out of the panel nor one running backwards is worth being faithful
+    /// to a bad number over.
+    ///
+    /// A theme with no pictures reads zero throughout. Its download is one small file and is over
+    /// before the row could draw anything, so there is nothing a fraction could usefully say.
+    public var fraction: Double {
+        guard bytesTotal > 0 else { return 0 }
+        return min(1, max(0, Double(bytesDone) / Double(bytesTotal)))
+    }
+
+    /// `3/5`, or nil while there is nothing to count — the palette step, and a theme that has no
+    /// pictures at all. A row that said `0/0` would be a row asking to be read twice.
+    ///
+    /// The number names the picture *being fetched* rather than the last one finished, which is
+    /// why it ends on `5/5` and not `4/5`: the label says what is happening and the bar says how
+    /// much of it is done, so the two deliberately do not agree until the end.
+    public var label: String? {
+        guard total > 0, fetching > 0 else { return nil }
+        return "\(fetching)/\(total)"
+    }
+}

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -1832,6 +1832,210 @@ h.test("the second column never runs into the title") { t in
             "a title longer than the row leaves nothing rather than a negative width")
 }
 
+// MARK: - A download, in the menu
+
+/// A Theme level mid-download: two themes on disk, two to be had, and Solitude being fetched.
+///
+/// Solitude's five pictures are deliberately lopsided — 100 KB, 100 KB, 100 KB, 100 KB and 4 MB —
+/// because that is the shape upstream actually has and the shape the first version of the bar got
+/// wrong. Uniform steps put four fifths of the bar behind a tenth of the bytes.
+let solitudePictures = [100_000, 100_000, 100_000, 100_000, 4_000_000]
+
+func downloadingStyle(fetching: Int, bytesDone: Int) -> StyleMenu {
+    let pictures = solitudePictures.enumerated().map {
+        RemoteFile(name: "\($0.offset)-x.webp", bytes: $0.element)
+    }
+    return StyleMenu(themes: [ThemeRef(slug: "gruvbox", name: "Gruvbox"),
+                              ThemeRef(slug: "nord", name: "Nord")],
+                     available: [RemoteTheme(slug: "solitude", name: "Solitude",
+                                             backgrounds: pictures),
+                                 RemoteTheme(slug: "lupine", name: "Lupine",
+                                             backgrounds: [RemoteFile(name: "0-y.webp",
+                                                                      bytes: 400_000)])],
+                     current: "gruvbox",
+                     downloading: ThemeDownload(slug: "solitude", fetching: fetching, total: 5,
+                                                bytesDone: bytesDone,
+                                                bytesTotal: solitudePictures.reduce(0, +)))
+}
+
+h.test("the bar measures bytes, so it does not race through the small pictures") { t in
+    let total = solitudePictures.reduce(0, +)          // 4.4 MB, of which the last is 4 MB
+    func at(_ bytesDone: Int) -> Double {
+        ThemeDownload(slug: "solitude", fetching: 1, total: 5,
+                      bytesDone: bytesDone, bytesTotal: total).fraction
+    }
+    // Four small pictures down and only the big one left. Counting files this was four fifths
+    // done; in bytes it is under a tenth, which is the truth — and the difference is exactly the
+    // stall the first version showed at the end.
+    t.expect(at(400_000) < 0.1, "four of five pictures is under a tenth of the bytes")
+    t.equal(at(total / 2), 0.5, "halfway through the bytes is halfway along the bar")
+    t.equal(at(total), 1, "and all of them fills it")
+
+    // The last picture arriving is most of the bar, and it arrives continuously — which is the
+    // point of reporting bytes while a transfer is running rather than only when it ends.
+    t.expect(at(400_000 + 2_000_000) > 0.5, "halfway into the last picture is past halfway")
+}
+
+h.test("a download's bar reaches its end") { t in
+    let total = solitudePictures.reduce(0, +)
+    // The complaint this fixes: every report but the last is sent before or during a transfer,
+    // so without a last word the final state the row ever drew was however much of the last
+    // picture had arrived when it was last asked.
+    let last = ThemeDownload(slug: "solitude", fetching: 5, total: 5,
+                             bytesDone: total, bytesTotal: total)
+    t.equal(last.fraction, 1, "the last word fills the row")
+    t.equal(last.label, "5/5", "with the count to match")
+
+    // Both numbers come off the network and can disagree.
+    t.equal(ThemeDownload(slug: "a", fetching: 1, total: 1,
+                          bytesDone: 9_000_000, bytesTotal: 1_000_000).fraction, 1,
+            "a transfer heavier than advertised fills the row rather than overrunning it")
+    t.equal(ThemeDownload(slug: "a", fetching: 1, total: 1,
+                          bytesDone: -5, bytesTotal: 1_000).fraction, 0, "and clamped below")
+    t.equal(ThemeDownload(slug: "a", fetching: 0, total: 0,
+                          bytesDone: 0, bytesTotal: 0).fraction, 0,
+            "a theme with no pictures has no fraction to draw and is over at once")
+}
+
+h.test("a download's label names the picture in flight, not the last one finished") { t in
+    t.equal(ThemeDownload(slug: "a", fetching: 0, total: 5,
+                          bytesDone: 0, bytesTotal: 100).label, nil,
+            "the palette step has nothing to count yet, so the row keeps showing its size")
+    t.equal(ThemeDownload(slug: "a", fetching: 3, total: 5,
+                          bytesDone: 40, bytesTotal: 100).label, "3/5",
+            "then it names what is being fetched")
+    // The label and the bar deliberately disagree until the end: one says what is happening, the
+    // other how much of it is done.
+    let mid = ThemeDownload(slug: "a", fetching: 5, total: 5, bytesDone: 10, bytesTotal: 100)
+    t.equal(mid.label, "5/5", "the last picture is in flight")
+    t.expect(mid.fraction < 0.2, "while the bar is still near the start of it")
+}
+
+h.test("the theme being downloaded is the row that fills") { t in
+    let rows = MenuModel.themes(downloadingStyle(fetching: 3, bytesDone: 200_000))
+    guard let solitude = rows.first(where: { $0.title == "Solitude" }),
+          let lupine = rows.first(where: { $0.title == "Lupine" }),
+          let gruvbox = rows.first(where: { $0.title == "Gruvbox" }) else {
+        return t.expect(false, "all three themes should have rows")
+    }
+    t.equal(solitude.progress, 200_000.0 / 4_400_000,
+            "the one being fetched carries the fraction, in bytes")
+    // The size was there to say what you were about to spend; once you have spent it the
+    // question has become how much longer.
+    t.equal(solitude.value, "3/5", "and trades its size for the count")
+    t.equal(lupine.progress, nil, "the other themes on offer are untouched")
+    t.equal(lupine.value, "0.4 MB", "and still say what they cost")
+    t.equal(gruvbox.progress, nil, "as is the one already on disk")
+    t.equal(gruvbox.value, "current", "which still says it is the one in effect")
+
+    // Nothing downloading is the ordinary case, and no row should carry a fraction in it.
+    let idle = MenuModel.themes(StyleMenu(themes: [], available: [
+        RemoteTheme(slug: "solitude", name: "Solitude", backgrounds: []),
+    ]))
+    t.equal(idle.compactMap { $0.progress }.count, 0, "with nothing being fetched, no row fills")
+}
+
+h.test("choosing a theme leaves the menu up, and everything else dismisses it") { t in
+    // Two reasons, pointing the same way: a theme toe has not got is being *fetched*, and the
+    // filling row is the only thing reporting it; and a theme recolours the menu itself, so
+    // staying put turns the list into something you can look through rather than commit to.
+    t.equal(Command.theme("solitude").keepsMenuOpen, true, "a theme to be downloaded stays")
+    t.equal(Command.theme("gruvbox").keepsMenuOpen, true, "and so does one already on disk")
+    t.equal(Command.theme("").keepsMenuOpen, true,
+            "`Your own colours` is the way back, and a way back you must reopen the menu to use "
+            + "is not much of one")
+
+    // A wallpaper is behind the panel rather than in it: nothing to restyle, nothing being
+    // fetched, and the picture is the whole of what changed.
+    t.equal(Command.background("1-a.jpg").keepsMenuOpen, false, "backgrounds still close")
+    t.equal(Command.nextBackground.keepsMenuOpen, false, "including stepping through them")
+    // The rest want the panel gone and the keyboard handed back before they begin.
+    t.equal(Command.quit.keepsMenuOpen, false, "quit tears the process down")
+    t.equal(Command.reload.keepsMenuOpen, false, "a reload is over before you could look at it")
+    t.equal(Command.exec("ghostty").keepsMenuOpen, false, "an exec brings something else forward")
+    t.equal(Command.killActive.keepsMenuOpen, false,
+            "and a window command acts on a window you cannot see past the menu")
+}
+
+h.test("a filling row is the row cut off at the fraction") { t in
+    let m = MenuMetrics(lineHeight: 22)
+    let row = MenuLayout.rowFrame(0, width: 400, m)
+    t.equalBox(MenuLayout.progressFrame(inRow: row, fraction: 0.5),
+               Box(x: row.x, y: row.y, w: row.w / 2, h: row.h),
+               "half the row, from its own left edge and its full height")
+    t.equalBox(MenuLayout.progressFrame(inRow: row, fraction: 0),
+               Box(x: row.x, y: row.y, w: 0, h: row.h), "nothing at nothing")
+    t.equalBox(MenuLayout.progressFrame(inRow: row, fraction: 1), row, "and the whole row at one")
+    // The fraction comes from arithmetic over a count off the network.
+    t.equalBox(MenuLayout.progressFrame(inRow: row, fraction: 4),
+               row, "a fraction past one fills the row rather than running out of the panel")
+    t.equalBox(MenuLayout.progressFrame(inRow: row, fraction: -1),
+               Box(x: row.x, y: row.y, w: 0, h: row.h), "and one below zero draws nothing")
+}
+
+h.test("rebuilding under an open menu leaves you where you were standing") { t in
+    var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: [],
+                                           style: downloadingStyle(fetching: 1, bytesDone: 0)), visibleRows: 10)
+    // Down into Style › Theme, the way a user gets there.
+    while m.selectedItem?.title != "Style" { m.move(by: 1) }
+    t.equal(m.activate(), .pushed, "into Style")
+    while m.selectedItem?.title != "Theme" { m.move(by: 1) }
+    t.equal(m.activate(), .pushed, "and into Theme")
+    while m.selectedItem?.title != "Solitude" { m.move(by: 1) }
+    let standingOn = m.selection
+    t.equal(m.selectedItem?.progress, 0, "the row under the cursor is filling from nothing")
+
+    // A picture lands. The whole tree is rebuilt, because the level in front of the user is two
+    // rungs down and the menu cannot know which of MenuModel's builders made it.
+    m.rebuild(root: MenuModel.root(loginItem: .off, bindings: [],
+                                   style: downloadingStyle(fetching: 5, bytesDone: 2_400_000)))
+    t.equal(m.breadcrumb, ["Style", "Theme"], "still on the level it was on")
+    t.equal(m.selection, standingOn, "still on the row it was on")
+    t.equal(m.selectedItem?.title, "Solitude", "which is still the same row")
+    t.equal(m.selectedItem?.progress, 2_400_000.0 / 4_400_000, "and it has filled further")
+    t.equal(m.selectedItem?.value, "5/5", "with the count to match")
+}
+
+h.test("a rebuild that cannot re-enter a level surfaces one rung up") { t in
+    // Background exists only while the current theme has pictures, so changing to a theme with
+    // none takes the level the user is standing in out from under them. Real, not defensive.
+    let withPictures = StyleMenu(themes: [ThemeRef(slug: "gruvbox", name: "Gruvbox")],
+                                 current: "gruvbox", backgrounds: ["1-a.jpg", "2-b.jpg"])
+    var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: [], style: withPictures),
+                      visibleRows: 10)
+    while m.selectedItem?.title != "Style" { m.move(by: 1) }
+    _ = m.activate()
+    while m.selectedItem?.title != "Background" { m.move(by: 1) }
+    _ = m.activate()
+    t.equal(m.breadcrumb, ["Style", "Background"], "standing in Background")
+    t.equal(m.visible.count, 3, "two pictures and the row that steps through them")
+
+    let withNone = StyleMenu(themes: [ThemeRef(slug: "vantablack", name: "Vantablack")],
+                             current: "vantablack")
+    m.rebuild(root: MenuModel.root(loginItem: .off, bindings: [], style: withNone))
+    // Not an error and not an empty level: the deepest level that still exists.
+    t.equal(m.breadcrumb, ["Style"], "the level went away, so the user comes up to Style")
+    t.equal(m.visible.map(\.title), ["Theme"], "which no longer offers Background at all")
+    t.expect(m.selection < m.visible.count, "and the selection is inside the level it landed on")
+}
+
+h.test("the fetching note appears and goes away without the menu being reopened") { t in
+    var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: [],
+                                           style: StyleMenu(fetching: true)), visibleRows: 10)
+    while m.selectedItem?.title != "Style" { m.move(by: 1) }
+    _ = m.activate()
+    while m.selectedItem?.title != "Theme" { m.move(by: 1) }
+    _ = m.activate()
+    t.equal(m.visible.map(\.title), ["Fetching Omarchy's themes…", "Your own colours"],
+            "a machine with nothing yet, mid-fetch")
+
+    // The catalogue arrives. This is what `ThemeCatalogue.onChange` now reaches.
+    m.rebuild(root: MenuModel.root(loginItem: .off, bindings: [], style: StyleMenu(
+        available: [RemoteTheme(slug: "nord", name: "Nord", backgrounds: [])], fetching: false)))
+    t.equal(m.visible.map(\.title), ["Nord", "Your own colours"],
+            "the note gives way to the themes it was waiting for")
+}
+
 h.test("the selection clamps at both ends") { t in
     var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 10)
     m.move(by: -1)
@@ -2085,6 +2289,45 @@ color14 = "#0db9d7"
 color15 = "#acb0d0"
 """
 
+/// The same theme, in the spelling Omarchy 4 publishes it in — `themes/tokyo-night/colors.toml`
+/// on the `quattro` branch, verbatim. Held beside the Omarchy 3 file above rather than replacing
+/// it, because both are files toe has to read: this one is what a download fetches today, and
+/// that one is what is already sitting in `~/.config/toe/themes` on the disk of anybody who
+/// copied a theme across before Omarchy 4.
+let tokyoNightColors4 = """
+mode = "dark"
+
+accent = "#7aa2f7"
+selection = "#292e42"
+muted = "#414868"
+
+background = "#1a1b26"
+dark_background = "#13141c"
+darker_background = "#0e0e14"
+lighter_background = "#24283b"
+
+foreground = "#a9b1d6"
+dark_foreground = "#565f89"
+light_foreground = "#b4bee6"
+bright_foreground = "#c0caf5"
+
+red = "#f7768e"
+yellow = "#e0af68"
+orange = "#eb927b"
+green = "#9ece6a"
+cyan = "#449dab"
+blue = "#7aa2f7"
+magenta = "#ad8ee6"
+brown = "#75493d"
+
+bright_red = "#ff7a93"
+bright_yellow = "#ff9e64"
+bright_green = "#b9f27c"
+bright_cyan = "#0db9d7"
+bright_blue = "#7da6ff"
+bright_magenta = "#bb9af7"
+"""
+
 /// Two themes to test against, built here rather than taken from toe. toe ships none: a theme is
 /// somebody else's work, and the list you choose from is what you have on disk plus what Omarchy
 /// publishes. So the fixtures below are exactly that — a theme somebody downloaded.
@@ -2124,6 +2367,119 @@ h.test("a theme missing a colour toe paints with is refused rather than guessed 
         t.equal(error as? PaletteError, .notAColour(key: "accent", value: "blue"),
                 "a colour that will not parse is named with what was there, as Hex.rgba's nil intends")
     }
+}
+
+h.test("Omarchy 4's colors.toml is read too, key for key") { t in
+    guard let p = try? Palette.parse(tokyoNightColors4) else {
+        return t.expect(false, "the Omarchy 4 Tokyo Night palette should parse")
+    }
+    // The three toe paints with are spelled the same in both files, and for this theme they carry
+    // the same values too — so following the new branch left Tokyo Night's border alone. It is
+    // not true of every theme: Kanagawa's accent changed upstream between the two, which is an
+    // Omarchy edit rather than anything this parser does.
+    t.equal(p.accent, "#7aa2f7", "accent is still accent")
+    t.equal(p.background, "#1a1b26", "as is background")
+    t.equal(p.foreground, "#a9b1d6", "and foreground")
+
+    t.equal(p.mode, .dark, "and mode is read, which Omarchy 3 never said")
+    t.equal(p.darkerBackground, "#0e0e14", "the background ramp lands, darkest first")
+    t.equal(p.darkBackground, "#13141c", "then dark")
+    t.equal(p.lighterBackground, "#24283b", "then lighter")
+    t.equal(p.darkForeground, "#565f89", "and the foreground ramp with it")
+    t.equal(p.lightForeground, "#b4bee6", "light")
+    t.equal(p.brightForeground, "#c0caf5", "and bright")
+    t.equal(p.selection, "#292e42", "selection replaces the selection_* pair")
+    t.equal(p.muted, "#414868", "and muted beside it")
+
+    // Two hues with no ANSI slot to live in, which is the whole reason they are stored by name.
+    t.equal(p.orange, "#eb927b", "orange has no terminal slot and is kept anyway")
+    t.equal(p.brown, "#75493d", "nor does brown")
+
+    // Nothing in Omarchy 4's file means any of these, and a nil is the honest answer.
+    t.equal(p.cursor, nil, "cursor is gone from the format, not defaulted to something")
+    t.equal(p.selectionForeground, nil, "and the keys it replaced are not invented back")
+    t.equal(p.selectionBackground, nil, "either of them")
+}
+
+h.test("a named hue and a numbered slot are the same colour under two names") { t in
+    guard let three = try? Palette.parse(tokyoNightColors),
+          let four = try? Palette.parse(tokyoNightColors4) else {
+        return t.expect(false, "both spellings of Tokyo Night should parse")
+    }
+    // The mapping in `Palette.ansiNames` is only allowed to exist because this holds — checked
+    // here on the one theme, and checked against all nineteen that exist on both of Omarchy's
+    // branches before it was written down.
+    for index in Palette.ansiNames.keys.sorted() {
+        t.equal(four.color(index), three.color(index),
+                "color\(index) is the same colour whichever file it came from")
+    }
+    t.equal(four.red, three.color(1), "and red is reachable under its own name")
+    t.equal(four.brightCyan, three.color(14), "as is bright_cyan")
+    t.equal(four.blue, four.accent, "Tokyo Night's accent is its blue, in both")
+
+    // ANSI's black and white ends have no Omarchy 4 key at all. `muted` and `lighter_background`
+    // sit near them in some themes and nowhere near them in most, so the slots stay empty: a
+    // caller can fall back from a nil and cannot fall back from a wrong colour.
+    for index in [0, 7, 8, 15] {
+        t.equal(four.color(index), nil, "slot \(index) has no Omarchy 4 key and is left empty")
+        t.expect(three.color(index) != nil, "though Omarchy 3 filled it")
+    }
+    t.equal(four.terminal.compactMap { $0 }.count, 12, "twelve of the sixteen land")
+    t.equal(three.terminal.compactMap { $0 }.count, 16, "against all sixteen from the older file")
+}
+
+h.test("a numbered slot wins over the named hue where a file has both") { t in
+    // A hand-written palette, or one caught mid-conversion. `color1` names the slot; `red` names
+    // a colour that usually sits in it, so the slot is the more specific of the two.
+    let both = """
+    accent = "#111111"
+    background = "#222222"
+    foreground = "#333333"
+    color1 = "#aaaaaa"
+    red = "#bbbbbb"
+    """
+    guard let p = try? Palette.parse(both) else {
+        return t.expect(false, "it should parse")
+    }
+    t.equal(p.color(1), "#aaaaaa", "the numbered slot is the one that lands")
+    t.equal(p.red, "#aaaaaa", "and reading it by name gives the same answer")
+}
+
+h.test("a theme's Hyprland overrides are left alone rather than read as colours") { t in
+    // `hackerman` carries this, and it is a Hyprland gradient rather than a colour. It is also
+    // the most tempting key in the file — literally the border colour — which is why the test
+    // exists: reading it would throw `notAColour` and take the theme down with it.
+    let hackerman = """
+    accent = "#82FB9C"
+    background = "#0B0C16"
+    foreground = "#ddf7ff"
+    hyprland_active_border = "rgba(26a269ee) rgba(2ec27eee) 45deg"
+    hyprland_inactive_border = "rgb(1e1e1e)"
+    active_border_color = "#f2fcff"
+    active_tab_background = "#6fb8e3"
+    """
+    guard let p = try? Palette.parse(hackerman) else {
+        return t.expect(false, "a theme with per-app overrides in it should still parse")
+    }
+    t.equal(p.accent, "#82FB9C", "the accent is read, uppercase hex and all")
+    t.equal(p.colours.contains { $0.key.hasPrefix("hyprland_") }, false,
+            "and Hyprland's own keys are not among the colours toe carries")
+}
+
+h.test("a mode toe does not recognise leaves the theme usable") { t in
+    // Not an error: `mode` is not a colour, nothing paints with it yet, and a third value
+    // arriving upstream should widen what toe knows rather than stop a theme from loading.
+    let odd = """
+    mode = "sepia"
+    accent = "#111111"
+    background = "#222222"
+    foreground = "#333333"
+    """
+    guard let p = try? Palette.parse(odd) else {
+        return t.expect(false, "it should still parse")
+    }
+    t.equal(p.mode, nil, "the mode is simply not known")
+    t.equal(p.accent, "#111111", "and the colours are all still there")
 }
 
 // MARK: - The catalogue
@@ -2233,6 +2589,34 @@ h.test("a catalogue goes stale, and a clock that jumped reads as stale too") { t
     // cheap answer; treating it as fresh would wedge the list until the skew passed.
     let future = Catalogue(fetchedAt: now.addingTimeInterval(3600), themes: [])
     t.equal(future.isStale(now: now, maxAge: 86400), true, "a stamp in the future is not fresh")
+}
+
+h.test("a catalogue written before the move to Omarchy 4 is not mistaken for a current one") { t in
+    // The real shape of a stale one, cut down from a catalogue.json this machine had actually
+    // written against Omarchy's `master` branch. What makes it unusable is not its age: the
+    // pictures it names were renamed when Omarchy 4 re-encoded them, so downloading White from
+    // this listing would ask for `1-white.jpg` and get a 404 partway through.
+    let old = Data("""
+    {"version":1,"fetchedAt":"2026-09-03T12:15:55Z","themes":[
+      {"slug":"white","name":"White","backgrounds":[{"name":"1-white.jpg","bytes":1229622}]}
+    ]}
+    """.utf8)
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    guard let decoded = try? decoder.decode(Catalogue.self, from: old) else {
+        return t.expect(false, "an old catalogue should still decode — it is refused, not unreadable")
+    }
+    t.equal(decoded.version, 1, "it reads back as the version it was written at")
+    t.expect(decoded.version != Catalogue.currentVersion,
+             "which is not the current one, so ThemeCatalogue.load discards it and refetches")
+    // Stated as the number rather than just "not current", so that a future bump has to come
+    // past this line and say what it is invalidating.
+    t.equal(Catalogue.currentVersion, 2, "2 since the move from master to quattro")
+
+    // A catalogue toe wrote itself is current by construction — the bump must not be reachable
+    // by forgetting to set the field.
+    t.equal(Catalogue(fetchedAt: Date(), themes: []).version, Catalogue.currentVersion,
+            "and a freshly built one is always current")
 }
 
 h.test("a byte count reads the way a menu row needs it to") { t in

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -40,10 +40,11 @@ final class Coordinator: WindowTrackerDelegate {
     /// reload, and from `runtimeWarnings`, which is for things that have gone wrong: this is
     /// progress, and it clears itself when it finishes.
     ///
-    /// Two strings because two surfaces show it and they have different room. `bar` goes in the
-    /// menu bar strip, which is where you will actually see it; `note` goes in the tooltip
-    /// behind it, which has room to say it properly.
-    private var progress: (bar: String, note: String)?
+    /// One value rather than the pair of pre-built strings this used to hold. Both of those were
+    /// for the menu bar — the strip and the tooltip behind it — and the menu bar has stopped
+    /// saying anything about a download: the quick menu fills the row instead, and a row wants
+    /// the numbers, not a sentence. It doubles as the one-download-at-a-time latch.
+    private var downloading: ThemeDownload?
     /// The current theme's pictures, in cycle order, and where in that cycle we are.
     private var backgrounds: [String] = []
     private var currentBackground: String?
@@ -121,8 +122,10 @@ final class Coordinator: WindowTrackerDelegate {
         writeDefaultConfigIfMissing()
         loadConfig(force: true)
 
-        // Starting and finishing both change what the menu bar should say.
-        available.onChange = { [weak self] in self?.refreshStatus() }
+        // Starting and finishing both change what the Theme level says — the note row appears
+        // and then gives way to the themes it was waiting for, without the menu having to be
+        // closed and opened again to notice.
+        available.onChange = { [weak self] in self?.refreshMenu() }
 
         watcher = ConfigWatcher(url: Coordinator.configURL)
         watcher?.onChange = { [weak self] in self?.loadConfig() }
@@ -342,6 +345,10 @@ final class Coordinator: WindowTrackerDelegate {
         applySessionSetting()
 
         refreshStatus()
+        // The theme may have changed under an open menu — most often because a download just
+        // finished and `setTheme` wrote it — so the row that is now `current` says so without
+        // waiting for the menu to be reopened.
+        refreshMenu()
         Log.info("config loaded: \(config.bindings.count) binding(s), \(warnings.count) warning(s)")
         for warning in warnings { Log.error("config: \(warning)") }
         desired.removeAll()
@@ -497,17 +504,27 @@ final class Coordinator: WindowTrackerDelegate {
     /// level draws from the catalogue already on disk, the request runs behind it, and what it
     /// finds is there the next time you look. `refreshIfStale` does nothing unless the list is
     /// missing or a day old.
-    private func styleMenu() -> StyleMenu {
-        available.refreshIfStale()
-        let (installed, offer) = Themes.merged(installed: ThemeStore.installed(),
-                                               available: available.themes)
-        themes = installed
+    /// - Parameter opening: true when the menu is being opened — the act that asks for a
+    ///   catalogue and for a fresh look at the themes directory. False when this is being rebuilt
+    ///   underneath an *open* menu, where it runs six times a second for as long as a download
+    ///   lasts: neither the directory nor the catalogue can change under it in that time, and two
+    ///   directory listings at that rate is work for nothing. The stored `themes` and
+    ///   `backgrounds` are what the last real look found, and `download`'s completion sets
+    ///   `themes` itself before asking for a reload, so a theme that has just landed is in them.
+    private func styleMenu(opening: Bool = true) -> StyleMenu {
         let current = config.theme.name.isEmpty ? nil : config.theme.name
-        if let current { backgrounds = ThemeStore.backgrounds(named: current) }
+        if opening {
+            available.refreshIfStale()
+            themes = ThemeStore.installed()
+            if let current { backgrounds = ThemeStore.backgrounds(named: current) }
+        }
+        let (installed, offer) = Themes.merged(installed: themes, available: available.themes)
+        themes = installed
         return StyleMenu(themes: installed, available: offer,
                          fetching: available.isFetching,
                          current: current,
-                         backgrounds: backgrounds, currentBackground: currentBackground)
+                         backgrounds: backgrounds, currentBackground: currentBackground,
+                         downloading: downloading)
     }
 
     /// Writes the theme into your config rather than holding it in memory, so it survives a
@@ -549,27 +566,36 @@ final class Coordinator: WindowTrackerDelegate {
         loadConfig(force: true)
     }
 
-    /// Fetches a theme, then sets it — the menu having already closed, as it does for any row.
+    /// Fetches a theme, then sets it.
     ///
-    /// The progress goes to the menu bar item's tooltip, which is the only surface toe has for
-    /// saying something while nothing is on screen. Nine megabytes over a slow connection is long
-    /// enough that silence would read as nothing having happened.
+    /// The menu is still up — `Command.keepsMenuOpen` is true for every theme row — and the
+    /// theme's own row fills as the pictures arrive. That is the only thing toe says about a
+    /// download now: nine megabytes over a slow connection is long enough that silence would
+    /// read as nothing having happened, and the row is where the spending was described in the
+    /// first place, so it is where the eye already is.
+    ///
+    /// Dismissing the menu does not cancel anything — the fetch is on a utility queue and knows
+    /// nothing about the panel. What it costs is the progress: close the menu and the download
+    /// finishes unwatched, announcing itself by the screen changing colour. That is the accepted
+    /// price of taking the strip out of the menu bar.
     private func download(_ theme: RemoteTheme) {
-        guard progress == nil else {
+        guard downloading == nil else {
             Log.error("themes: already fetching something")
             return
         }
-        progress = (bar: theme.name, note: "Fetching \(theme.name)…")
-        refreshStatus()
+        downloading = ThemeDownload(slug: theme.slug, fetching: 0,
+                                    total: theme.backgrounds.count,
+                                    bytesDone: 0, bytesTotal: theme.bytes)
+        refreshMenu()
 
         ThemeDownloader.fetch(theme, into: ThemeStore.directory,
                               progress: { [weak self] step in
-                                  self?.progress = Coordinator.describe(step)
-                                  self?.refreshStatus()
+                                  self?.downloading = step
+                                  self?.refreshMenu()
                               },
                               completion: { [weak self] result in
             guard let self else { return }
-            self.progress = nil
+            self.downloading = nil
             switch result {
             case .success:
                 Log.info("themes: fetched \(theme.slug)")
@@ -578,27 +604,27 @@ final class Coordinator: WindowTrackerDelegate {
                 // and the same reload.
                 self.themes = ThemeStore.installed()
                 self.setTheme(theme.slug)
+                // And then unconditionally, rather than trusting the reload inside `setTheme` to
+                // have happened. It has five early returns — no such theme, the config
+                // unreadable, the line already naming this theme, the rewritten file failing its
+                // own parse, the write refused — and on every one of them there is no reload and
+                // so no refresh. `downloading` is nil by here, so a menu that went unrefreshed
+                // would keep drawing the last progress it was handed: a row stopped part-filled,
+                // which is the one thing a finished download must not look like.
+                //
+                // The third of those returns is not hypothetical. Delete a theme's folder while
+                // your config still names it, then fetch it again from the menu — a normal thing
+                // to do to replace a theme — and the line needs no change, so nothing reloads.
+                self.refreshMenu()
             case .failure(let why):
                 self.runtimeWarnings.append("\(theme.name) could not be fetched: \(why)")
                 Log.error("themes: \(theme.slug): \(why)")
+                // The tooltip still carries a failure — that is a thing that went wrong rather
+                // than progress, and the row it happened on has gone back to saying its size.
                 self.refreshStatus()
+                self.refreshMenu()
             }
         })
-    }
-
-    /// A download step as the two surfaces want it.
-    ///
-    /// The fraction is left off while the palette is being fetched — one small file, before there
-    /// is a count worth showing — so the bar reads `⟳ Gruvbox` for a moment and then starts
-    /// counting. A theme with no pictures never gets a fraction at all, which is right: there is
-    /// nothing to count.
-    private static func describe(_ step: ThemeDownloader.Progress)
-    -> (bar: String, note: String) {
-        guard step.total > 0, step.done > 0 else {
-            return (bar: step.theme, note: "Fetching \(step.theme)…")
-        }
-        return (bar: "\(step.theme) \(step.done)/\(step.total)",
-                note: "Fetching \(step.theme) — picture \(step.done) of \(step.total)…")
     }
 
     private func setBackground(_ file: String) {
@@ -679,18 +705,27 @@ final class Coordinator: WindowTrackerDelegate {
     }
 
     private func refreshStatus() {
-        // `progress` leads, because it is the thing happening now and the other two are things
-        // that have already gone wrong. It is the only line here that goes away by itself.
-        // A download wins the strip if both are happening: it is the long one, and the one you
-        // asked for. The catalogue is kept out of `progress` itself because that doubles as the
-        // one-download-at-a-time latch, and a list refresh must not hold it.
-        let showing = progress ?? (available.isFetching
-                                   ? (bar: "themes", note: "Fetching Omarchy's themes…")
-                                   : nil)
+        // No progress line any more. Both things that used to put one here — a theme downloading
+        // and the catalogue being fetched — are said in the quick menu now, the first by the
+        // theme's own row filling and the second by the note row that was always there. The strip
+        // is back to workspaces and the tooltip to things that have gone wrong, which is what the
+        // menu bar is for: `⟳ Gruvbox 3/6` was a second, worse copy of a list the menu draws
+        // properly, and it was on screen at the moment the user was looking at the menu anyway.
         status.update(workspaces: workspaceStates(),
-                      warnings: [showing?.note].compactMap { $0 } + warnings + runtimeWarnings,
-                      accessibilityGranted: AXIsProcessTrusted(),
-                      progress: showing?.bar)
+                      warnings: warnings + runtimeWarnings,
+                      accessibilityGranted: AXIsProcessTrusted())
+    }
+
+    /// Pushes the theme state into the menu, if it is open.
+    ///
+    /// Separate from `refreshStatus` and deliberately not called from it: `refreshStatus` runs on
+    /// every focus change, and this rebuilds the menu's whole tree and re-lays the panel out.
+    /// Called only where what the menu draws has actually changed — a download starting,
+    /// stepping on, finishing or failing; the catalogue arriving; and a reload, which is what
+    /// carries a newly applied theme's colours into the panel as well as its `current` marker.
+    private func refreshMenu() {
+        guard quickMenu.isVisible else { return }
+        quickMenu.update(config: config, style: styleMenu(opening: false))
     }
 
     /// What the strip in the menu bar title draws. This runs on every focus change and every

--- a/Sources/toe/ThemeCatalogue.swift
+++ b/Sources/toe/ThemeCatalogue.swift
@@ -8,17 +8,29 @@ import ToeCore
 /// catalogue is fetched when you open `Style › Theme` and at most once a day, and a theme is
 /// downloaded only when you choose it.
 enum Upstream {
-    /// The numeric id rather than `basecamp/omarchy`, because the repository has been renamed
-    /// once already and an id does not move.
+    /// The numeric id rather than `omacom/omarchy`, because the repository has now been renamed
+    /// twice — `basecamp` to `omacom` — and an id does not move. The owner still has to be spelled
+    /// out for `raw.githubusercontent.com`, which takes a path and not an id; that one is the
+    /// current name, and GitHub keeps serving the old one, so a rename shows up as a stale
+    /// string here rather than as a broken download.
     static let repository = "994093166"
-    static let branch = "master"
+
+    /// Omarchy 4's branch, and the repository's default. Not `master`, which is where toe looked
+    /// first and which stopped moving at Omarchy 3.8.5 in August 2026: every release from
+    /// v3.8.4 onwards has been cut from `quattro`, and the three themes added since — Last
+    /// Horizon, Lupine, Solitude — exist only here. The catalogue and the palette both had to
+    /// learn something for this: the backgrounds were mostly re-encoded to webp and renumbered,
+    /// which is why `Catalogue.currentVersion` went up rather than letting a cached listing point
+    /// at files that are no longer there, and `colors.toml` was rewritten, which `Palette.parse`
+    /// now reads in both spellings.
+    static let branch = "quattro"
 
     static var tree: URL {
         URL(string: "https://api.github.com/repositories/\(repository)/git/trees/\(branch)?recursive=1")!
     }
 
     static func file(theme slug: String, _ path: String) -> URL {
-        URL(string: "https://raw.githubusercontent.com/basecamp/omarchy/\(branch)/themes/\(slug)/\(path)")!
+        URL(string: "https://raw.githubusercontent.com/omacom/omarchy/\(branch)/themes/\(slug)/\(path)")!
     }
 
     /// Every host toe is allowed to end up talking to. Checked after redirects rather than

--- a/Sources/toe/ThemeDownloader.swift
+++ b/Sources/toe/ThemeDownloader.swift
@@ -24,6 +24,14 @@ enum ThemeDownloader {
     /// wallpaper may be; it is a ceiling so a redirect to something enormous cannot fill a disk.
     private static let fileLimit = 64 << 20
     private static let paletteLimit = 64 << 10
+    /// How often a transfer in flight says how much of it has arrived.
+    ///
+    /// Every report rebuilds the menu's tree and redraws the panel, so this is a rate rather than
+    /// a resolution: six a second is smooth to the eye and nowhere near the cost of a keystroke,
+    /// which does the same work. It is also why `Coordinator.refreshMenu` stopped re-reading the
+    /// themes directory — at this rate that was twelve directory listings a second for a list
+    /// that cannot change while a download is running.
+    private static let progressInterval: TimeInterval = 1.0 / 6
     private static let timeout: TimeInterval = 60
 
     enum Failure: Error, CustomStringConvertible {
@@ -40,23 +48,16 @@ enum ThemeDownloader {
         }
     }
 
-    /// How far along a download is.
-    ///
-    /// A name and two numbers rather than a sentence, because two surfaces show this and they
-    /// want different lengths: the menu bar has room for `Gruvbox 3/6` and the tooltip behind it
-    /// has room to say it properly. Building the sentence here would have forced both to use it.
-    struct Progress {
-        let theme: String
-        /// Files finished. Zero while the palette is being fetched — the step that has no
-        /// meaningful fraction, being one small file before the count is even known to matter.
-        let done: Int
-        let total: Int
-    }
-
     /// Downloads `theme` and calls back on the main queue with where it landed.
+    ///
+    /// `progress` reports `ThemeDownload` — ToeCore's own type — rather than a shape of this
+    /// file's. It used to be a local struct carrying the theme's *name* as well, for the menu bar
+    /// strip that built `⟳ Gruvbox 3/6` out of it; the strip is gone, the row that fills instead
+    /// is identified by slug, and what was left was two numbers being copied into a type that
+    /// already held two numbers. This reports the one that has the arithmetic on it.
     static func fetch(_ theme: RemoteTheme,
                       into directory: URL,
-                      progress: @escaping (Progress) -> Void,
+                      progress: @escaping (ThemeDownload) -> Void,
                       completion: @escaping (Result<Void, Failure>) -> Void) {
         let slug = Slug.make(theme.slug)
         guard slug == theme.slug, !slug.isEmpty else {
@@ -70,7 +71,7 @@ enum ThemeDownloader {
     }
 
     private static func fetchSynchronously(_ theme: RemoteTheme, slug: String, into directory: URL,
-                                           progress: @escaping (Progress) -> Void)
+                                           progress: @escaping (ThemeDownload) -> Void)
     -> Result<Void, Failure> {
         let staging = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("toe-theme-\(slug)-\(UUID().uuidString)")
@@ -84,12 +85,25 @@ enum ThemeDownloader {
             return .failure(.couldNotWrite(error.localizedDescription))
         }
 
-        // The palette first: if it will not parse there is no point fetching nine megabytes of
-        // photographs to go with it.
         let total = theme.backgrounds.count
-        DispatchQueue.main.async {
-            progress(Progress(theme: theme.name, done: 0, total: total))
+        let bytesTotal = theme.bytes
+        // Bytes of the pictures finished with. Advanced by the catalogue's figure for each
+        // picture rather than by what actually arrived, so that it lands exactly on `bytesTotal`
+        // at the end however much the two disagreed on the way — the bar reaching its end is
+        // worth more than it being faithful to a size somebody else's repository reported.
+        var landed = 0
+
+        func report(_ fetching: Int, _ bytesDone: Int) {
+            DispatchQueue.main.async {
+                progress(ThemeDownload(slug: slug, fetching: fetching, total: total,
+                                       bytesDone: bytesDone, bytesTotal: bytesTotal))
+            }
         }
+
+        // The palette first: if it will not parse there is no point fetching nine megabytes of
+        // photographs to go with it. `fetching: 0` says so — no picture is in flight yet, so the
+        // row keeps showing what the theme costs until there is a count to put there instead.
+        report(0, 0)
         let paletteData: Data
         switch get(Upstream.file(theme: slug, "colors.toml"), limit: paletteLimit) {
         case .success(let data): paletteData = data
@@ -110,20 +124,30 @@ enum ThemeDownloader {
         }
 
         for (index, picture) in theme.backgrounds.enumerated() {
-            // Checked again here rather than trusted from the catalogue. The catalogue is a cache
-            // — it is a file on disk that something else could have written — and this is the
-            // moment a name becomes a path.
-            guard Catalogue.isSafeFileName(picture.name),
-                  !Backgrounds.isUpstreamBranding(picture.name),
-                  Backgrounds.list([picture.name]).count == 1 else { continue }
-
             // `index + 1`, and reported before the fetch rather than after: the number names the
             // picture being fetched, so it reads as "picture 1 of 2" while that is what is
             // happening, and ends on 2 of 2 rather than stopping at 1.
-            DispatchQueue.main.async {
-                progress(Progress(theme: theme.name, done: index + 1, total: total))
+            report(index + 1, landed)
+
+            // Checked again here rather than trusted from the catalogue. The catalogue is a cache
+            // — it is a file on disk that something else could have written — and this is the
+            // moment a name becomes a path.
+            //
+            // A skipped picture still takes its share of the bar on the way past. It is work
+            // accounted for, and the alternative is a bar that can never reach its end because
+            // one name in the listing was not a name.
+            guard Catalogue.isSafeFileName(picture.name),
+                  !Backgrounds.isUpstreamBranding(picture.name),
+                  Backgrounds.list([picture.name]).count == 1 else {
+                landed += picture.bytes
+                continue
             }
-            switch get(Upstream.file(theme: slug, "backgrounds/\(picture.name)"), limit: fileLimit) {
+
+            switch get(Upstream.file(theme: slug, "backgrounds/\(picture.name)"), limit: fileLimit,
+                       // Capped at what the catalogue said this picture weighs, so a transfer
+                       // that comes in heavier than advertised cannot push the bar past the
+                       // pictures still to come.
+                       received: { received in report(index + 1, landed + min(received, picture.bytes)) }) {
             case .success(let data):
                 // `appendingPathComponent` on a name that has been through both filters above:
                 // no separator, no leading dot, a known image extension.
@@ -133,7 +157,14 @@ enum ThemeDownloader {
                 // part that changes what you see.
                 Log.error("themes: \(theme.slug)/\(picture.name): \(why)")
             }
+            landed += picture.bytes
         }
+
+        // The last word, and the reason the bar reaches its end rather than stopping just short
+        // of it. Every other report is sent before or during a transfer, so without this one the
+        // final state the row ever draws is however much of the last picture had arrived when it
+        // was last asked — which is what "it stops at the last end" looked like.
+        report(total, bytesTotal)
 
         // Into place in one move, so a theme is either there whole or not there.
         let destination = directory.appendingPathComponent(slug)
@@ -154,7 +185,16 @@ enum ThemeDownloader {
     }
 
     /// One synchronous GET, on a queue where blocking is the point.
-    private static func get(_ url: URL, limit: Int) -> Result<Data, Failure> {
+    ///
+    /// - Parameter received: called with the bytes taken in so far, every `progressInterval`,
+    ///   while the transfer is still running. This is why the wait below is a loop rather than the
+    ///   single `semaphore.wait` it used to be: a four-megabyte photograph is the longest thing
+    ///   toe does, and a bar that could only move when a whole file landed sat still for the
+    ///   whole of it. Polling `countOfBytesReceived` rather than a delegate or KVO because this
+    ///   function is already blocking on a semaphore with a deadline — the loop is the wait it
+    ///   was doing anyway, cut into slices.
+    private static func get(_ url: URL, limit: Int,
+                            received: ((Int) -> Void)? = nil) -> Result<Data, Failure> {
         var request = URLRequest(url: url)
         request.timeoutInterval = timeout
         request.setValue("toe (macOS window manager)", forHTTPHeaderField: "User-Agent")
@@ -162,7 +202,7 @@ enum ThemeDownloader {
         let semaphore = DispatchSemaphore(value: 0)
         var outcome: Result<Data, Failure> = .failure(.network("no answer"))
 
-        URLSession.shared.dataTask(with: request) { data, response, error in
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
             defer { semaphore.signal() }
             if let error { return outcome = .failure(.network(error.localizedDescription)) }
             guard let http = response as? HTTPURLResponse else {
@@ -179,9 +219,17 @@ enum ThemeDownloader {
                 return outcome = .failure(.network("the answer was too large"))
             }
             outcome = .success(data)
-        }.resume()
+        }
+        task.resume()
 
-        _ = semaphore.wait(timeout: .now() + timeout + 5)
+        // The same deadline as before, waited out in slices. Reporting between them rather than
+        // after the wait returns, because by then the transfer is over and there is nothing left
+        // to say about it.
+        let deadline = Date().addingTimeInterval(timeout + 5)
+        while semaphore.wait(timeout: .now() + progressInterval) == .timedOut {
+            if Date() >= deadline { break }
+            received?(Int(task.countOfBytesReceived))
+        }
         return outcome
     }
 }

--- a/Sources/toe/UI/MenuView.swift
+++ b/Sources/toe/UI/MenuView.swift
@@ -102,6 +102,15 @@ final class MenuView: NSView {
         for (index, item) in s.rows.enumerated() {
             let row = MenuLayout.rowFrame(index, width: width, m)
             let selected = index == s.selectedRow
+            if let fraction = item.progress {
+                // The accent, well down in alpha — the colour the selected row already draws its
+                // text in, so a filling row belongs to the theme rather than being the one thing
+                // in the menu that ignores it. Under the selection wash rather than over it, so
+                // that the row you are standing on still reads as the row you are standing on
+                // while it fills.
+                NSColor(s.accent.withAlpha(0.3)).setFill()
+                rect(MenuLayout.progressFrame(inRow: row, fraction: fraction)).fill()
+            }
             if selected {
                 // `child:selected { background: alpha(@text, 0.07) }`
                 NSColor(s.foreground.withAlpha(0.07)).setFill()

--- a/Sources/toe/UI/QuickMenu.swift
+++ b/Sources/toe/UI/QuickMenu.swift
@@ -39,6 +39,13 @@ final class QuickMenu {
     /// there: the menu is a function of what is true when you look at it, and a theme folder that
     /// appeared a second ago should be in the list.
     private var style = StyleMenu()
+    /// launchd's answer, read once when the menu opened.
+    ///
+    /// Held rather than re-read by `update(config:style:)`, because that runs six times a second
+    /// for as long as a download lasts and `LoginItem.state()` shells out to `launchctl`. Nothing can change it
+    /// while the menu is up except the toggle itself, which rebuilds its own level with the fresh
+    /// answer and does not come through here.
+    private var loginItem: LoginItemState = .off
     private var usable: Box?
     private var metrics = MenuMetrics(lineHeight: 22)
     /// Guards the close path against itself: ordering the panel out resigns key, which is one of
@@ -100,18 +107,12 @@ final class QuickMenu {
         self.page = page
         MenuFont.register()
 
-        let font = MenuFont.text(size: config.menu.fontSize)
-        // Measured rather than assumed: `MenuLayout` cannot ask a font how tall a line is, and
-        // every metric below it is derived from this one.
-        metrics = MenuMetrics(fontSize: config.menu.fontSize,
-                              lineHeight: ceil(Double(font.ascender - font.descender + font.leading)))
-        let subtitle = MenuFont.text(size: config.menu.fontSize * Self.subtitleScale)
-        metrics.subtitleLineHeight =
-            ceil(Double(subtitle.ascender - subtitle.descender + subtitle.leading))
+        measure()
 
+        loginItem = LoginItem.state()
         let items = page == .keybindings
             ? MenuModel.keybindings(config.bindings, superKey: config.superKey)
-            : MenuModel.root(loginItem: LoginItem.state(), bindings: config.bindings, style: style)
+            : MenuModel.root(loginItem: loginItem, bindings: config.bindings, style: style)
         state = MenuState(root: items, visibleRows: 10)
 
         frontmostAtOpen = NSWorkspace.shared.frontmostApplication?.processIdentifier
@@ -119,6 +120,56 @@ final class QuickMenu {
         layoutAndRender()
         panel.makeKeyAndOrderFront(nil)
         panel.makeFirstResponder(view)
+    }
+
+    /// Line heights, measured from the font the config asks for.
+    ///
+    /// Measured rather than assumed: `MenuLayout` cannot ask a font how tall a line is, and every
+    /// metric below it is derived from this one. Its own function rather than part of `open`
+    /// because `update` needs it too — a config arriving while the menu is up can have changed
+    /// `font_size`, and every row height and the panel's own height come from here.
+    private func measure() {
+        let font = MenuFont.text(size: config.menu.fontSize)
+        metrics = MenuMetrics(fontSize: config.menu.fontSize,
+                              lineHeight: ceil(Double(font.ascender - font.descender + font.leading)))
+        let subtitle = MenuFont.text(size: config.menu.fontSize * Self.subtitleScale)
+        metrics.subtitleLineHeight =
+            ceil(Double(subtitle.ascender - subtitle.descender + subtitle.leading))
+    }
+
+    /// New theme state, into a menu that is already open.
+    ///
+    /// The catalogue arriving and a download getting a picture further both change what the rows
+    /// in front of you say, and until now neither reached them: `style` was handed in at open and
+    /// held, so the list was whatever was true when you pressed the key. That was survivable
+    /// while a download had the menu bar to talk through and is not now that the row is the only
+    /// surface it has.
+    ///
+    /// The config comes with it, and that is not incidental. Finishing a download *applies* the
+    /// theme, which is to say it rewrites `[menu]` — so a panel still drawing from the config it
+    /// was opened with would sit there in the old theme's colours while its own rows announced
+    /// the new one as `current`. The picker has to restyle itself, because it is the one surface
+    /// on screen at the moment a theme changes.
+    ///
+    /// Only the root page is rebuilt: the keybindings page is a different tree with no theme rows
+    /// in it, and rebuilding it from `MenuModel.root` would replace the page under the user. It
+    /// still gets the new colours, which is why the re-render is outside that branch.
+    func update(config: Config, style: StyleMenu) {
+        // Row heights only change when the font does, and this runs six times a second for as
+        // long as a download lasts.
+        let fontChanged = config.menu.fontSize != self.config.menu.fontSize
+        self.config = config
+        self.style = style
+        guard panel.isVisible, state != nil else { return }
+        if fontChanged { measure() }
+        if page == .root {
+            state?.rebuild(root: MenuModel.root(loginItem: loginItem, bindings: config.bindings,
+                                                style: style))
+        }
+        // Through the full path rather than straight to `render()`: a level that gained or lost
+        // rows — the fetching note going away, a downloaded theme moving up into the installed
+        // list — changes how tall the panel wants to be, and so does a new `font_size`.
+        layoutAndRender()
     }
 
     func close() {
@@ -202,10 +253,14 @@ final class QuickMenu {
             if !setup.isEmpty { state?.replaceLevel(with: setup) }
             layoutAndRender()
         case .run(let command):
-            // Closed first, and dispatched a turn later: an `exec` brings another application
-            // forward and `quit` tears the process down, and both want the panel gone and the
-            // keyboard handed back before they begin.
-            close()
+            // Theme rows stay — `Command.keepsMenuOpen` says why at length. Everything else
+            // goes: an `exec` brings another application forward and `quit` tears the process
+            // down, and both want the panel gone and the keyboard handed back before they begin.
+            //
+            // Still dispatched a turn later either way, so the two paths differ in one thing
+            // only. Escape or a click elsewhere closes the menu as it always did, and anything
+            // it started carries on behind it; what it does not do is close by itself.
+            if !command.keepsMenuOpen { close() }
             DispatchQueue.main.async { [weak self] in self?.onCommand?(command) }
         }
     }

--- a/Sources/toe/UI/StatusItem.swift
+++ b/Sources/toe/UI/StatusItem.swift
@@ -20,8 +20,6 @@ final class StatusItem: NSObject {
     var onOpenMenu: (() -> Void)?
 
     private var accessibilityGranted = false
-    /// What is being fetched, if anything — see `update(workspaces:warnings:…)`.
-    private var progress: String?
 
     /// waybar's `persistent-workspaces` — how many workspaces keep a slot when empty.
     var persistentWorkspaces = WorkspaceStrip.defaultPersistent
@@ -91,14 +89,14 @@ final class StatusItem: NSObject {
 
     /// Cheap: only the title strip is recomputed, from the little the strip reads.
     ///
-    /// - Parameter progress: what is being fetched, if anything. It goes in the strip rather than
-    ///   only in the tooltip because a tooltip needs you to already suspect something is
-    ///   happening and go looking — and the one moment this matters is a nine-megabyte download
-    ///   running with the menu closed and nothing else on screen to say so.
+    /// This used to take a `progress` string as well, and draw `⟳ Gruvbox 3/6` after the
+    /// workspaces while a theme was being fetched. It does not any more: the quick menu fills the
+    /// downloading theme's own row instead, which is the row that told you what the download
+    /// would cost, so the progress is now reported where the decision was made rather than in a
+    /// second place that had to abbreviate it. The strip is workspaces and nothing else again.
     func update(workspaces: [WorkspaceStrip.State], warnings: [String],
-                accessibilityGranted: Bool, progress: String? = nil) {
+                accessibilityGranted: Bool) {
         self.accessibilityGranted = accessibilityGranted
-        self.progress = progress
         item.button?.attributedTitle = title(for: workspaces)
 
         // The focused workspace is drawn as a square rather than a digit, so the title on
@@ -141,26 +139,7 @@ final class StatusItem: NSObject {
             stripItems.append(item)
             stripWidths.append(Double(width(of: item)))
         }
-        // After the workspaces, never instead of them: what workspace you are on is the thing
-        // this item exists to tell you, and a download must not take that away for a minute.
-        // No entry goes into `stripItems`, so the click targets are unchanged and clicking the
-        // progress opens the menu like clicking anywhere else on the item.
-        if let progress {
-            strip.append(spacer)
-            strip.append(progressPiece(progress))
-        }
         return strip
-    }
-
-    /// `⟳ Gruvbox 3/6`, in the same dimmed grey an unfocused workspace takes.
-    ///
-    /// Static rather than animated: an animation needs a timer running for as long as the
-    /// download, and the step count already moves often enough to read as alive. The glyph is
-    /// there so a glance finds it without reading the words.
-    private func progressPiece(_ text: String) -> NSAttributedString {
-        NSAttributedString(string: "⟳ " + text, attributes: [
-            .font: font, .foregroundColor: NSColor.secondaryLabelColor,
-        ])
     }
 
     /// A fixed `gap` of empty space, kerned rather than padded so its width is exactly known.

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -60,11 +60,12 @@ split_bias             = 0
 # theme there and editing it here are the same act. It refuses to write at all if the result would
 # not parse.
 #
-# A theme is a folder: ~/.config/toe/themes/<name>/colors.toml, in Omarchy's own format, plus an
-# optional backgrounds/ beside it. Nothing has to be registered — one appears in the menu the
-# moment you next open it, and saving its palette recolours the screen the way saving this file
-# does. Style > Background appears exactly when that theme has pictures, and SUPER+CTRL+SPACE
-# steps through them.
+# A theme is a folder: ~/.config/toe/themes/<name>/colors.toml, in Omarchy's own format — either
+# spelling of it, the named hues Omarchy 4 writes or the numbered color0-color15 of Omarchy 3 —
+# plus an optional backgrounds/ beside it. Nothing has to be registered — one appears in the
+# menu the moment you next open it, and saving its palette recolours the screen the way saving
+# this file does. Style > Background appears exactly when that theme has pictures, and
+# SUPER+CTRL+SPACE steps through them.
 name = ""
 
 [border]


### PR DESCRIPTION
## Why

toe was fetching themes from `basecamp/omarchy` on `master`. Both parts had gone stale: the repository is now `omacom/omarchy`, its default branch is `quattro`, and `master` stopped moving at Omarchy 3.8.5 in August. Every release since v3.8.4 has been cut from `quattro`, and three themes exist only there — Last Horizon, Lupine and Solitude.

## Following the branch

**`colors.toml` was rewritten.** `color0`…`color15` became named hues, `cursor` went away, the `selection_*` pair became `selection`/`muted`, and a `mode` key plus two ramps arrived. Both spellings are read — the folders people copied across before Omarchy 4 are written in the old one. `accent`, `background` and `foreground` are spelled the same in both, so this is a widening, not a migration.

The named-hue → ANSI mapping is checked rather than assumed. Against all nineteen themes on both branches, eleven of the twelve agree 19/19; `blue` agrees 18/19, the exception being Retro 82, whose old file had its orange accent in slot 4 and no blue at all. Slots 0, 7, 8 and 15 have no Omarchy 4 key and stay nil rather than being approximated from `muted` or `lighter_background`, which land on them in under half the themes.

One visible upstream consequence: **Kanagawa's `accent` changed** (`#7e9cd8` → `#dcd7ba`), so following the new branch does recolour that one border. Noted in `Palette` so nobody hunts for it here.

**`Catalogue.currentVersion` → 2.** Omarchy 4 re-encoded most backgrounds to webp and renumbered them — nine of fifty-nine filenames survive — so a cached listing names pictures that are gone and would 404 partway through a download.

## Download progress moves into the menu

`⟳ Gruvbox 3/6` in the menu bar strip was a second, worse copy of a list the menu draws properly, and it was on screen exactly when you were looking at the menu. Now the theme's own row fills in the accent and its size gives way to `3/5`. The strip is workspaces again.

**The bar measures bytes, not files.** Counting files was wrong where it mattered — pictures run from 10 KB to 4 MB, so the bar raced through the small ones and froze for the largest. Tokyo Night's stopped at 87.5% and stayed there through the last picture, which reads as a dead download:

| | picture | size | old bar | now |
|---|---|---|---|---|
| 6/7 | `5-oma-cityscape.jpg` | 1.41 MB | 75.0% | 56.3% |
| 7/7 | `6-oma.webp` | 0.28 MB | 87.5% | 92.7% |

`get` now reports `countOfBytesReceived` while a transfer is in flight, so the bar moves *during* a file. A final report closes it on exactly 100% before the row flips.

**Picking a theme no longer closes the panel.** Two reasons pointing the same way: a download needs its row visible, and a theme recolours the menu, so staying put makes the list something you look through rather than commit to. That needed `QuickMenu.update` to take the config too — it was holding the one it opened with, so the picker would have sat in the old theme's colours while its rows announced the new one. Backgrounds still close: a wallpaper is behind the panel, not in it.

## Two holes found on the way

- The completion path trusted the reload inside `setTheme` to refresh the menu. `setTheme` has five early returns, and one is reachable in normal use — delete a theme's folder while your config still names it, then re-fetch it — which left the row stopped part-filled permanently.
- `refreshMenu` re-read the themes directory on every report: twelve directory listings a second, for a list that cannot change mid-download.

## Verification

`make test` — **913 assertions**, up from 812. New coverage for both `colors.toml` spellings (the real quattro file as a verbatim fixture), a slot-for-slot cross-check between them, byte-weighted progress, `MenuState.rebuild` keeping your place and surfacing a rung when a level vanishes, and `Command.keepsMenuOpen`.

Beyond the suite, checked against live upstream: all 22 quattro palettes parse; the 19 shared themes agree slot-for-slot bar the two noted; `Catalogue.parse` on the live tree yields 22 themes with wordmarks excluded. And the real downloader was run against the real repository — 15 reports over 2.67s for Solitude, monotonic, ending on 100.0%.