### PR TITLE
Follow Omarchy's own menu tree, and open it at a level

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,28 @@ Two invariants in that loop are easy to break:
 - **A window the user has hold of is never written to.** `draggedWindow` is checked in `apply`,
   `windowFrameChangedExternally` and `updateBorder`; the frame is written once, on release.
 
+## The quick menu mirrors Omarchy's tree
+
+`MenuModel` is a port of `default/omarchy/omarchy-menu.jsonc` on Omarchy's `quattro` branch, not a
+menu that borrowed some names — the same rows at the same depth in the same order, so that an
+Omarchy user diving it finds their own menu with the Linux taken out. The rule for what is absent
+is Omarchy's own `when` guard: a row whose condition fails is not listed, and a submenu whose
+visible descendants have all gone goes with them. Before adding a row, check where upstream puts
+it; before leaving one out, check that it genuinely cannot work here rather than that it was
+inconvenient.
+
+Two divergences are deliberate and should stay:
+
+- **`Quit` is a root row.** Omarchy's `System` is a power menu for the machine; toe quits an
+  agent, and one row does not want a level.
+- **`About` is a `.note` row carrying the version**, where upstream's opens a branding window.
+  toe has no window to open and one fact to report.
+
+`disabled` (dim, ticked, unselectable, omitted from search) is upstream's guard for "you already
+have this" and is why `Install › Style › Theme` can list the whole catalogue. `MenuState` enforces
+it in four places — `move`, `select`, `activate` and the search filter — so a new way of reaching a
+row needs a fifth.
+
 ## Things that will bite you
 
 **Coordinate spaces.** `Box` is Accessibility coordinates: origin top-left of the primary display,

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ as the defaults.
 | `SUPER` + `W` | Close window |
 | `SUPER` + `J` | Toggle split orientation |
 | `SUPER` + `T` | Cycle floating: 70×80% of the display, 80×90%, back to tiling |
-| `SUPER` + `SPACE` | The quick menu — Configure, Learn, Style, Quit |
-| `SUPER` + `CTRL` + `SPACE` | Next background, when the theme has any |
+| `SUPER` + `SPACE` | The quick menu — Learn, Style, Setup, Install, Remove, Quit |
+| `SUPER` + `CTRL` + `SPACE` | The background picker, when the theme has pictures |
+| `SUPER` + `SHIFT` + `CTRL` + `SPACE` | The theme picker |
 | `SUPER` + `K` | Every binding, in a list |
 | `SUPER` + `,` | Edit the config — a VS Code window |
 | `SUPER` + `SHIFT` + `R` / `Q` | Reload the config / quit toe |
@@ -111,7 +112,7 @@ what it does — and it will not launch anything you did not bind. Point them wh
 
 A binding naming an application you do not have fails quietly: `/bin/sh` runs, `open` reports
 that it cannot find it, and no window appears. Nothing else in toe depends on the press. The one
-knock-on is the quick menu's *Edit configuration* row, which is whichever `exec` mentions
+knock-on is the quick menu's *Config* row, which is whichever `exec` mentions
 `toe.toml` — repoint `SUPER`+`,` and the row follows it; remove the binding and the row goes.
 
 The `[[float]]` rules name 1Password, Raycast, System Settings and Activity Monitor, but those
@@ -244,24 +245,36 @@ interface, and a Homebrew user has no way to discover one of them. Omarchy has t
 fills that gap, and it is not a menu bar menu — it is the one walker draws for `omarchy-menu`, on
 `SUPER`+`ALT`+`SPACE`. toe ports that to `SUPER`+`SPACE`, with the keybindings list on
 `SUPER`+`K` as Omarchy has it. Arrows to move, `ENTER` to choose, `ESC` or backspace to back out,
-and a second `SUPER`+`SPACE` to close. `Configure` holds *Run on startup* and *Edit
-configuration*, `Learn` holds the keybindings, and `Quit` is a row rather than a keystroke you
-had to know. *Run on startup* is `SMAppService`, so it appears in System Settings › General ›
-Login Items too — and it is left out of the menu entirely where it cannot work: from a build
-directory rather than `/Applications`, or alongside a LaunchAgent that `make start-at-login`
-wrote. The log says which, and what fixes it.
+and a second `SUPER`+`SPACE` to close.
 
-*Edit configuration* runs **your** binding rather than an editor toe picked: it is whichever
-`exec` in your config mentions `toe.toml`, so pointing `SUPER`+`,` at Zed points the menu row at
-Zed, moving it to another key takes the row with it, and removing it removes the row. The
-keybindings list names that same binding *Edit the config* instead of printing the shell line, by
-the same rule. Where neither row can be offered — no such binding, and *Run on startup*
-unavailable — `Configure` is left out too, rather than leading into an empty level.
+**The tree is Omarchy's**, and the rule for what is missing is Omarchy's own `when` guard: a row
+whose condition fails is not listed, and a submenu whose visible descendants have all gone goes
+with them. So the root reads `Learn`, `Style`, `Setup`, `Install`, `Remove`, `About`, `Quit` —
+upstream's order, with the rows a Mac cannot honour left out rather than renamed. There is no
+`Style` › `Menu Bar`, because upstream's two rows there are Position (macOS fixes it) and
+Transparency (that menu bar is not toe's to style); no `Apps`, `Trigger` or `Update`; and no
+`System`, whose rows power the machine down. `Quit` is toe's own and comes last, a row rather
+than a keystroke you had to know.
+
+A binding can open any level, the way `omarchy-menu toggle <route>` does: `menu theme`,
+`menu background`, `menu setup`, `menu install` and the rest, Omarchy's aliases included. That is
+what puts the background picker on `SUPER`+`CTRL`+`SPACE` and the theme picker on
+`SUPER`+`SHIFT`+`CTRL`+`SPACE` — the keys Omarchy binds them to, opening the levels Omarchy opens.
+
+`Setup` holds *Config* and *Run on startup*. The first runs **your** binding rather than an editor
+toe picked: it is whichever `exec` in your config mentions `toe.toml`, so pointing `SUPER`+`,` at
+Zed points the menu row at Zed, moving it to another key takes the row with it, and removing it
+removes the row. The keybindings list names that same binding *Edit the config* instead of
+printing the shell line, by the same rule. *Run on startup* is `SMAppService`, so it appears in
+System Settings › General › Login Items too — and it is left out entirely where it cannot work:
+from a build directory rather than `/Applications`, or alongside a LaunchAgent that
+`make start-at-login` wrote. The log says which, and what fixes it. Where neither row can be
+offered, `Setup` is left out too, rather than leading into an empty level.
 
 Typing searches what a row does as well as what it is called — on the keybindings page the name
 is `SUPER`+`W` and the description is *Close window*, so a filter that read only names would have
 you typing modifiers to find anything. It searches the whole tree rather than the level in front
-of you, too, and every hit says where it was found — type `startup` at the top and *Run on startup* comes back labelled `Configure`,
+of you, too, and every hit says where it was found — type `startup` at the top and *Run on startup* comes back labelled `Setup`,
 ready to act on without going there first. That is Omarchy's behaviour, and it is the difference
 between a filter and a search: you should not have to know which submenu something lives in to be
 able to type its name.
@@ -299,26 +312,38 @@ toe redistributing them rather than Omarchy. So the list you choose from is what
 from Omarchy for you. All nineteen of them, rather than a chosen three, and 79 MB of pictures that
 never ship.
 
-`Style` › `Theme` lists what you have first, then what you could have, each with what it would
-cost to fetch:
+The three verbs sit where Omarchy puts them. `Style` › `Theme` is what is on the disk — a list
+where nothing takes longer than a repaint:
 
 ```
-Tokyo Night           current
+Tokyo Night           ✓
 Rose Pine
-Everforest            0.3 MB
-Kanagawa              2.1 MB
-Gruvbox               9.2 MB
 Your own colours
 ```
 
+`Install` › `Style` › `Theme` is Omarchy's catalogue entire, priced, with what you already have
+listed and dimmed rather than dropped — upstream's `disabled` guard, which is what keeps the level
+a catalogue of everything toe can fetch instead of a list that empties as you use it:
+
+```
+Tokyo Night           ✓
+Everforest            0.3 MB
+Kanagawa              2.1 MB
+Gruvbox               9.2 MB
+```
+
 The size is the disclosure — they run from a third of a megabyte to nine, and a row that fetched
-nine without saying so would be a row that surprised you. Choosing one is the same act either way:
-if you have it, it is applied; if you do not, it is fetched and then applied.
+nine without saying so would be a row that surprised you. Choosing one fetches it and then applies
+it, so the row you press does the same thing in either level.
+
+`Remove` › `Theme` puts a folder in the Trash, the current theme included — removing the one you
+are wearing hands your own colours back on the way out. Every folder in `~/.config/toe/themes` is
+listed, whether toe fetched it or you wrote it, because on disk there is nothing to tell them
+apart.
 
 **The network, stated plainly.** toe asks for Accessibility and nothing else, and it makes exactly
 two kinds of request, both to github.com and both because you did something: the list of themes
-when you open `Style` › `Theme`, cached and refreshed at most once a day, and a theme when you
-choose one. Nothing at launch, no update check, no telemetry. A machine that has never been online
+when you open the menu, cached and refreshed at most once a day, and a theme when you choose one. Nothing at launch, no update check, no telemetry. A machine that has never been online
 has no themes to choose from and toe's own colours, which is the cost of not shipping other
 people's work.
 
@@ -344,8 +369,9 @@ Nothing is registered: a folder you add appears the moment you next open the men
 palette recolours the screen within about 150 ms the way saving `toe.toml` does.
 
 Pictures come only from that folder. `Style` › `Background` appears exactly when the current theme
-has some, and `SUPER`+`CTRL`+`SPACE` steps through them — the key Omarchy gives to backgrounds,
-where it opens the picker, which here is the menu's job.
+has some, and `SUPER`+`CTRL`+`SPACE` opens it — the key Omarchy gives to backgrounds, doing there
+what it does here. Its last row steps to the next picture without stopping to choose one, which is
+also the `nextbackground` command if you would rather have that on the key.
 
 The focused border goes **flat** under a theme. That is Omarchy's, not a simplification:
 `hyprland.conf.tpl` renders `col.active_border = rgb({{ accent_strip }})` — one opaque colour,
@@ -528,31 +554,37 @@ menu bar item's tooltip — a typo can never leave you without a keyboard. See
 Binding specs parse in both the dash spelling and Omarchy's, so you can paste from either:
 `"alt-shift-1"`, `"super+shift+1"` and `"SUPER SHIFT, 1"` are the same binding.
 
-`reload`, `quit`, the quick menu and `nextbackground` are bound in code as well as in the file —
-`SUPER`+`SHIFT`+`R`, `SUPER`+`SHIFT`+`Q`, `SUPER`+`SPACE`, `SUPER`+`K` and
-`SUPER`+`CTRL`+`SPACE` — so they exist whether or not your config mentions them. Your config is never rewritten once it is there, so a binding introduced after you
+`reload`, `quit`, the quick menu and its two picker routes are bound in code as well as in the
+file — `SUPER`+`SHIFT`+`R`, `SUPER`+`SHIFT`+`Q`, `SUPER`+`SPACE`, `SUPER`+`K`,
+`SUPER`+`CTRL`+`SPACE` and `SUPER`+`SHIFT`+`CTRL`+`SPACE` — so they exist whether or not your config mentions them. Your config is never rewritten once it is there, so a binding introduced after you
 first ran toe would otherwise never reach you: that is how the menu bar item losing its menu left
 anyone upgrading with no way to quit but `pkill`. A fallback applies only when the command is
 bound nowhere, so rebinding `quit` keeps your key and does not also collect the default, and a
 fallback whose own combination you have already used for something else is dropped rather than
 registered on top of yours.
 
-The first four are escape hatches — a config that forgot them leaves you stuck. `nextbackground`
-is not, and is the only entry on that list which isn't: it is there because it is a key that
-could otherwise never reach an install that predates it, and because stepping through a theme's
-pictures is the one thing the menu cannot do for you. Those same two rules are how you take it
-back: bind `nextbackground` to another key and `SUPER`+`CTRL`+`SPACE` is yours again, and if you
-already use that combination it is left alone. Opening the config is not on that list: it is an `exec` like any
+The first four are escape hatches — a config that forgot them leaves you stuck. The two picker
+routes are not, and are the only entries on that list which aren't: they are there because they
+are keys that could otherwise never reach an install that predates them. Those same two rules are
+how you take them back: bind `menu background` to another key and `SUPER`+`CTRL`+`SPACE` is yours
+again, and if you already use that combination — including a config that still says
+`"super-ctrl-space" = "nextbackground"`, which is what the key used to do — it is left alone.
+Opening the config is not on that list: it is an `exec` like any
 other now, and a fallback would have to name an editor toe has no business choosing.
 
 Commands: `movefocus`, `swapwindow`, `movewindow`, `workspace`, `movetoworkspace`,
 `movetoworkspacesilent`, `killactive`, `togglefloating`, `togglesplit`, `swapsplit`, `exec`,
-`reload`, `menu`, `keybindings`, `theme`, `background`, `nextbackground`, `quit`.
+`reload`, `menu`, `keybindings`, `theme`, `removetheme`, `background`, `nextbackground`, `quit`.
+
+`menu` takes a route — `root`, `keybindings`, `learn`, `style`, `theme`, `background`, `setup`,
+`install`, `remove`, plus Omarchy's aliases `settings`, `wallpaper`, `uninstall` and `themes` —
+and opens the tree there. Pressing the same key again closes it; pressing another route's key
+moves to that level.
 
 `[theme] name` names a folder in `~/.config/toe/themes` — one you put there, or one the menu
 downloaded from Omarchy; empty is toe's own colours. toe ships none. `theme` takes a name in either spelling (`theme gruvbox`, `theme Tokyo Night`) and,
-alone, clears it. Only `nextbackground` is bound by default, on `SUPER`+`CTRL`+`SPACE`. That is
-the one binding with a macOS shortcut behind it: ⌃⌥Space is *select next input source*, a
+alone, clears it; `removetheme` takes the same name and deletes the folder. `SUPER`+`CTRL`+`SPACE`
+is the one binding with a macOS shortcut behind it: ⌃⌥Space is *select next input source*, a
 symbolic hotkey the window server resolves ahead of anything toe can register — but one that is
 switched off unless you have two or more input sources.
 

--- a/Sources/ToeCore/Config/Config.swift
+++ b/Sources/ToeCore/Config/Config.swift
@@ -212,18 +212,19 @@ public struct Config: Equatable {
         // list by the same reasoning that put them here.
         ("super-space", .menu(.root)),
         ("super-k", .menu(.keybindings)),
-        // Not an escape hatch, and the one entry here that is not. It is on the list because the
-        // problem this list exists to solve is exactly its problem: a config is never rewritten,
-        // so a binding introduced after you first ran toe reaches nobody who already had one, and
-        // every existing user is in that position for this key. The menu is not a substitute —
-        // Style › Background can pick a picture, but the thing worth having on a key is stepping
-        // through them without stopping to choose, which is the one thing the menu cannot do.
+        // Not escape hatches, and the two entries here that are not. They are on the list because
+        // the problem it exists to solve is exactly theirs: a config is never rewritten, so a
+        // binding introduced after you first ran toe reaches nobody who already had one, and
+        // every existing user is in that position for both keys. These are the two Omarchy gives
+        // to how the desktop looks, doing there what they do here.
         //
-        // The cost, stated plainly because it is real: unlike the four above, this is a key you
-        // may not want given away. Binding `nextbackground` anywhere else takes it back — a
-        // fallback applies only when its command is bound nowhere — and if ⌃⌥Space is already
-        // claimed the fallback is dropped rather than registered on top of whatever has it.
-        ("super-ctrl-space", .nextBackground),
+        // ⌃⌥Space used to be `nextbackground`, and a config that says so keeps it: a fallback
+        // applies only when its command is bound nowhere, and a key already claimed drops its
+        // fallback rather than being registered on top of whatever has it. So an upgrader who
+        // copied that line out of an older default keeps stepping through pictures, and one who
+        // never had the key gets Omarchy's picker.
+        ("super-ctrl-space", .menu(.background)),
+        ("super-shift-ctrl-space", .menu(.theme)),
     ]
 
     public static let defaultFloatRules: [FloatRule] = [

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -52,14 +52,15 @@ split_bias             = 0
 # focused border takes the accent, flat, and the quick menu takes the background, the foreground
 # and the accent.
 #
-# SUPER+SPACE > Style > Theme is where you get one. toe ships no themes: a theme is somebody
-# else's work, and the list you choose from is what is in ~/.config/toe/themes plus what Omarchy
-# publishes. Choosing one you have not got downloads it from Omarchy into that folder — palette
-# and pictures — and then sets it, so a theme you fetched and a theme you copied in by hand are
-# the same thing afterwards.
+# SUPER+SHIFT+CTRL+SPACE is Style > Theme, which lists what is in ~/.config/toe/themes. toe ships
+# no themes — a theme is somebody else's work — so on a new machine that list is short, and the
+# rest of them are under Install > Style > Theme, where Omarchy keeps its own: everything Omarchy
+# publishes, priced, with the ones you already have dimmed. Choosing one there downloads it into
+# that folder, palette and pictures, and then sets it, so a theme you fetched and a theme you
+# copied in by hand are the same thing afterwards. Remove > Theme puts one in the Trash.
 #
 # That download is the only time toe touches the network, along with the list of themes it fetches
-# when you open Style > Theme, at most once a day. Nothing at launch, no update check, no
+# when you open the menu, at most once a day. Nothing at launch, no update check, no
 # telemetry; the only host it talks to is github.com. A machine that has never been online has no
 # themes to choose from, and the colours below.
 #
@@ -72,7 +73,7 @@ split_bias             = 0
 # plus an optional backgrounds/ beside it. Nothing has to be registered — one appears in the
 # menu the moment you next open it, and saving its palette recolours the screen the way saving
 # this file does. Style > Background appears exactly when that theme has pictures, and
-# SUPER+CTRL+SPACE steps through them.
+# SUPER+CTRL+SPACE opens it.
 name = ""
 
 [border]
@@ -152,7 +153,9 @@ persistent_workspaces = 5
 [menu]
 # SUPER+SPACE opens the quick menu, styled after Omarchy's — the one walker draws for
 # `omarchy-menu`. Arrows to move, Enter to choose, Escape to back out. Typing searches the whole
-# tree rather than the level you are on, and each hit says which submenu it came from.
+# tree rather than the level you are on, and each hit says which submenu it came from. The tree
+# is Omarchy's, with the rows that mean nothing on a Mac left out the way Omarchy's own `when`
+# guard leaves out a row whose condition fails.
 # These are its theme's tokens: Omarchy's default (Tokyo Night) resolved the way walker's
 # stylesheet resolves them — background, foreground (which is also the border), and the accent
 # the selected row's text takes. Which is to say these three are already a theme: setting
@@ -240,21 +243,31 @@ font_size  = 18
 "super-shift-r" = "reload"
 # Puts every window on a hidden workspace back where it came from on the way out.
 "super-shift-q" = "quit"
-# The quick menu — Omarchy's SUPER+ALT+SPACE, and the keybindings list it holds. Note that this
-# takes ⌥Space and ⌥K away from typing ` ` and ˚ for as long as toe runs.
+# The quick menu — Omarchy's SUPER+SPACE, and the keybindings list it holds. Note that this takes
+# ⌥Space and ⌥K away from typing ` ` and ˚ for as long as toe runs.
+#
+# `menu` takes a route, the way `omarchy-menu toggle <route>` does, and opens the tree at that
+# level: root, keybindings, learn, style, theme, background, setup, install, remove. Pressing the
+# same key again closes; pressing another one moves to its level. Omarchy's own aliases work too,
+# so `menu settings` and `menu wallpaper` are lines you can copy across.
 "super-space"   = "menu"
 "super-k"       = "keybindings"
-# Omarchy's background key. SUPER+CTRL+SPACE is what its bindings.conf gives to backgrounds —
-# there it opens the picker, which here is Style › Background in the menu above, so the key does
-# the thing the menu cannot: step to the next picture without stopping to choose one. Does
-# nothing until the current theme has a backgrounds/ folder with something in it.
+# Omarchy's two look-and-feel keys, doing what they do there: SUPER+CTRL+SPACE opens the
+# background picker and SUPER+SHIFT+CTRL+SPACE the theme one. Background is only offered when the
+# current theme has a backgrounds/ folder with something in it, so on a themeless machine that
+# key opens the menu one rung up rather than at a level that is not there.
+#
+# `nextbackground` is what this key used to do — step to the next picture without stopping to
+# choose one. It is still a command, and still what Style › Background's last row does:
+#   "super-ctrl-space" = "nextbackground"
 #
 # The one binding here with a macOS shortcut behind it: ⌃⌥Space is "select next input source",
 # and while that is a symbolic hotkey — resolved inside the window server, ahead of anything toe
 # can register — it is switched off unless you have two or more input sources. If you do, and
 # this key changes your keyboard instead of your wallpaper, that is why; move it, or turn the
 # shortcut off in System Settings › Keyboard › Keyboard Shortcuts › Input Sources.
-"super-ctrl-space" = "nextbackground"
+"super-ctrl-space"       = "menu background"
+"super-shift-ctrl-space" = "menu theme"
 
 # ── Launch ────────────────────────────────────────────────────────────────────
 # AppleScript's `new window` reuses the running instance, so the window opens on the current

--- a/Sources/ToeCore/Dispatch/Command.swift
+++ b/Sources/ToeCore/Dispatch/Command.swift
@@ -20,16 +20,22 @@ public enum Command: Equatable {
     case swapSplit
     case exec(String)
     case reload
-    /// The quick menu, and the keybindings list it holds. One case with a page rather than two
-    /// cases: the keybindings view *is* the menu on another page — same panel, same filter, same
-    /// keys — so two cases would give `dispatch` two arms with one body between them.
-    case menu(MenuPage)
+    /// The quick menu, at a level. One case with a route rather than one per door: the
+    /// keybindings view *is* the menu on another page — same panel, same filter, same keys — and
+    /// `menu theme` is the same panel again, opened three rows in. Separate cases would give
+    /// `dispatch` several arms with one body between them.
+    case menu(MenuRoute)
     case quit
     /// An Omarchy theme, by slug — `omarchy-theme-set`. Empty clears it and hands your own
     /// `[border]` and `[menu]` colours back, which is why the argument is the one in the parser
     /// that may be missing: `theme none` would be wrong, since `none` is a directory somebody
     /// could legitimately name.
     case theme(String)
+    /// Deletes a theme's folder from `~/.config/toe/themes` — `omarchy-theme-remove`. The one
+    /// destructive thing the menu can do, which is why it takes a slug rather than a path: the
+    /// name is joined onto a directory that is about to be removed, and `Slug.make` is what
+    /// stands between that join and a name with a `/` or a `..` in it.
+    case removeTheme(String)
     /// A picture from the current theme's `backgrounds/`, by file name.
     case background(String)
     /// `omarchy-theme-bg-next`.
@@ -79,8 +85,10 @@ public extension Command {
     /// changed, and the menu is what is in front of it.
     var keepsMenuOpen: Bool {
         switch self {
-        case .theme: return true
-        default:     return false
+        // Removing one is the same argument from the other side: the row leaves the list under
+        // the cursor, and that disappearance is the whole of what toe says about it.
+        case .theme, .removeTheme: return true
+        default:                   return false
         }
     }
 }
@@ -145,6 +153,11 @@ public enum CommandParser {
         // Night"` copied out of an Omarchy config finds the same directory, and so that no
         // un-slugified string can reach the code that writes this name back into your config.
         case "theme":                       return .theme(Slug.make(argument))
+        // `omarchy theme remove <name>`, one word rather than two because a binding's value is a
+        // verb and its argument, and `theme` had already taken the first word.
+        case "removetheme", "theme-remove":
+            guard !argument.isEmpty else { throw CommandError.missingArgument(name) }
+            return .removeTheme(Slug.make(argument))
         // Not slugified: a background is a file name, with an extension and whatever case the
         // photographer gave it.
         case "background", "bg":
@@ -155,10 +168,20 @@ public enum CommandParser {
 
         // Spelled the way `omarchy-menu` and `omarchy-menu keybindings` are invoked, so a
         // binding can be read across from an Omarchy config without translating it.
+        // Routes are Omarchy's, aliases included: `omarchy-menu toggle background` and
+        // `toggle settings` are lines out of its own bindings and its own menu file, and they
+        // open the same levels here.
         case "menu":
             switch argument.lowercased() {
-            case "", "root":            return .menu(.root)
-            case "keybindings", "keys": return .menu(.keybindings)
+            case "", "root", "go":                    return .menu(.root)
+            case "keybindings", "keys":               return .menu(.keybindings)
+            case "learn":                             return .menu(.learn)
+            case "style":                             return .menu(.style)
+            case "theme", "themes":                   return .menu(.theme)
+            case "background", "backgrounds", "wallpaper": return .menu(.background)
+            case "setup", "settings":                 return .menu(.setup)
+            case "install":                           return .menu(.install)
+            case "remove", "uninstall":               return .menu(.remove)
             default:                    throw CommandError.badArgument(name, argument)
             }
         case "keybindings":                 return .menu(.keybindings)

--- a/Sources/ToeCore/Dispatch/CommandLabel.swift
+++ b/Sources/ToeCore/Dispatch/CommandLabel.swift
@@ -30,17 +30,21 @@ public enum CommandLabel {
             return command.opensConfig ? "Edit the config" : "Run \(ellipsised(line))"
         case .reload:               return "Reload the config"
         case .quit:                 return "Quit toe"
-        case .menu(let page):
-            switch page {
-            case .root:        return "Open the menu"
-            case .keybindings: return "Show the keybindings"
-            }
+        case .menu(let route):
+            if route == .root { return "Open the menu" }
+            if route == .keybindings { return "Show the keybindings" }
+            // The path, not a name for it: a route names the level it opens, and that level's own
+            // breadcrumb is what the user sees a moment later. A table saying "Choose a theme"
+            // for `Style › Theme` would be a second name for one place, and the day the level is
+            // renamed only one of the two would follow.
+            return "Open " + route.path.joined(separator: " › ")
         case .theme(let slug):
             // Titled from the slug, because that is all a label has: toe ships no themes, so
             // there is no table of names to look one up in, and a theme's directory name is the
             // only thing true of it whether it is installed, merely available, or neither.
             guard !slug.isEmpty else { return "Use your own colours" }
             return "Theme: \(Slug.title(slug))"
+        case .removeTheme(let slug): return "Remove the theme \(Slug.title(slug))"
         case .background(let file):  return "Background: \(ellipsised(file))"
         case .nextBackground:        return "Next background"
         }

--- a/Sources/ToeCore/Menu/MenuModel.swift
+++ b/Sources/ToeCore/Menu/MenuModel.swift
@@ -7,6 +7,38 @@ public enum MenuPage: String, Equatable, Sendable {
     case keybindings
 }
 
+/// Where a `menu` binding opens the quick menu.
+///
+/// Omarchy's menu is one tree with many doors into it — `omarchy-menu toggle background` opens
+/// at `style.background`, `toggle system` at the power rows — and its default bindings use four
+/// of them. toe had two doors, `root` and `keybindings`, so the two keys an Omarchy user reaches
+/// for to change how their desktop looks did not open the menu at all.
+///
+/// The path is titles rather than ids because toe's rows have no ids: `MenuState.rebuild` already
+/// walks the tree by title, for the menu that changes while you are looking at it, so opening at
+/// a level is that same walk with the titles handed in rather than remembered. A path that no
+/// longer resolves — `Style › Background` on a theme with no pictures — stops where it can and
+/// leaves you one rung up, which is the behaviour `rebuild` already had to have.
+public struct MenuRoute: Equatable, Sendable {
+    public let page: MenuPage
+    public let path: [String]
+
+    public init(page: MenuPage = .root, path: [String] = []) {
+        self.page = page
+        self.path = path
+    }
+
+    public static let root = MenuRoute()
+    public static let keybindings = MenuRoute(page: .keybindings)
+    public static let learn = MenuRoute(path: ["Learn"])
+    public static let style = MenuRoute(path: ["Style"])
+    public static let theme = MenuRoute(path: ["Style", "Theme"])
+    public static let background = MenuRoute(path: ["Style", "Background"])
+    public static let setup = MenuRoute(path: ["Setup"])
+    public static let install = MenuRoute(path: ["Install"])
+    public static let remove = MenuRoute(path: ["Remove"])
+}
+
 /// One row.
 public struct MenuItem: Equatable {
 
@@ -16,6 +48,7 @@ public struct MenuItem: Equatable {
     public enum Icon: Equatable, Sendable {
         case gear, book, keyboard, pencil, power, toggleOn, toggleOff
         case paintbrush, droplet, image
+        case download, trash, info, globe
     }
 
     public indirect enum Action: Equatable {
@@ -34,7 +67,8 @@ public struct MenuItem: Equatable {
     /// Only a filtered list sets this: see `MenuState`.
     public let subtitle: String?
     public let icon: Icon?
-    /// The second column: `on`/`off` for the login toggle, what it does for a keybinding row.
+    /// The second column: `on`/`off` for the login toggle, what it does for a keybinding row, a
+    /// `✓` on the choice already in effect.
     public let value: String?
     /// How full to draw the row, 0…1, or nil for the ordinary case of a row that is not doing
     /// anything. Set on the theme being downloaded, and the reason a download is visible at all
@@ -44,21 +78,32 @@ public struct MenuItem: Equatable {
     /// `MenuView` fills whatever row carries this, so the next thing that takes time — and there
     /// will be one — does not need a second way of showing it.
     public let progress: Double?
+    /// Omarchy's `disabled` guard: the row stays listed but goes dim, takes a `✓`, and can no
+    /// longer be selected — the cursor steps over it, a click does not take it, Return does
+    /// nothing, and a search omits it.
+    ///
+    /// It exists for one job, and the job is the reason the Install level is worth having:
+    /// software you already have reads as *installed* rather than vanishing from the list it was
+    /// installed from, so the list stays a catalogue of what toe can fetch rather than a list
+    /// that gets shorter every time you use it.
+    public let isDisabled: Bool
     public let action: Action
 
     public init(title: String, subtitle: String? = nil, icon: Icon? = nil,
-                value: String? = nil, progress: Double? = nil, action: Action) {
+                value: String? = nil, progress: Double? = nil, isDisabled: Bool = false,
+                action: Action) {
         self.title = title
         self.subtitle = subtitle
         self.icon = icon
         self.value = value
         self.progress = progress
+        self.isDisabled = isDisabled
         self.action = action
     }
 
     public func with(subtitle: String?) -> MenuItem {
         MenuItem(title: title, subtitle: subtitle, icon: icon, value: value, progress: progress,
-                 action: action)
+                 isDisabled: isDisabled, action: action)
     }
 
     /// walker marks the rows that lead somewhere with a trailing `›`, right-aligned.
@@ -79,7 +124,7 @@ public enum LoginItemState: Equatable, Sendable {
     case unavailable(String)
 }
 
-/// What the Style level needs to draw itself.
+/// What the Style, Install and Remove levels need to draw themselves.
 ///
 /// A value rather than four parameters, because it is threaded from the Coordinator through
 /// `QuickMenu` to here unchanged, and because it is rebuilt every time the menu opens — that is
@@ -91,7 +136,10 @@ public enum LoginItemState: Equatable, Sendable {
 public struct StyleMenu: Equatable {
     /// Themes on disk — the ones that can be chosen without waiting for anything.
     public var themes: [ThemeRef]
-    /// Themes Omarchy publishes that this machine does not have. Choosing one downloads it.
+    /// Omarchy's published catalogue, whole: the ones this machine has as well as the ones it
+    /// does not. Filtering it is the menu's job rather than the Coordinator's, because the two
+    /// levels that read it want opposite halves — `Style › Theme` offers what is here, and
+    /// `Install › Style › Theme` lists everything and dims what is here.
     public var available: [RemoteTheme]
     /// True while the catalogue is being fetched, so the level can say so rather than looking
     /// like a list that happens to be short.
@@ -123,34 +171,84 @@ public struct StyleMenu: Equatable {
 ///
 /// Deliberately a function of the state it displays rather than a constant: a "Run on startup"
 /// row that shows a remembered value instead of launchd's is a row that will eventually lie.
+///
+/// The tree follows Omarchy's — the same names at the same depth, in the same order — and the
+/// rule for what is missing is Omarchy's own `when` guard: a row whose condition fails is not
+/// listed, and a submenu whose visible descendants have all gone goes with them. That is why
+/// there is no `Style › Menu Bar` (its two rows upstream are Position, which macOS fixes, and
+/// Transparency, which is not toe's menu bar to style) and no `System` (Omarchy's is a power
+/// menu for the machine). What is left should read to an Omarchy user as their own menu with the
+/// Linux taken out, rather than as a different menu that borrowed some names.
 public enum MenuModel {
 
+    /// Omarchy's "this is the current choice" marker: a `✓` appended to the label. toe puts it in
+    /// the second column instead, because that column already exists and right-aligning it keeps
+    /// the titles lined up — but the glyph is the same one, and it means the same thing on a
+    /// theme, a background and an already-installed row.
+    public static let checkmark = "✓"
+
     public static func root(loginItem: LoginItemState, bindings: [Binding],
-                            style: StyleMenu = StyleMenu()) -> [MenuItem] {
-        var items: [MenuItem] = []
-        // Configure can come out empty — neither of its rows is guaranteed — and a row that
-        // leads into an empty level is worse than no row, so the parent goes with it.
-        let configure = configure(loginItem: loginItem, bindings: bindings)
-        if !configure.isEmpty {
-            items.append(MenuItem(title: "Configure", icon: .gear, action: .submenu(configure)))
+                            style: StyleMenu = StyleMenu(),
+                            version: String? = nil) -> [MenuItem] {
+        // Omarchy's root order, with the rows toe has no analogue for left out: Apps, **Learn**,
+        // Trigger, **Style**, **Setup**, **Install**, **Remove**, Update, **About**, System.
+        // Quit is toe's own and goes last, after everything ported.
+        var items: [MenuItem] = [
+            MenuItem(title: "Learn", icon: .book, action: .submenu(learn())),
+            MenuItem(title: "Style", icon: .paintbrush, action: .submenu(MenuModel.style(style))),
+        ]
+        // Setup can come out empty — neither of its rows is guaranteed — and a row that leads
+        // into an empty level is worse than no row, so the parent goes with it. That is Omarchy's
+        // rule for a submenu whose children have all failed their `when`, applied here by hand
+        // because toe's levels are built rather than filtered.
+        let setupRows = setup(loginItem: loginItem, bindings: bindings)
+        if !setupRows.isEmpty {
+            items.append(MenuItem(title: "Setup", icon: .gear, action: .submenu(setupRows)))
         }
-        items.append(MenuItem(title: "Learn", icon: .book, action: .submenu([
-            MenuItem(title: "Keybindings", icon: .keyboard, action: .page(.keybindings)),
-        ])))
-        // Omarchy's own order — Learn, then Style — with Quit last by toe's rule. Unlike
-        // Configure, Style is never conditional: three themes ship, so the level it leads to
-        // cannot come out empty.
-        items.append(MenuItem(title: "Style", icon: .paintbrush, action: .submenu(MenuModel.style(style))))
+        let installRows = install(style)
+        if !installRows.isEmpty {
+            items.append(MenuItem(title: "Install", icon: .download, action: .submenu(installRows)))
+        }
+        let removeRows = remove(style)
+        if !removeRows.isEmpty {
+            items.append(MenuItem(title: "Remove", icon: .trash, action: .submenu(removeRows)))
+        }
+        // Omarchy's About opens a window with the branding in it; toe has no window to open and
+        // one fact to report, so the row *is* the fact — the version in the second column, and
+        // nothing to press. Left out entirely when there is no version to show, which is what a
+        // debug build run straight out of `.build` has.
+        if let version {
+            items.append(MenuItem(title: "About", icon: .info, value: version, action: .note))
+        }
         items.append(MenuItem(title: "Quit", icon: .power, action: .run(.quit)))
         return items
+    }
+
+    /// Omarchy's `Learn` level: the keybindings, then the manuals.
+    ///
+    /// Three of upstream's nine links survive. `toe` stands where `learn.omarchy` does — the
+    /// system's own manual — and Omarchy's is kept because toe ships its defaults and fetches
+    /// its themes, Hyprland's because the layout in the middle of toe is a port of theirs and
+    /// `dwindle`, `preserve_split` and `force_split` are documented there and nowhere else. Arch,
+    /// Neovim, Bash, Tmux, Herdr and the Discord are about a machine this is not running on.
+    public static func learn() -> [MenuItem] {
+        [
+            MenuItem(title: "Keybindings", icon: .keyboard, action: .page(.keybindings)),
+            MenuItem(title: "toe", icon: .globe,
+                     action: .run(.exec("open https://github.com/theclifmeister/toe"))),
+            MenuItem(title: "Omarchy", icon: .globe,
+                     action: .run(.exec("open https://omarchy.org/manual/"))),
+            MenuItem(title: "Hyprland", icon: .globe,
+                     action: .run(.exec("open https://wiki.hypr.land/"))),
+        ]
     }
 
     /// Omarchy's `Style` level, minus the parts toe has no analogue for.
     public static func style(_ style: StyleMenu) -> [MenuItem] {
         var rows = [MenuItem(title: "Theme", icon: .droplet, action: .submenu(themes(style)))]
-        // The Configure rule, one level down: a row that leads into an empty level is worse than
-        // no row. Background appears exactly when the current theme has pictures — which means
-        // when one was downloaded with it, or when you put some there yourself.
+        // The Setup rule, one level down: a row that leads into an empty level is worse than no
+        // row. Background appears exactly when the current theme has pictures — which means when
+        // one was downloaded with it, or when you put some there yourself.
         if !style.backgrounds.isEmpty {
             rows.append(MenuItem(title: "Background", icon: .image,
                                  action: .submenu(MenuModel.backgrounds(style))))
@@ -158,7 +256,12 @@ public enum MenuModel {
         return rows
     }
 
-    /// Every theme toe can see, with the one in effect marked.
+    /// The themes on this machine, with the one in effect marked.
+    ///
+    /// Installed only. A theme that has to be fetched first is under `Install › Style › Theme`,
+    /// where Omarchy keeps it — the split costs toe the one list it used to have and buys the
+    /// thing the split is for: `Style › Theme` is a list of things that happen instantly, and
+    /// nothing in it can start a nine-megabyte download.
     ///
     /// Marked with a value rather than by opening the level with the cursor already on it:
     /// walker preselects, and matching that needs a new mutating entry point on `MenuState`. The
@@ -167,14 +270,46 @@ public enum MenuModel {
     public static func themes(_ style: StyleMenu) -> [MenuItem] {
         var rows = style.themes.map { theme in
             MenuItem(title: theme.name,
-                     value: theme.slug == style.current ? "current" : nil,
+                     value: theme.slug == style.current ? checkmark : nil,
                      action: .run(.theme(theme.slug)))
         }
 
-        // Then what Omarchy publishes and this machine does not have. The size is the disclosure:
-        // these run from a third of a megabyte to nine, and a row that downloaded nine megabytes
-        // without having said so first would be a row that surprised you.
-        rows += style.available.map { theme in
+        // Last rather than first, so the list reads as a list of themes. Short, because a value
+        // in the second column takes its width out of the title's.
+        rows.append(MenuItem(title: "Your own colours",
+                             value: style.current == nil ? checkmark : nil,
+                             action: .run(.theme(""))))
+        return rows
+    }
+
+    /// Omarchy's `Install` level. Upstream it holds sixteen submenus; toe can fetch one kind of
+    /// thing, so it holds `Style › Theme` and the two levels above it exist to put that row
+    /// where an Omarchy user's hands expect to find it.
+    ///
+    /// Empty — and so absent from the root — until the catalogue has been fetched once. A
+    /// machine that has never had a network has nothing to install and says so by not offering.
+    public static func install(_ style: StyleMenu) -> [MenuItem] {
+        let rows = installableThemes(style)
+        guard !rows.isEmpty else { return [] }
+        return [MenuItem(title: "Style", icon: .paintbrush, action: .submenu([
+            MenuItem(title: "Theme", icon: .droplet, action: .submenu(rows)),
+        ]))]
+    }
+
+    /// Everything Omarchy publishes: what you have, dimmed, and what you do not, priced.
+    ///
+    /// The size is the disclosure — these run from a third of a megabyte to nine, and a row that
+    /// downloaded nine megabytes without having said so first would be a row that surprised you.
+    public static func installableThemes(_ style: StyleMenu) -> [MenuItem] {
+        let have = Set(style.themes.map(\.slug))
+        var rows = style.available.map { theme -> MenuItem in
+            guard !have.contains(theme.slug) else {
+                // Omarchy's `disabled`: listed, dim, ticked, unselectable. The action is left on
+                // the row rather than swapped for a `.note` because the row still *is* the thing
+                // it describes; it is the guard that says you cannot have it again.
+                return MenuItem(title: theme.name, value: checkmark, isDisabled: true,
+                                action: .run(.theme(theme.slug)))
+            }
             // The one being fetched trades its size for a count and starts filling: the size was
             // there to tell you what you were about to spend, and once you have spent it the
             // question has become how much longer.
@@ -185,18 +320,26 @@ public enum MenuModel {
                             action: .run(.theme(theme.slug)))
         }
 
-        // Said rather than left to be inferred from a short list. Deliberately after the themes
-        // and before the way out, which is where the rows it is waiting for will appear.
+        // Said rather than left to be inferred from a short list. Deliberately last, which is
+        // where the rows it is waiting for will appear.
         if style.fetching {
             rows.append(MenuItem(title: "Fetching Omarchy's themes…", action: .note))
         }
-
-        // Last rather than first, so the list reads as a list of themes. Short, because a value
-        // in the second column takes its width out of the title's.
-        rows.append(MenuItem(title: "Your own colours",
-                             value: style.current == nil ? "current" : nil,
-                             action: .run(.theme(""))))
         return rows
+    }
+
+    /// Omarchy's `Remove` level. Upstream it is the mirror of Install and hides with `when` what
+    /// is not there to remove; toe has one removable kind of thing, and no themes of its own, so
+    /// this is every folder in `~/.config/toe/themes` — the ones fetched from the catalogue and
+    /// the ones you wrote yourself alike, because on disk there is no difference between them.
+    ///
+    /// No `✓` on the theme in effect. In a list called Remove a tick would read as *this one is
+    /// already gone*; removing the theme you are wearing is allowed, and hands your own colours
+    /// back on the way out.
+    public static func remove(_ style: StyleMenu) -> [MenuItem] {
+        guard !style.themes.isEmpty else { return [] }
+        return [MenuItem(title: "Theme", icon: .droplet, action: .submenu(
+            style.themes.map { MenuItem(title: $0.name, action: .run(.removeTheme($0.slug))) }))]
     }
 
     /// The current theme's pictures, and the row that steps through them.
@@ -211,22 +354,28 @@ public enum MenuModel {
             // The whole file name, extension and all: strip it and a folder holding city.jpg
             // beside city.png gets two rows that say the same thing.
             MenuItem(title: file,
-                     value: file == style.currentBackground ? "current" : nil,
+                     value: file == style.currentBackground ? checkmark : nil,
                      action: .run(.background(file)))
         }
         rows.append(MenuItem(title: "Next background", action: .run(.nextBackground)))
         return rows
     }
 
-    /// The Configure level. Also built on its own, by the menu, when throwing the startup toggle
-    /// rebuilds the level under the cursor.
-    public static func configure(loginItem: LoginItemState, bindings: [Binding]) -> [MenuItem] {
+    /// Omarchy's `Setup` level — the name upstream gives it, and the level `settings` routes to.
+    /// Also built on its own, by the menu, when throwing the startup toggle rebuilds the level
+    /// under the cursor.
+    ///
+    /// `Config` is `setup.config`, which upstream is a submenu of the files Omarchy will open for
+    /// you. toe has one file, so it is one row.
+    public static func setup(loginItem: LoginItemState, bindings: [Binding]) -> [MenuItem] {
         var rows: [MenuItem] = []
-        if let startup = startup(loginItem) { rows.append(startup) }
         if let opener = configOpener(in: bindings) {
-            rows.append(MenuItem(title: "Edit configuration", icon: .pencil,
-                                 action: .run(opener.command)))
+            rows.append(MenuItem(title: "Config", icon: .pencil, action: .run(opener.command)))
         }
+        // After the ported row rather than before it: this one has no Omarchy counterpart — an
+        // Omarchy session does not start its window manager at login, it *is* the login — and
+        // toe's own rows go under the ones an Omarchy user came looking for.
+        if let startup = startup(loginItem) { rows.append(startup) }
         return rows
     }
 
@@ -246,6 +395,10 @@ public enum MenuModel {
     /// to give ("needs /Applications"), so a row that has to explain itself has nowhere to do
     /// it. And a switch you can see but not throw is worse than one that is not offered.
     /// `LoginItem` logs why.
+    ///
+    /// Deliberately not Omarchy's `disabled`, which would leave it listed and dim: that guard
+    /// means "you already have this", and a tick beside a switch that cannot be thrown would say
+    /// the opposite of what is true.
     private static func startup(_ state: LoginItemState) -> MenuItem? {
         switch state {
         case .on:
@@ -294,7 +447,7 @@ public enum MenuModel {
         case .moveToWorkspace:  return 4
         case .workspace:        return 5
         case .killActive, .toggleFloating, .toggleSplit, .swapSplit: return 6
-        case .theme, .background, .nextBackground: return 7
+        case .theme, .removeTheme, .background, .nextBackground: return 7
         case .menu:             return 8
         case .reload, .quit:    return 9
         case .exec:             return 10

--- a/Sources/ToeCore/Menu/MenuState.swift
+++ b/Sources/ToeCore/Menu/MenuState.swift
@@ -29,11 +29,17 @@ public struct MenuState: Equatable {
     public private(set) var scroll: Int = 0
     public private(set) var visibleRows: Int
 
-    public init(root: [MenuItem], visibleRows: Int) {
-        self.stack = [root]
-        self.titles = []
-        self.filtered = root
+    /// - Parameter path: the level to open at, by row title — `["Style", "Theme"]` for the key
+    ///   Omarchy gives its theme picker. Empty is the root, which is every case but a `menu`
+    ///   binding that named a route. A path that does not resolve stops where it can: see
+    ///   `MenuState.walk`.
+    public init(root: [MenuItem], visibleRows: Int, path: [String] = []) {
+        let (levels, reached) = MenuState.walk(root: root, titles: path)
+        self.stack = levels
+        self.titles = reached
+        self.filtered = levels[levels.count - 1]
         self.visibleRows = max(1, visibleRows)
+        self.selection = MenuState.firstSelectable(in: filtered) ?? 0
     }
 
     // MARK: - Reading
@@ -79,23 +85,36 @@ public struct MenuState: Equatable {
 
     /// Clamps rather than wraps. A menu of three rows could defensibly wrap; a keybindings list
     /// of fifty cannot — holding ↓ and finding yourself back at the top reads as a glitch.
+    ///
+    /// A disabled row is stepped over rather than landed on, which is Omarchy's rule for one:
+    /// the search continues past it in the direction of travel, and only if the list runs out
+    /// that way does it look back — so `End` on a list whose last rows are all installed lands on
+    /// the last row you could actually choose instead of refusing to move.
     public mutating func move(by delta: Int) {
-        guard !filtered.isEmpty else { return }
-        selection = min(max(selection + delta, 0), filtered.count - 1)
+        guard !filtered.isEmpty, delta != 0 else { return }
+        let target = min(max(selection + delta, 0), filtered.count - 1)
+        guard let landing = selectable(from: target, step: delta > 0 ? 1 : -1)
+                         ?? selectable(from: target, step: delta > 0 ? -1 : 1) else { return }
+        selection = landing
         clampScroll()
     }
 
-    public mutating func moveToTop() { selection = 0; clampScroll() }
+    public mutating func moveToTop() {
+        selection = selectable(from: 0, step: 1) ?? selection
+        clampScroll()
+    }
 
     public mutating func moveToEnd() {
-        selection = max(filtered.count - 1, 0)
+        guard !filtered.isEmpty else { return }
+        selection = selectable(from: filtered.count - 1, step: -1) ?? selection
         clampScroll()
     }
 
-    /// A click, in on-screen rows rather than filtered indices.
+    /// A click, in on-screen rows rather than filtered indices. A disabled row does not take it —
+    /// the pointer steps over one exactly as the cursor does.
     public mutating func select(row: Int) {
         let index = scroll + row
-        guard filtered.indices.contains(index) else { return }
+        guard filtered.indices.contains(index), !filtered[index].isDisabled else { return }
         selection = index
     }
 
@@ -107,7 +126,10 @@ public struct MenuState: Equatable {
     // MARK: - Acting
 
     public mutating func activate() -> MenuOutcome {
-        guard let item = selectedItem else { return .none }
+        // `selectedItem` can be a disabled row only if one was under the cursor before it became
+        // disabled — a download finishing turns its Install row into an installed one under your
+        // hand. Return does nothing to it, as it does to a `.note`.
+        guard let item = selectedItem, !item.isDisabled else { return .none }
         switch item.action {
         case .submenu(let items):
             stack.append(items)
@@ -159,14 +181,7 @@ public struct MenuState: Equatable {
     /// changing to a theme with none takes the level you are standing in out from under you, and
     /// surfacing one rung up is the answer that cannot show rows belonging to a theme you left.
     public mutating func rebuild(root: [MenuItem]) {
-        var levels: [[MenuItem]] = [root]
-        var reached: [String] = []
-        for title in titles {
-            guard let item = levels[levels.count - 1].first(where: { $0.title == title }),
-                  case .submenu(let children) = item.action else { break }
-            levels.append(children)
-            reached.append(title)
-        }
+        let (levels, reached) = MenuState.walk(root: root, titles: titles)
         stack = levels
         titles = reached
         // The selection is kept rather than reset, which is what makes the fill appear under the
@@ -191,7 +206,10 @@ public struct MenuState: Equatable {
         if query.isEmpty {
             filtered = level
         } else {
-            let flat = MenuState.flatten(level, path: [])
+            // Disabled rows are omitted rather than listed and refused: Omarchy's search does
+            // the same, and a search that offers you a row you cannot press is a worse answer
+            // than one that does not mention it.
+            let flat = MenuState.flatten(level, path: []).filter { !$0.item.isDisabled }
             // Both halves of a row are searchable. On the keybindings page the title is the
             // shortcut and the value is what it does, so a search that only read titles would
             // have you typing `SUPER` to find things.
@@ -205,12 +223,48 @@ public struct MenuState: Equatable {
         }
         if resettingSelection {
             // A keystroke re-ranks the list, so the old index refers to a row that has moved.
-            selection = 0
+            selection = MenuState.firstSelectable(in: filtered) ?? 0
             scroll = 0
         } else {
             selection = min(selection, max(filtered.count - 1, 0))
             clampScroll()
         }
+    }
+
+    /// The first row a cursor may rest on, or nil when every row is disabled — which is a real
+    /// list rather than a defensive one: an Install level whose every theme is already installed
+    /// is exactly that.
+    private static func firstSelectable(in items: [MenuItem]) -> Int? {
+        items.firstIndex { !$0.isDisabled }
+    }
+
+    /// The first selectable row at or beyond `start`, walking one way.
+    private func selectable(from start: Int, step: Int) -> Int? {
+        var index = start
+        while filtered.indices.contains(index) {
+            if !filtered[index].isDisabled { return index }
+            index += step
+        }
+        return nil
+    }
+
+    /// Walks a fresh tree down a list of titles, as far as it goes.
+    ///
+    /// A level that cannot be entered — its row is gone, or stopped leading anywhere — stops the
+    /// walk and leaves the caller at the deepest level that still exists. Shared by `rebuild`,
+    /// where the titles are where the user already is, and by `init(root:visibleRows:path:)`,
+    /// where they are the route a binding asked for.
+    private static func walk(root: [MenuItem],
+                             titles: [String]) -> (levels: [[MenuItem]], reached: [String]) {
+        var levels: [[MenuItem]] = [root]
+        var reached: [String] = []
+        for title in titles {
+            guard let item = levels[levels.count - 1].first(where: { $0.title == title }),
+                  case .submenu(let children) = item.action else { break }
+            levels.append(children)
+            reached.append(title)
+        }
+        return (levels, reached)
     }
 
     /// Every row below this level, branches included: a branch is a thing you can go to, so it

--- a/Sources/ToeCore/Theme/Theme.swift
+++ b/Sources/ToeCore/Theme/Theme.swift
@@ -47,17 +47,14 @@ public struct Theme: Equatable, Sendable {
 /// unthemed.
 public enum Themes {
 
-    /// Everything the menu can offer: what is installed, then what is merely available.
+    /// Yours, in the order every level that lists them draws them: by name, ignoring case.
     ///
-    /// A theme you have beats the same theme upstream, and only appears once — otherwise
-    /// downloading Nord would leave you with two rows saying Nord, one of which would offer to
-    /// download it again. Installed themes keep the order the disk gave them (sorted by name);
-    /// the rest follow, so the list reads as "yours, then everything else".
-    public static func merged(installed: [ThemeRef],
-                              available: [RemoteTheme]) -> (installed: [ThemeRef],
-                                                            available: [RemoteTheme]) {
-        let have = Set(installed.map(\.slug))
-        return (installed.sorted { $0.name.lowercased() < $1.name.lowercased() },
-                available.filter { !have.contains($0.slug) })
+    /// The dedupe that used to live beside this has moved into `MenuModel.installableThemes`,
+    /// where a theme you already have is now *listed and dimmed* rather than dropped from the
+    /// catalogue — Omarchy's `disabled` guard, and what lets `Install › Style › Theme` stay a
+    /// list of everything Omarchy publishes rather than a list that gets shorter every time you
+    /// use it.
+    public static func ordered(_ installed: [ThemeRef]) -> [ThemeRef] {
+        installed.sorted { $0.name.lowercased() < $1.name.lowercased() }
     }
 }

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -876,8 +876,10 @@ h.test("the shipped default config parses cleanly") { t in
     t.equal(binding("super-space")?.command, .menu(.root), "SUPER+SPACE opens the quick menu")
     t.equal(binding("super-space")?.keyCode, 0x31, "space key code")
     t.equal(binding("super-k")?.command, .menu(.keybindings), "SUPER+K lists the bindings")
-    t.equal(binding("super-ctrl-space")?.command, .nextBackground,
-            "SUPER+CTRL+SPACE is the key Omarchy gives to backgrounds")
+    t.equal(binding("super-ctrl-space")?.command, .menu(.background),
+            "SUPER+CTRL+SPACE opens the background picker, as it does in Omarchy")
+    t.equal(binding("super-shift-ctrl-space")?.command, .menu(.theme),
+            "and SUPER+SHIFT+CTRL+SPACE the theme one, the same key upstream binds")
     t.equal(c.menu.background, "#1a1b26", "the menu ships Omarchy's Tokyo Night background")
 
     let arrows = ["super-left", "super-right", "super-up", "super-down"]
@@ -993,7 +995,7 @@ h.test("the escape hatches are bound even when the config forgets them") { t in
 
     // The shipped config binds them itself, so nothing should be duplicated.
     let shipped = try Config.parse(Config.defaultTOML)
-    for command in [Command.quit, .reload, .nextBackground] {
+    for command in [Command.quit, .reload, .menu(.background), .menu(.theme)] {
         t.equal(shipped.bindings.filter { $0.command == command }.count, 1,
                 "the shipped config binds \(command) exactly once")
     }
@@ -1002,13 +1004,21 @@ h.test("the escape hatches are bound even when the config forgets them") { t in
     // others are — a config is never rewritten, so a key added later reaches nobody who already
     // had one — and it obeys the same two rules, which is what makes it something you can take
     // back rather than something done to you.
-    t.equal(binding(old, .nextBackground)?.source, "super-ctrl-space",
-            "a config written before backgrounds existed still gets the key")
-    let moved = try Config.parse("[binds]\n\"super-b\" = \"nextbackground\"\n")
-    t.equal(binding(moved, .nextBackground)?.source, "super-b", "binding it elsewhere takes the key back")
-    t.equal(moved.bindings.filter { $0.command == .nextBackground }.count, 1, "and not twice")
+    t.equal(binding(old, .menu(.background))?.source, "super-ctrl-space",
+            "a config written before backgrounds existed still gets Omarchy's key for them")
+    t.equal(binding(old, .menu(.theme))?.source, "super-shift-ctrl-space", "and the theme one")
+    let moved = try Config.parse("[binds]\n\"super-b\" = \"menu background\"\n")
+    t.equal(binding(moved, .menu(.background))?.source, "super-b",
+            "binding it elsewhere takes the key back")
+    // The key changed hands in the release that followed Omarchy onto quattro. A config that
+    // still names the old command keeps it, because a fallback never lands on a taken key.
+    let stepping = try Config.parse("[binds]\n\"super-ctrl-space\" = \"nextbackground\"\n")
+    t.equal(binding(stepping, .nextBackground)?.source, "super-ctrl-space",
+            "an upgrader who had the old line goes on stepping through pictures")
+    t.equal(binding(stepping, .menu(.background)), nil, "and is not given the picker on top of it")
+    t.equal(moved.bindings.filter { $0.command == .menu(.background) }.count, 1, "and not twice")
     let taken = try Config.parse("[binds]\n\"super-ctrl-space\" = \"killactive\"\n")
-    t.equal(binding(taken, .nextBackground), nil, "and a key you already use is left alone")
+    t.equal(binding(taken, .menu(.background)), nil, "and a key you already use is left alone")
     t.equal(binding(taken, .killActive)?.source, "super-ctrl-space", "still doing what you asked")
 }
 
@@ -1653,12 +1663,12 @@ h.test("typing puts the selection back at the top") { t in
 h.test("a submenu is entered, backed out of, and clears the query on the way in") { t in
     var m = MenuState(root: MenuModel.root(loginItem: .on, bindings: []), visibleRows: 10)
     t.equal(m.prompt, "Go…", "walker's placeholder at the root")
-    m.type("configure")
-    t.equal(m.visible.count, 1, "one row matches 'configure'")
-    t.equal(m.activate(), .pushed, "Configure descends rather than dispatching")
+    m.type("setup")
+    t.equal(m.visible.count, 1, "one row matches 'setup'")
+    t.equal(m.activate(), .pushed, "Setup descends rather than dispatching")
     t.equal(m.query, "", "the query does not follow you into the submenu")
-    t.equal(m.breadcrumb, ["Configure"], "the level is named")
-    t.equal(m.prompt, "Configure…", "and the placeholder says where you are")
+    t.equal(m.breadcrumb, ["Setup"], "the level is named")
+    t.equal(m.prompt, "Setup…", "and the placeholder says where you are")
     t.equal(m.visible.map(\.title), ["Run on startup"], "what toe can actually change for you")
     t.equal(m.pop(), .popped, "Escape climbs one level")
     t.equal(m.pop(), .closed, "and closes at the root")
@@ -1707,7 +1717,7 @@ h.test("typing searches the whole tree, not the level in front of you") { t in
     m.type("startup")
     t.equal(m.visible.map(\.title), ["Run on startup"],
             "found two levels down without anyone having to go there")
-    t.equal(m.visible.first?.subtitle, "Configure", "and the row says where it lives")
+    t.equal(m.visible.first?.subtitle, "Setup", "and the row says where it lives")
     t.equal(m.activate(), .toggleLoginItem, "acting on it needs no descent either")
 
     var deep = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 10)
@@ -1730,14 +1740,14 @@ h.test("an empty query is one level at a time, with no paths") { t in
     m.type("z")
     t.equal(m.visible.count, 0, "nothing matches")
     m.backspace()
-    t.equal(m.visible.map(\.title), ["Configure", "Learn", "Style", "Quit"], "the level comes back")
+    t.equal(m.visible.map(\.title), ["Learn", "Style", "Setup", "Quit"], "the level comes back")
     t.expect(m.visible.allSatisfy { $0.subtitle == nil },
              "and the paths go away with the search that needed them")
 }
 
 h.test("the rows lead where the menu says they do") { t in
     var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 10)
-    t.equal(m.visible.map(\.title), ["Configure", "Learn", "Style", "Quit"], "the whole menu, bare minimum")
+    t.equal(m.visible.map(\.title), ["Learn", "Style", "Setup", "Quit"], "the whole menu, bare minimum")
     t.equal(m.visible.map(\.leadsOn), [true, true, true, false], "three lead on, Quit acts")
     m.type("quit")
     t.equal(m.activate(), .run(.quit), "and Quit dispatches rather than descending")
@@ -1751,9 +1761,9 @@ h.test("the rows lead where the menu says they do") { t in
 h.test("the startup row reads the state it is handed") { t in
     func startup(_ state: LoginItemState) -> MenuItem? {
         let root = MenuModel.root(loginItem: state, bindings: [])
-        // By title rather than by position: Configure is the first row only while it is there
-        // at all, and the case below is the one where it is not.
-        guard case .submenu(let setup)? = root.first(where: { $0.title == "Configure" })?.action
+        // By title rather than by position: Setup moves as Install and Remove come and go with
+        // the catalogue, and in the case below it is not there at all.
+        guard case .submenu(let setup)? = root.first(where: { $0.title == "Setup" })?.action
         else { return nil }
         return setup.first
     }
@@ -1765,26 +1775,27 @@ h.test("the startup row reads the state it is handed") { t in
             + "throw is worse than one you were never offered")
 }
 
-h.test("the Edit configuration row is your binding, not toe's idea of an editor") { t in
+h.test("the Config row is your binding, not toe's idea of an editor") { t in
     func rows(_ toml: String, loginItem: LoginItemState = .off) throws -> [MenuItem] {
-        MenuModel.configure(loginItem: loginItem, bindings: try Config.parse(toml).bindings)
+        MenuModel.setup(loginItem: loginItem, bindings: try Config.parse(toml).bindings)
     }
 
     // The shipped config: the row runs exactly the line the file bound, character for character.
+    // Omarchy's `setup.config` first, then toe's own row — the ported rows lead.
     let shipped = try rows(Config.defaultTOML)
-    t.equal(shipped.map(\.title), ["Run on startup", "Edit configuration"], "both rows")
-    t.equal(shipped.last?.action,
+    t.equal(shipped.map(\.title), ["Config", "Run on startup"], "both rows, Omarchy's leading")
+    t.equal(shipped.first?.action,
             .run(.exec("open -a \"Visual Studio Code\" ~/.config/toe/toe.toml")),
             "and it opens the config the way your config says to")
 
     // Point it at another editor and the row follows — nothing here names one.
     let zed = try rows("[binds]\n\"super-comma\" = \"exec open -a Zed ~/.config/toe/toe.toml\"\n")
-    t.equal(zed.last?.action, .run(.exec("open -a Zed ~/.config/toe/toe.toml")),
+    t.equal(zed.first?.action, .run(.exec("open -a Zed ~/.config/toe/toe.toml")),
             "the menu opens Zed because the config does")
 
     // On another key, too: the row is found by what it does, not by where it is bound.
     let moved = try rows("[binds]\n\"super-shift-c\" = \"exec open -e ~/.config/toe/toe.toml\"\n")
-    t.equal(moved.last?.action, .run(.exec("open -e ~/.config/toe/toe.toml")),
+    t.equal(moved.first?.action, .run(.exec("open -e ~/.config/toe/toe.toml")),
             "SUPER+SHIFT+C is as good as SUPER+, — the row follows the binding")
 
     // An exec that opens something else is not an editor for this file.
@@ -1795,15 +1806,14 @@ h.test("the Edit configuration row is your binding, not toe's idea of an editor"
                            bindings: try Config.parse("[binds]\n\"super-enter\" = \"exec open -a Ghostty\"\n").bindings)
                 .map(\.title),
             ["Learn", "Style", "Quit"],
-            "and with the startup row gone as well, Configure has nothing left to hold")
+            "and with the startup row gone as well, Setup has nothing left to hold")
 
     // The row is there even when the startup toggle cannot be.
     let buildDir = try rows(Config.defaultTOML, loginItem: .unavailable("needs /Applications"))
-    t.equal(buildDir.map(\.title), ["Edit configuration"],
-            "the one row that works is still offered")
+    t.equal(buildDir.map(\.title), ["Config"], "the one row that works is still offered")
 }
 
-h.test("Configure goes with the startup row, being all that was left in it") { t in
+h.test("Setup goes with the startup row, being all that was left in it") { t in
     let m = MenuState(root: MenuModel.root(loginItem: .unavailable("needs /Applications"), bindings: []),
                       visibleRows: 10)
     t.equal(m.visible.map(\.title), ["Learn", "Style", "Quit"],
@@ -1917,10 +1927,14 @@ h.test("a download's label names the picture in flight, not the last one finishe
 }
 
 h.test("the theme being downloaded is the row that fills") { t in
-    let rows = MenuModel.themes(downloadingStyle(fetching: 3, bytesDone: 200_000))
+    let style = downloadingStyle(fetching: 3, bytesDone: 200_000)
+    // Install lists what Omarchy publishes; Style lists what is on the disk. A download happens
+    // in the first and lands in the second, which is why the fill is asserted on Install's rows
+    // and the `✓` on Style's.
+    let rows = MenuModel.installableThemes(style)
     guard let solitude = rows.first(where: { $0.title == "Solitude" }),
           let lupine = rows.first(where: { $0.title == "Lupine" }),
-          let gruvbox = rows.first(where: { $0.title == "Gruvbox" }) else {
+          let gruvbox = MenuModel.themes(style).first(where: { $0.title == "Gruvbox" }) else {
         return t.expect(false, "all three themes should have rows")
     }
     t.equal(solitude.progress, 200_000.0 / 4_400_000,
@@ -1931,10 +1945,10 @@ h.test("the theme being downloaded is the row that fills") { t in
     t.equal(lupine.progress, nil, "the other themes on offer are untouched")
     t.equal(lupine.value, "0.4 MB", "and still say what they cost")
     t.equal(gruvbox.progress, nil, "as is the one already on disk")
-    t.equal(gruvbox.value, "current", "which still says it is the one in effect")
+    t.equal(gruvbox.value, MenuModel.checkmark, "which still says it is the one in effect")
 
     // Nothing downloading is the ordinary case, and no row should carry a fraction in it.
-    let idle = MenuModel.themes(StyleMenu(themes: [], available: [
+    let idle = MenuModel.installableThemes(StyleMenu(themes: [], available: [
         RemoteTheme(slug: "solitude", name: "Solitude", backgrounds: []),
     ]))
     t.equal(idle.compactMap { $0.progress }.count, 0, "with nothing being fetched, no row fills")
@@ -1981,7 +1995,9 @@ h.test("a filling row is the row cut off at the fraction") { t in
 h.test("rebuilding under an open menu leaves you where you were standing") { t in
     var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: [],
                                            style: downloadingStyle(fetching: 1, bytesDone: 0)), visibleRows: 10)
-    // Down into Style › Theme, the way a user gets there.
+    // Down into Install › Style › Theme, the way a user gets to a theme they have not got.
+    while m.selectedItem?.title != "Install" { m.move(by: 1) }
+    t.equal(m.activate(), .pushed, "into Install")
     while m.selectedItem?.title != "Style" { m.move(by: 1) }
     t.equal(m.activate(), .pushed, "into Style")
     while m.selectedItem?.title != "Theme" { m.move(by: 1) }
@@ -1994,7 +2010,7 @@ h.test("rebuilding under an open menu leaves you where you were standing") { t i
     // rungs down and the menu cannot know which of MenuModel's builders made it.
     m.rebuild(root: MenuModel.root(loginItem: .off, bindings: [],
                                    style: downloadingStyle(fetching: 5, bytesDone: 2_400_000)))
-    t.equal(m.breadcrumb, ["Style", "Theme"], "still on the level it was on")
+    t.equal(m.breadcrumb, ["Install", "Style", "Theme"], "still on the level it was on")
     t.equal(m.selection, standingOn, "still on the row it was on")
     t.equal(m.selectedItem?.title, "Solitude", "which is still the same row")
     t.equal(m.selectedItem?.progress, 2_400_000.0 / 4_400_000, "and it has filled further")
@@ -2026,18 +2042,15 @@ h.test("a rebuild that cannot re-enter a level surfaces one rung up") { t in
 
 h.test("the fetching note appears and goes away without the menu being reopened") { t in
     var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: [],
-                                           style: StyleMenu(fetching: true)), visibleRows: 10)
-    while m.selectedItem?.title != "Style" { m.move(by: 1) }
-    _ = m.activate()
-    while m.selectedItem?.title != "Theme" { m.move(by: 1) }
-    _ = m.activate()
-    t.equal(m.visible.map(\.title), ["Fetching Omarchy's themes…", "Your own colours"],
+                                           style: StyleMenu(fetching: true)),
+                      visibleRows: 10, path: ["Install", "Style", "Theme"])
+    t.equal(m.visible.map(\.title), ["Fetching Omarchy's themes…"],
             "a machine with nothing yet, mid-fetch")
 
     // The catalogue arrives. This is what `ThemeCatalogue.onChange` now reaches.
     m.rebuild(root: MenuModel.root(loginItem: .off, bindings: [], style: StyleMenu(
         available: [RemoteTheme(slug: "nord", name: "Nord", backgrounds: [])], fetching: false)))
-    t.equal(m.visible.map(\.title), ["Nord", "Your own colours"],
+    t.equal(m.visible.map(\.title), ["Nord"],
             "the note gives way to the themes it was waiting for")
 }
 
@@ -2088,8 +2101,9 @@ h.test("every command has a label a reader could use") { t in
         .moveToWorkspace(5, follow: true), .moveToWorkspace(5, follow: false),
         .killActive, .toggleFloating, .toggleSplit, .swapSplit,
         .exec("open -a Safari"), .reload, .quit,
-        .menu(.root), .menu(.keybindings),
-        .theme("gruvbox"), .theme(""), .background("city.jpg"), .nextBackground,
+        .menu(.root), .menu(.keybindings), .menu(.theme), .menu(.background),
+        .theme("gruvbox"), .theme(""), .removeTheme("gruvbox"),
+        .background("city.jpg"), .nextBackground,
     ]
     for command in all {
         let label = CommandLabel.describe(command)
@@ -2098,6 +2112,10 @@ h.test("every command has a label a reader could use") { t in
     }
     t.equal(CommandLabel.describe(.moveFocus(.left)), "Move focus left", "a sample of the prose")
     t.equal(CommandLabel.describe(.menu(.keybindings)), "Show the keybindings", "and the new one")
+    t.equal(CommandLabel.describe(.menu(.theme)), "Open Style › Theme",
+            "a route is named by the level it opens, so the label cannot drift from the menu")
+    t.equal(CommandLabel.describe(.removeTheme("rose-pine")), "Remove the theme Rose Pine",
+            "and removing one reads as what it does to the disk")
     t.equal(CommandLabel.describe(.theme("gruvbox")), "Theme: Gruvbox",
             "a theme toe ships is named the way it names itself")
     t.equal(CommandLabel.describe(.theme("rose-pine")), "Theme: Rose Pine",
@@ -2120,7 +2138,7 @@ h.test("the binding that opens the config is named rather than spelled out") { t
     // The same rule the menu row is found by, so the two can never disagree.
     let c = try Config.parse(Config.defaultTOML)
     t.equal(MenuModel.configOpener(in: c.bindings)?.source, "super-comma",
-            "and it is the binding the menu offers as Edit configuration")
+            "and it is the binding the menu offers as Config")
     t.equal(c.bindings.filter { $0.command.opensConfig }.count, 1,
             "exactly one binding in the shipped config opens it")
 }
@@ -2260,7 +2278,28 @@ h.test("menu commands parse in both spellings") { t in
     t.equal(try CommandParser.parse("keybindings"), .menu(.keybindings), "the shorthand")
     t.equal(try CommandParser.parse("menu keys"), .menu(.keybindings), "and its abbreviation")
     t.expect((try? CommandParser.parse("menu wardrobe")) == nil,
-             "an unknown page is an error rather than quietly the root menu")
+             "an unknown route is an error rather than quietly the root menu")
+}
+
+h.test("a menu binding opens the level Omarchy's own key opens") { t in
+    // The routes are `omarchy-menu toggle <route>`, aliases included, so a line copied out of
+    // Omarchy's bindings opens the same level here.
+    t.equal(try CommandParser.parse("menu theme"), .menu(.theme), "SUPER+SHIFT+CTRL+SPACE's")
+    t.equal(try CommandParser.parse("menu themes"), .menu(.theme), "and upstream's plural alias")
+    t.equal(try CommandParser.parse("menu background"), .menu(.background), "SUPER+CTRL+SPACE's")
+    t.equal(try CommandParser.parse("menu wallpaper"), .menu(.background), "by its other name")
+    t.equal(try CommandParser.parse("menu settings"), .menu(.setup),
+            "Omarchy's alias for Setup, which is the name it gives the level")
+    t.equal(try CommandParser.parse("menu uninstall"), .menu(.remove), "and for Remove")
+    t.equal(try CommandParser.parse("menu install"), .menu(.install), "the level itself")
+    t.equal(MenuRoute.theme.path, ["Style", "Theme"], "a route is a path through the tree")
+
+    t.equal(try CommandParser.parse("removetheme gruvbox"), .removeTheme("gruvbox"),
+            "removing one is a command like any other")
+    t.equal(try CommandParser.parse("removetheme \"Rose Pine\""), .removeTheme("rose-pine"),
+            "slugified at the door, because the name is about to be joined onto a path")
+    t.expect((try? CommandParser.parse("removetheme")) == nil,
+             "and it needs an argument — there is no theme called nothing to delete")
 }
 
 // MARK: - Themes
@@ -2654,21 +2693,26 @@ h.test("a directory name reads back as a title") { t in
     t.equal(Slug.title(""), "", "and nothing is nothing")
 }
 
-h.test("a theme you have is not also offered for download") { t in
-    let installed = [ThemeRef(slug: "gruvbox", name: "Gruvbox"),
-                     ThemeRef(slug: "rose-pine", name: "Rose Pine")]
+h.test("a theme you have is listed and dimmed rather than offered twice") { t in
+    let installed = [ThemeRef(slug: "rose-pine", name: "Rose Pine"),
+                     ThemeRef(slug: "gruvbox", name: "Gruvbox")]
     let available = [RemoteTheme(slug: "gruvbox", name: "Gruvbox", backgrounds: []),
                      RemoteTheme(slug: "nord", name: "Nord",
                                  backgrounds: [RemoteFile(name: "a.jpg", bytes: 4_300_000)])]
-    let (have, offer) = Themes.merged(installed: installed, available: available)
-    t.equal(have.map(\.slug), ["gruvbox", "rose-pine"], "yours, sorted by name")
-    // Otherwise downloading Nord would leave two rows saying Nord, one offering to fetch it again.
-    t.equal(offer.map(\.slug), ["nord"], "and only what you have not got")
-    t.equal(offer.first?.bytes, 4_300_000, "carrying what it would cost")
+    t.equal(Themes.ordered(installed).map(\.slug), ["gruvbox", "rose-pine"],
+            "yours, sorted by name — the order every level that lists them draws")
 
-    let (none, all) = Themes.merged(installed: [], available: available)
-    t.equal(none.isEmpty, true, "a machine that has fetched nothing has nothing installed")
-    t.equal(all.count, 2, "and is offered everything")
+    // Omarchy's `disabled` guard: Install stays a catalogue of everything it can fetch rather
+    // than a list that gets shorter every time you use it.
+    let rows = MenuModel.installableThemes(StyleMenu(themes: installed, available: available))
+    t.equal(rows.map(\.title), ["Gruvbox", "Nord"], "the whole catalogue, in its own order")
+    t.equal(rows.map(\.isDisabled), [true, false], "and the one you have cannot be fetched again")
+    t.equal(rows.first?.value, MenuModel.checkmark, "which is what the tick says")
+    t.equal(rows.last?.value, "4.1 MB", "while the one you could have says what it costs")
+
+    let fresh = MenuModel.installableThemes(StyleMenu(themes: [], available: available))
+    t.equal(fresh.map(\.isDisabled), [false, false],
+            "a machine that has fetched nothing is offered everything")
 }
 
 h.test("toe's own colours are Tokyo Night already, so that theme only moves the border") { t in
@@ -2905,7 +2949,7 @@ h.test("a backgrounds folder is filtered and sorted the same way twice") { t in
 h.test("Style is always at the root, because it is how you get a theme at all") { t in
     let m = MenuState(root: MenuModel.root(loginItem: .unavailable("needs /Applications"),
                                            bindings: []), visibleRows: 10)
-    // Unlike Configure, which goes when both its rows are unavailable, Style stays even on a
+    // Unlike Setup, which goes when both its rows are unavailable, Style stays even on a
     // machine with no themes and no network: it is the level you go to *to* get one, so leaving
     // it out exactly when it is most needed would be the wrong way round.
     t.equal(m.visible.map(\.title), ["Learn", "Style", "Quit"], "still there with nothing behind it")
@@ -2914,7 +2958,7 @@ h.test("Style is always at the root, because it is how you get a theme at all") 
 }
 
 h.test("Background is left out when there are no images") { t in
-    // The Configure-when-empty rule, one level down — and the usual case, since toe ships no
+    // The Setup-when-empty rule, one level down — and the usual case, since toe ships no
     // pictures of its own.
     t.equal(MenuModel.style(StyleMenu()).count, 1, "nothing to show, so no row leading to it")
     let withPictures = StyleMenu(current: "gruvbox", backgrounds: ["a.jpg", "b.jpg"])
@@ -2927,42 +2971,78 @@ h.test("the theme you are on is marked, and so is having none") { t in
     let themed = MenuModel.themes(StyleMenu(themes: have, current: "gruvbox"))
     t.equal(themed.map(\.title), ["Tokyo Night", "Gruvbox", "Your own colours"],
             "what is installed, then the way back out")
-    t.equal(themed.filter { $0.value == "current" }.map(\.title), ["Gruvbox"], "exactly one is marked")
+    t.equal(themed.filter { $0.value == MenuModel.checkmark }.map(\.title), ["Gruvbox"],
+            "exactly one is marked, with the tick Omarchy marks a current choice with")
     t.equal(themed.first?.action, .run(.theme("tokyo-night")), "and a row runs the theme command")
 
     let bare = MenuModel.themes(StyleMenu(themes: have))
-    t.equal(bare.filter { $0.value == "current" }.map(\.title), ["Your own colours"],
+    t.equal(bare.filter { $0.value == MenuModel.checkmark }.map(\.title), ["Your own colours"],
             "no theme is a state the list can show, not an absence of state")
     t.equal(bare.last?.action, .run(.theme("")), "and choosing it clears the name")
 }
 
-h.test("what you have leads, what you could have follows, with its price on it") { t in
-    let rows = MenuModel.themes(StyleMenu(
+h.test("Style lists what is instant, Install what has to be fetched") { t in
+    // Omarchy's split, and what it buys: nothing in Style › Theme can start a nine-megabyte
+    // download, and Install stays a catalogue rather than a list that empties as you use it.
+    let style = StyleMenu(
         themes: [ThemeRef(slug: "rose-pine", name: "Rose Pine")],
         available: [RemoteTheme(slug: "nord", name: "Nord",
                                 backgrounds: [RemoteFile(name: "a.jpg", bytes: 4_300_000)]),
                     RemoteTheme(slug: "everforest", name: "Everforest", backgrounds: [])],
-        current: "rose-pine"))
-    t.equal(rows.map(\.title), ["Rose Pine", "Nord", "Everforest", "Your own colours"],
-            "installed first, then what Omarchy publishes")
-    t.equal(rows.first?.value, "current", "the one you are on is marked")
+        current: "rose-pine")
+
+    let mine = MenuModel.themes(style)
+    t.equal(mine.map(\.title), ["Rose Pine", "Your own colours"],
+            "what is on the disk, then the way back out — and nothing that would download")
+    t.equal(mine.first?.value, MenuModel.checkmark, "the one you are on is marked")
+
+    let catalogue = MenuModel.installableThemes(style)
+    t.equal(catalogue.map(\.title), ["Nord", "Everforest"], "everything Omarchy publishes")
     // The size is the disclosure: these run from a third of a megabyte to nine, and a row that
     // fetched nine megabytes without saying so first would be a row that surprised you.
-    t.equal(rows[1].value, "4.1 MB", "and a download says what it costs")
-    t.equal(rows[2].value, "", "one with no pictures costs nothing worth printing")
-    // One command either way: choosing a theme is the same act whether or not you have it yet.
-    t.equal(rows[1].action, .run(.theme("nord")), "and is chosen the same way as one you have")
+    t.equal(catalogue.first?.value, "4.1 MB", "and a download says what it costs")
+    t.equal(catalogue.last?.value, "", "one with no pictures costs nothing worth printing")
+    // One command either way: choosing a theme is the same act wherever the row lives.
+    t.equal(catalogue.first?.action, .run(.theme("nord")),
+            "and is chosen the same way as one you have")
+
+    // Install is a row at the root only while there is something behind it.
+    t.equal(MenuModel.install(StyleMenu()).isEmpty, true,
+            "a machine that has never fetched the catalogue is offered no Install at all")
+    guard case .submenu(let inner)? = MenuModel.install(style).first?.action else {
+        return t.expect(false, "Install holds Omarchy's Style level")
+    }
+    t.equal(MenuModel.install(style).map(\.title), ["Style"], "Omarchy's own depth, kept")
+    t.equal(inner.map(\.title), ["Theme"], "with Theme under it")
+}
+
+h.test("Remove lists the themes on the disk, and nothing when there are none") { t in
+    let style = StyleMenu(themes: [ThemeRef(slug: "gruvbox", name: "Gruvbox"),
+                                   ThemeRef(slug: "nord", name: "Nord")],
+                          current: "gruvbox")
+    guard case .submenu(let themes)? = MenuModel.remove(style).first?.action else {
+        return t.expect(false, "Remove holds a Theme level")
+    }
+    t.equal(MenuModel.remove(style).map(\.title), ["Theme"], "one kind of thing to remove")
+    t.equal(themes.map(\.title), ["Gruvbox", "Nord"], "every folder, fetched or hand-written")
+    t.equal(themes.first?.action, .run(.removeTheme("gruvbox")),
+            "including the one in effect, which hands your own colours back on the way out")
+    t.equal(themes.compactMap(\.value).count, 0,
+            "and no tick: in a list called Remove one would read as `already gone`")
+    t.equal(MenuModel.remove(StyleMenu()).isEmpty, true, "nothing to remove, no row offering to")
 }
 
 h.test("an empty list says it is fetching rather than looking short") { t in
-    let rows = MenuModel.themes(StyleMenu(fetching: true))
-    t.equal(rows.map(\.title), ["Fetching Omarchy's themes…", "Your own colours"],
+    let rows = MenuModel.installableThemes(StyleMenu(fetching: true))
+    t.equal(rows.map(\.title), ["Fetching Omarchy's themes…"],
             "said, not left to be inferred from a list with nothing in it")
     t.equal(rows.first?.leadsOn, false, "it does not lead anywhere")
     var m = MenuState(root: rows, visibleRows: 10)
     t.equal(m.activate(), MenuOutcome.none, "and pressing it does nothing, leaving the menu up")
+    t.equal(MenuModel.installableThemes(StyleMenu()).isEmpty, true,
+            "and once it is not fetching, a bare list is bare enough to take Install with it")
     t.equal(MenuModel.themes(StyleMenu()).map(\.title), ["Your own colours"],
-            "and once it is not fetching, a bare list is just bare")
+            "while Style always has the way back out")
 }
 
 h.test("the Background level is shaped like the Theme level above it") { t in
@@ -2975,7 +3055,8 @@ h.test("the Background level is shaped like the Theme level above it") { t in
     t.equal(rows.compactMap(\.icon).count, 0,
             "no icons: one icon among four rows indents that row's text past the rest")
     t.equal(MenuModel.themes(StyleMenu()).compactMap(\.icon).count, 0, "as the theme list has none")
-    t.equal(rows.first { $0.title == "city.png" }?.value, "current", "with the one on screen marked")
+    t.equal(rows.first { $0.title == "city.png" }?.value, MenuModel.checkmark,
+            "with the one on screen marked")
     t.equal(rows.first?.value, nil, "and only that one")
     t.expect(rows.first?.title.hasSuffix(".jpg") == true,
              "the extension stays, or two files would give two rows saying the same word")
@@ -2986,9 +3067,13 @@ h.test("a theme can be found by typing its name from the root") { t in
     var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: [], style: style),
                       visibleRows: 10)
     m.type("gruv")
-    t.equal(m.visible.map(\.title), ["Gruvbox"], "two levels down, without going there")
-    t.equal(m.visible.first?.subtitle, "Style › Theme", "and it says where it was found")
-    t.equal(m.activate(), .run(.theme("gruvbox")), "ready to act on")
+    // Twice, because a theme on the disk is two rows now: the one that wears it and the one that
+    // deletes it. That is upstream's answer too — searching Omarchy's menu for a theme finds its
+    // Install row beside its Remove row — and the path under each is what tells them apart.
+    t.equal(m.visible.map(\.title), ["Gruvbox", "Gruvbox"], "two levels down, without going there")
+    t.equal(m.visible.map(\.subtitle), ["Style › Theme", "Remove › Theme"],
+            "and each says where it was found")
+    t.equal(m.activate(), .run(.theme("gruvbox")), "the first is the one that wears it")
 
     var picture = MenuState(root: MenuModel.root(loginItem: .off, bindings: [],
                                                  style: StyleMenu(current: "gruvbox",
@@ -2996,6 +3081,89 @@ h.test("a theme can be found by typing its name from the root") { t in
                             visibleRows: 10)
     picture.type("city")
     t.equal(picture.activate(), .run(.background("city.jpg")), "a picture is reachable the same way")
+}
+
+// MARK: - Following Omarchy's tree
+
+h.test("the root is Omarchy's root, with what a Mac cannot do left out") { t in
+    // Upstream's order is Apps, Learn, Trigger, Style, Setup, Install, Remove, Update, About,
+    // System. Every row toe has an analogue for, in that order, and Quit — which has no
+    // counterpart, Omarchy's System being a power menu for the machine — last.
+    let full = StyleMenu(themes: [ThemeRef(slug: "gruvbox", name: "Gruvbox")],
+                         available: [RemoteTheme(slug: "nord", name: "Nord", backgrounds: [])],
+                         current: "gruvbox", backgrounds: ["a.jpg"])
+    let c = try Config.parse(Config.defaultTOML)
+    let rows = MenuModel.root(loginItem: .off, bindings: c.bindings, style: full, version: "0.9.7")
+    t.equal(rows.map(\.title),
+            ["Learn", "Style", "Setup", "Install", "Remove", "About", "Quit"],
+            "the same names at the same depth, in the same order")
+    t.equal(rows.first { $0.title == "About" }?.value, "0.9.7",
+            "About is the one fact toe can report about itself, in the second column")
+    t.equal(rows.first { $0.title == "About" }?.action, .note, "and nothing to press")
+    t.expect(MenuModel.root(loginItem: .off, bindings: c.bindings, style: full)
+                .allSatisfy { $0.title != "About" },
+             "a build with no stamped version leaves the row out rather than saying `unknown`")
+}
+
+h.test("Learn is the keybindings and the three manuals that are about this machine") { t in
+    let rows = MenuModel.learn()
+    t.equal(rows.map(\.title), ["Keybindings", "toe", "Omarchy", "Hyprland"],
+            "toe stands where learn.omarchy does — the system's own manual")
+    t.equal(rows.first?.action, .page(.keybindings), "the first row is still the page")
+    t.expect(rows.dropFirst().allSatisfy {
+        if case .run(.exec(let line)) = $0.action { return line.hasPrefix("open https://") }
+        return false
+    }, "and the rest open a URL, which is all upstream's links do")
+}
+
+h.test("a binding can open the menu at a level, the way omarchy-menu toggle does") { t in
+    let style = StyleMenu(themes: [ThemeRef(slug: "gruvbox", name: "Gruvbox")],
+                          current: "gruvbox", backgrounds: ["city.jpg", "coast.jpg"])
+    let root = MenuModel.root(loginItem: .off, bindings: [], style: style)
+
+    var m = MenuState(root: root, visibleRows: 10, path: MenuRoute.background.path)
+    t.equal(m.breadcrumb, ["Style", "Background"], "opened three rows in")
+    t.equal(m.prompt, "Background…", "and the placeholder says so")
+    t.equal(m.visible.map(\.title), ["city.jpg", "coast.jpg", "Next background"], "at the pictures")
+    t.equal(m.pop(), .popped, "Escape still climbs out of it")
+    t.equal(m.breadcrumb, ["Style"], "one rung at a time, into the tree it was opened inside")
+
+    // A route that does not resolve stops where it can rather than failing: Background exists
+    // only while the current theme has pictures, and the key is bound whether it does or not.
+    let bare = MenuState(root: MenuModel.root(loginItem: .off, bindings: [], style: StyleMenu()),
+                         visibleRows: 10, path: MenuRoute.background.path)
+    t.equal(bare.breadcrumb, ["Style"], "as deep as the tree goes, and no error")
+    t.equal(MenuState(root: root, visibleRows: 10).breadcrumb, [],
+            "and no path at all is the root, which is every other way the menu opens")
+}
+
+h.test("a disabled row is listed, ticked, and cannot be reached") { t in
+    // Omarchy's `disabled`: the cursor steps over it, the pointer does not take it, Return does
+    // nothing to it, and a search does not turn it up.
+    let style = StyleMenu(themes: [ThemeRef(slug: "gruvbox", name: "Gruvbox")],
+                          available: [RemoteTheme(slug: "gruvbox", name: "Gruvbox", backgrounds: []),
+                                      RemoteTheme(slug: "nord", name: "Nord", backgrounds: [])])
+    var m = MenuState(root: MenuModel.installableThemes(style), visibleRows: 10)
+    t.equal(m.visible.map(\.title), ["Gruvbox", "Nord"], "both rows are listed")
+    t.equal(m.selection, 1, "but the cursor opens on the first one it could act on")
+    m.move(by: -1)
+    t.equal(m.selection, 1, "and moving up cannot land on the one above it")
+    m.select(row: 0)
+    t.equal(m.selection, 1, "a click does not take it either")
+    m.moveToTop()
+    t.equal(m.selection, 1, "nor does Home")
+
+    m.type("gruv")
+    t.equal(m.visible.count, 0, "and a search that would find it does not offer it")
+    m.backspace(); m.backspace(); m.backspace(); m.backspace()
+    t.equal(m.visible.count, 2, "the level comes back whole")
+
+    // The one way the cursor can end up on one: it was selectable when you arrived, and a
+    // download finishing turned it into an installed row under your hand.
+    var landed = MenuState(root: [MenuItem(title: "Gruvbox", isDisabled: true,
+                                           action: .run(.theme("gruvbox")))],
+                           visibleRows: 10)
+    t.equal(landed.activate(), MenuOutcome.none, "pressing it does nothing, leaving the menu up")
 }
 
 exit(h.report())

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -522,13 +522,32 @@ final class Coordinator: WindowTrackerDelegate {
             themes = ThemeStore.installed()
             if let current { backgrounds = ThemeStore.backgrounds(named: current) }
         }
-        let (installed, offer) = Themes.merged(installed: themes, available: available.themes)
+        let installed = Themes.ordered(themes)
         themes = installed
-        return StyleMenu(themes: installed, available: offer,
+        // The catalogue whole, installed themes included: `Style › Theme` reads the first field
+        // and `Install › Style › Theme` reads this one, dimming what it finds in both.
+        return StyleMenu(themes: installed, available: available.themes,
                          fetching: available.isFetching,
                          current: current,
                          backgrounds: backgrounds, currentBackground: currentBackground,
                          downloading: downloading)
+    }
+
+    /// Takes a theme off the disk, and off your border if you were wearing it.
+    ///
+    /// The order matters: the config is rewritten *first*, so that the moment the folder goes
+    /// there is nothing left pointing at it. Doing it the other way round leaves a window — short,
+    /// but real, because writing the config reloads it — in which the palette in effect names a
+    /// directory that is no longer there, and toe would report the theme it just removed as
+    /// broken rather than as gone.
+    private func removeTheme(_ slug: String) {
+        // Through the slug, because a hand-written config may say `name = "Tokyo Night"` where
+        // the folder is `tokyo-night`, and the theme about to be deleted would otherwise not be
+        // recognised as the one in effect.
+        if slug == Slug.make(config.theme.name) { setTheme("") }
+        guard ThemeStore.remove(named: slug) else { return }
+        themes = ThemeStore.installed()
+        refreshMenu()
     }
 
     /// Writes the theme into your config rather than holding it in memory, so it survives a
@@ -1264,11 +1283,11 @@ final class Coordinator: WindowTrackerDelegate {
             // changed, so the unchanged-bytes early-out would make it do nothing at all.
             loadConfig(force: true)
 
-        case .menu(let page):
+        case .menu(let route):
             // `styleMenu()` re-reads the themes directory here rather than relying on the last
             // reload, which is what makes a theme folder you created a moment ago appear the
             // first time you look. It is a directory listing; nothing is opened.
-            quickMenu.toggle(page: page, config: config,
+            quickMenu.toggle(route: route, config: config,
                              usable: workspaces.monitor(id: workspaces.focusedMonitorID)?.usable,
                              style: styleMenu())
 
@@ -1278,6 +1297,9 @@ final class Coordinator: WindowTrackerDelegate {
 
         case .theme(let slug):
             setTheme(slug)
+
+        case .removeTheme(let slug):
+            removeTheme(slug)
 
         case .background(let file):
             setBackground(file)

--- a/Sources/toe/ThemeStore.swift
+++ b/Sources/toe/ThemeStore.swift
@@ -85,6 +85,44 @@ enum ThemeStore {
         return Backgrounds.list(names)
     }
 
+    /// Deletes a theme's folder — `omarchy-theme-remove`, which is `rm -rf` on the same path.
+    ///
+    /// The one thing in toe that destroys a directory the user might have written by hand, so it
+    /// is held to the shape of a theme name before it joins the path rather than after: a slug
+    /// has no `/` and cannot be `..`, and a name that is not one names nothing here. That is
+    /// upstream's guard too, and for the same reason — a theme called `..` would take
+    /// `~/.config/toe` with it.
+    ///
+    /// The trash rather than an unlink, because this is somebody's own colours and a menu row is
+    /// a small thing to have pressed by accident. Falls back to removing outright where there is
+    /// no trash to move it to.
+    @discardableResult
+    static func remove(named slug: String) -> Bool {
+        guard !slug.isEmpty, slug == Slug.make(slug) else {
+            Log.error("theme remove: '\(slug)' is not a theme name")
+            return false
+        }
+        let folder = directory.appendingPathComponent(slug)
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: folder.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            Log.error("theme remove: there is no theme called '\(slug)'")
+            return false
+        }
+        do {
+            try FileManager.default.trashItem(at: folder, resultingItemURL: nil)
+        } catch {
+            do {
+                try FileManager.default.removeItem(at: folder)
+            } catch {
+                Log.error("theme remove: \(slug) could not be removed (\(error))")
+                return false
+            }
+        }
+        Log.info("theme remove: \(slug)")
+        return true
+    }
+
     static func background(named file: String, in slug: String) -> URL {
         directory.appendingPathComponent(slug)
             .appendingPathComponent("backgrounds")

--- a/Sources/toe/UI/MenuFont.swift
+++ b/Sources/toe/UI/MenuFont.swift
@@ -106,6 +106,10 @@ enum MenuFont {
         case .paintbrush: return "\u{F1FC}"  // nf-fa-paint_brush
         case .droplet:   return "\u{F043}"   // nf-fa-tint
         case .image:     return "\u{F03E}"   // nf-fa-picture_o
+        case .download:  return "\u{F019}"   // nf-fa-download
+        case .trash:     return "\u{F014}"   // nf-fa-trash_o
+        case .info:      return "\u{F05A}"   // nf-fa-info_circle
+        case .globe:     return "\u{F0AC}"   // nf-fa-globe
         }
     }
 
@@ -123,6 +127,10 @@ enum MenuFont {
         case .paintbrush: return "paintbrush"
         case .droplet:   return "drop"
         case .image:     return "photo"
+        case .download:  return "arrow.down.circle"
+        case .trash:     return "trash"
+        case .info:      return "info.circle"
+        case .globe:     return "globe"
         }
     }
 }

--- a/Sources/toe/UI/MenuView.swift
+++ b/Sources/toe/UI/MenuView.swift
@@ -118,7 +118,13 @@ final class MenuView: NSView {
             }
             // `child:selected .item-box * { color: @selected-text }` — the whole row, icon
             // included, takes the accent when it is the one under the cursor.
-            let colour = selected ? s.accent : s.foreground
+            //
+            // A disabled row takes neither: Omarchy dims one to say "you already have this", and
+            // half alpha is the same signal the subtitle already uses for a line that is context
+            // rather than choice. It can never be the selected row — `MenuState` steps the cursor
+            // over it — so the two cases do not have to compose.
+            let colour = item.isDisabled ? s.foreground.withAlpha(0.4)
+                                         : (selected ? s.accent : s.foreground)
 
             if let icon = item.icon {
                 let box = MenuLayout.iconFrame(inRow: row, m)

--- a/Sources/toe/UI/QuickMenu.swift
+++ b/Sources/toe/UI/QuickMenu.swift
@@ -30,10 +30,20 @@ final class QuickMenu {
     /// Where a chosen row goes. `Coordinator` hands these straight to `dispatch`.
     var onCommand: ((Command) -> Void)?
 
+    /// What the bundle was stamped with, for the `About` row. nil for a binary run straight out
+    /// of `.build`, which has no Info.plist to have been stamped — and the row is then left out
+    /// rather than reporting a version toe does not know.
+    private static let version =
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+
     private let panel: MenuPanel
     private let view = MenuView()
     private var state: MenuState?
-    private var page: MenuPage = .root
+    /// Which door the menu was opened by — the page, and the level within it. Held because the
+    /// hotkey toggles: pressing `SUPER`+`CTRL`+`SPACE` twice closes the background level, while
+    /// pressing it with the *root* menu up switches to that level rather than closing, which is
+    /// what `omarchy-menu toggle <route>` does.
+    private var route: MenuRoute = .root
     private var config = Config()
     /// Handed in at every open rather than held, for the same reason `LoginItem.state()` is read
     /// there: the menu is a function of what is true when you look at it, and a theme folder that
@@ -92,28 +102,29 @@ final class QuickMenu {
 
     /// The hotkey. A second press closes: `RegisterEventHotKey` intercepts ahead of the key
     /// window, so `SUPER`+`SPACE` reaches this rather than typing a space into the filter.
-    func toggle(page: MenuPage, config: Config, usable: Box?, style: StyleMenu = StyleMenu()) {
-        if isVisible, page == self.page {
+    func toggle(route: MenuRoute, config: Config, usable: Box?, style: StyleMenu = StyleMenu()) {
+        if isVisible, route == self.route {
             close()
             return
         }
         self.config = config
         self.usable = usable
         self.style = style
-        open(page: page)
+        open(route: route)
     }
 
-    private func open(page: MenuPage) {
-        self.page = page
+    private func open(route: MenuRoute) {
+        self.route = route
         MenuFont.register()
 
         measure()
 
         loginItem = LoginItem.state()
-        let items = page == .keybindings
+        let items = route.page == .keybindings
             ? MenuModel.keybindings(config.bindings, superKey: config.superKey)
-            : MenuModel.root(loginItem: loginItem, bindings: config.bindings, style: style)
-        state = MenuState(root: items, visibleRows: 10)
+            : MenuModel.root(loginItem: loginItem, bindings: config.bindings, style: style,
+                             version: QuickMenu.version)
+        state = MenuState(root: items, visibleRows: 10, path: route.path)
 
         frontmostAtOpen = NSWorkspace.shared.frontmostApplication?.processIdentifier
         observe()
@@ -162,9 +173,9 @@ final class QuickMenu {
         self.style = style
         guard panel.isVisible, state != nil else { return }
         if fontChanged { measure() }
-        if page == .root {
+        if route.page == .root {
             state?.rebuild(root: MenuModel.root(loginItem: loginItem, bindings: config.bindings,
-                                                style: style))
+                                                style: style, version: QuickMenu.version))
         }
         // Through the full path rather than straight to `render()`: a level that gained or lost
         // rows — the fetching note going away, a downloaded theme moving up into the installed
@@ -242,14 +253,15 @@ final class QuickMenu {
         case .none:
             render()
         case .page(let page):
-            open(page: page)
+            open(route: MenuRoute(page: page))
         case .toggleLoginItem:
             // Deliberately does not close: the value flips under the cursor, as omarchy-menu's
             // toggles do, so you can see what you just did.
-            let setup = MenuModel.configure(loginItem: LoginItem.toggle(),
-                                            bindings: config.bindings)
-            // The level itself rather than the root's first row: Configure is not always the
-            // first row, and on the day the toggle answers `unavailable` it is not there at all.
+            let setup = MenuModel.setup(loginItem: LoginItem.toggle(),
+                                        bindings: config.bindings)
+            // The level itself rather than a row of the root: Setup is not always in the same
+            // place — Install and Remove come and go with the catalogue — and on the day the
+            // toggle answers `unavailable` it is not there at all.
             if !setup.isEmpty { state?.replaceLevel(with: setup) }
             layoutAndRender()
         case .run(let command):
@@ -277,7 +289,7 @@ final class QuickMenu {
         // would be a ragged one.
         metrics.showsSubtitles = !current.query.isEmpty
         let area = usable ?? Coordinates.toAX(NSScreen.main?.visibleFrame ?? .zero)
-        let wanted = page == .keybindings ? config.menu.listWidth : config.menu.width
+        let wanted = route.page == .keybindings ? config.menu.listWidth : config.menu.width
         // Clamped, so `list_width = 800` on a laptop is a wide menu rather than one with its
         // ends off the screen.
         let width = min(wanted, area.w - MenuLayout.contentInset(metrics) * 2)
@@ -300,7 +312,7 @@ final class QuickMenu {
             rows: Array(state.window),
             selectedRow: state.selection - state.scroll,
             metrics: metrics,
-            valueColumn: page == .keybindings ? 0.5 : nil,
+            valueColumn: route.page == .keybindings ? 0.5 : nil,
             background: Colors.rgba(menu.background, or: RGBA(r: 0.10, g: 0.11, b: 0.15, a: 1)),
             foreground: Colors.rgba(menu.foreground, or: RGBA(r: 0.66, g: 0.69, b: 0.84, a: 1)),
             accent: Colors.rgba(menu.accent, or: RGBA(r: 0.48, g: 0.64, b: 0.97, a: 1)),

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -45,14 +45,15 @@ split_bias             = 0
 # focused border takes the accent, flat, and the quick menu takes the background, the foreground
 # and the accent.
 #
-# SUPER+SPACE > Style > Theme is where you get one. toe ships no themes: a theme is somebody
-# else's work, and the list you choose from is what is in ~/.config/toe/themes plus what Omarchy
-# publishes. Choosing one you have not got downloads it from Omarchy into that folder — palette
-# and pictures — and then sets it, so a theme you fetched and a theme you copied in by hand are
-# the same thing afterwards.
+# SUPER+SHIFT+CTRL+SPACE is Style > Theme, which lists what is in ~/.config/toe/themes. toe ships
+# no themes — a theme is somebody else's work — so on a new machine that list is short, and the
+# rest of them are under Install > Style > Theme, where Omarchy keeps its own: everything Omarchy
+# publishes, priced, with the ones you already have dimmed. Choosing one there downloads it into
+# that folder, palette and pictures, and then sets it, so a theme you fetched and a theme you
+# copied in by hand are the same thing afterwards. Remove > Theme puts one in the Trash.
 #
 # That download is the only time toe touches the network, along with the list of themes it fetches
-# when you open Style > Theme, at most once a day. Nothing at launch, no update check, no
+# when you open the menu, at most once a day. Nothing at launch, no update check, no
 # telemetry; the only host it talks to is github.com. A machine that has never been online has no
 # themes to choose from, and the colours below.
 #
@@ -65,7 +66,7 @@ split_bias             = 0
 # plus an optional backgrounds/ beside it. Nothing has to be registered — one appears in the
 # menu the moment you next open it, and saving its palette recolours the screen the way saving
 # this file does. Style > Background appears exactly when that theme has pictures, and
-# SUPER+CTRL+SPACE steps through them.
+# SUPER+CTRL+SPACE opens it.
 name = ""
 
 [border]
@@ -145,7 +146,9 @@ persistent_workspaces = 5
 [menu]
 # SUPER+SPACE opens the quick menu, styled after Omarchy's — the one walker draws for
 # `omarchy-menu`. Arrows to move, Enter to choose, Escape to back out. Typing searches the whole
-# tree rather than the level you are on, and each hit says which submenu it came from.
+# tree rather than the level you are on, and each hit says which submenu it came from. The tree
+# is Omarchy's, with the rows that mean nothing on a Mac left out the way Omarchy's own `when`
+# guard leaves out a row whose condition fails.
 # These are its theme's tokens: Omarchy's default (Tokyo Night) resolved the way walker's
 # stylesheet resolves them — background, foreground (which is also the border), and the accent
 # the selected row's text takes. Which is to say these three are already a theme: setting
@@ -233,21 +236,31 @@ font_size  = 18
 "super-shift-r" = "reload"
 # Puts every window on a hidden workspace back where it came from on the way out.
 "super-shift-q" = "quit"
-# The quick menu — Omarchy's SUPER+ALT+SPACE, and the keybindings list it holds. Note that this
-# takes ⌥Space and ⌥K away from typing ` ` and ˚ for as long as toe runs.
+# The quick menu — Omarchy's SUPER+SPACE, and the keybindings list it holds. Note that this takes
+# ⌥Space and ⌥K away from typing ` ` and ˚ for as long as toe runs.
+#
+# `menu` takes a route, the way `omarchy-menu toggle <route>` does, and opens the tree at that
+# level: root, keybindings, learn, style, theme, background, setup, install, remove. Pressing the
+# same key again closes; pressing another one moves to its level. Omarchy's own aliases work too,
+# so `menu settings` and `menu wallpaper` are lines you can copy across.
 "super-space"   = "menu"
 "super-k"       = "keybindings"
-# Omarchy's background key. SUPER+CTRL+SPACE is what its bindings.conf gives to backgrounds —
-# there it opens the picker, which here is Style › Background in the menu above, so the key does
-# the thing the menu cannot: step to the next picture without stopping to choose one. Does
-# nothing until the current theme has a backgrounds/ folder with something in it.
+# Omarchy's two look-and-feel keys, doing what they do there: SUPER+CTRL+SPACE opens the
+# background picker and SUPER+SHIFT+CTRL+SPACE the theme one. Background is only offered when the
+# current theme has a backgrounds/ folder with something in it, so on a themeless machine that
+# key opens the menu one rung up rather than at a level that is not there.
+#
+# `nextbackground` is what this key used to do — step to the next picture without stopping to
+# choose one. It is still a command, and still what Style › Background's last row does:
+#   "super-ctrl-space" = "nextbackground"
 #
 # The one binding here with a macOS shortcut behind it: ⌃⌥Space is "select next input source",
 # and while that is a symbolic hotkey — resolved inside the window server, ahead of anything toe
 # can register — it is switched off unless you have two or more input sources. If you do, and
 # this key changes your keyboard instead of your wallpaper, that is why; move it, or turn the
 # shortcut off in System Settings › Keyboard › Keyboard Shortcuts › Input Sources.
-"super-ctrl-space" = "nextbackground"
+"super-ctrl-space"       = "menu background"
+"super-shift-ctrl-space" = "menu theme"
 
 # ── Launch ────────────────────────────────────────────────────────────────────
 # AppleScript's `new window` reuses the running instance, so the window opens on the current


### PR DESCRIPTION
The quick menu was a menu that had borrowed some names. Omarchy's is one tree with many doors into it, defined as data on the `quattro` branch in `default/omarchy/omarchy-menu.jsonc` — and comparing the two found four things wrong with the port rather than one.

## The root was in the wrong order, under the wrong name

Upstream's root is Apps, Learn, Trigger, Style, Setup, Install, Remove, Update, About, System. toe had Configure, Learn, Style, Quit — with `Configure` a name that appears nowhere upstream, where the level is `Setup` (alias `settings`) and `Config` is a level *inside* it.

The root now reads **Learn, Style, Setup, Install, Remove, About, Quit**: every row toe has an analogue for, in Omarchy's order, with `Quit` last because it is toe's own.

The rule for what is missing is now Omarchy's own `when` guard, written down in CLAUDE.md: a row whose condition fails is not listed, and a submenu whose visible descendants have all gone goes with them. toe already had half of it — *a row that leads into an empty level is worse than no row* — and stating it the other way round is what makes the absences defensible rather than arbitrary. There is no `Style › Menu Bar` because its two rows upstream are Position, which macOS fixes, and Transparency, which is not toe's menu bar to style.

## The two keys an Omarchy user reaches for did not open the menu

`utilities.lua` binds `SUPER`+`CTRL`+`SPACE` to the background picker and `SUPER`+`SHIFT`+`CTRL`+`SPACE` to the theme one. toe had two doors into the tree, `root` and `keybindings`, and gave the first of those keys to `nextbackground`.

`Command.menu` now carries a `MenuRoute` — a page and a path — and `menu theme`, `menu background`, `menu setup`, `menu install`, `menu remove`, `menu learn` and `menu style` all parse, with upstream's aliases (`settings`, `wallpaper`, `uninstall`, `themes`) so a line can be copied across. Both keys are on the fallback list, so upgraders get them; a config that still says `"super-ctrl-space" = "nextbackground"` keeps it, because a fallback never lands on a key you have already claimed.

Walking to the level is `MenuState.walk`, which is the walk `rebuild` already had to do for the menu that changes while you are looking at it — so a route that no longer resolves stops at the deepest level that exists rather than failing. That is what `SUPER`+`CTRL`+`SPACE` does on a theme with no pictures.

## Themes were one list where Omarchy has three

Upstream switches under Style, installs under `Install › Style › Theme` and deletes under `Remove › Theme`. Split accordingly:

- **`Style › Theme`** is the disk only, so nothing in it can start a nine-megabyte download.
- **`Install › Style › Theme`** is the catalogue entire, priced, with what you already have listed *dimmed and ticked* rather than dropped. That is Omarchy's `disabled` guard, new on `MenuItem`, and it is the point of the level: Install stays a catalogue of everything toe can fetch instead of a list that empties as you use it. `MenuState` enforces it in four places — `move`, `select`, `activate` and the search filter — so the cursor steps over one, a click does not take it, Return does nothing, and a search does not turn it up.
- **`Remove › Theme`** is new capability rather than a new row: `Command.removeTheme`, `ThemeStore.remove`, `Coordinator.removeTheme`. The name is held to a slug before it is joined onto the path it is about to delete — upstream's guard, for the same reason, a theme called `..` would take `~/.config/toe` with it — and the folder goes to the Trash rather than being unlinked, because a menu row is a small thing to have pressed by accident. Removing the theme in effect clears the config *first*, so the moment the folder goes there is nothing left pointing at it.

## The current choice said `current` where Omarchy says `✓`

Same glyph now, on themes, backgrounds and installed rows alike. It lives in the second column rather than appended to the label, because that column already exists and right-aligning it keeps the titles lined up.

## Smaller things that came with following the tree

`Learn` gained the three of upstream's eight links that are about this machine — toe's own manual where `learn.omarchy` sits, Omarchy's because toe ships its defaults and fetches its themes, Hyprland's because the layout in the middle of toe is a port of theirs.

`About` is a `.note` row carrying the bundle version, where upstream's opens a branding window: toe has no window to open and one fact to report. It is left out of a build with nothing stamped rather than reporting `unknown`.

## Verification

975 assertions. The panel was also driven by hand, because three of these only exist on screen: the dimmed rows in Install, the cursor opening *past* them onto the first row it could act on, and `SUPER`+`SHIFT`+`CTRL`+`SPACE` landing in `Style › Theme` with Tokyo Night ticked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf1GMBAUjgNPYWxN9YzooC
