### PR TITLE
Drop the icons from a searched menu list

### DIFF
--- a/Sources/ToeCore/Menu/MenuModel.swift
+++ b/Sources/ToeCore/Menu/MenuModel.swift
@@ -101,8 +101,16 @@ public struct MenuItem: Equatable {
         self.action = action
     }
 
-    public func with(subtitle: String?) -> MenuItem {
-        MenuItem(title: title, subtitle: subtitle, icon: icon, value: value, progress: progress,
+    /// The same row as a search hit: it gains the path it was found at and loses its icon.
+    ///
+    /// Losing the icon is the point. One level of the tree is a handful of rows that mostly
+    /// carry a glyph, so the icons form a column and the titles start after it. A search mixes
+    /// levels, and most of what it turns up — a theme, a wallpaper, a keybinding — never had an
+    /// icon, so that column is a column no longer: a few rows indent while the rest do not, and
+    /// the eye reads the ragged left edge before it reads any of the titles. Dropping the glyph
+    /// costs a hint that the subtitle now gives better, and buys back the straight edge.
+    public func foundAt(path: String?) -> MenuItem {
+        MenuItem(title: title, subtitle: path, icon: nil, value: value, progress: progress,
                  isDisabled: isDisabled, action: action)
     }
 

--- a/Sources/ToeCore/Menu/MenuState.swift
+++ b/Sources/ToeCore/Menu/MenuState.swift
@@ -216,9 +216,9 @@ public struct MenuState: Equatable {
             let fields = flat.map { [$0.item.title, $0.item.value ?? ""] }
             filtered = FuzzyFilter.rank(query, in: fields).map { match in
                 let found = flat[match.index]
-                return found.item.with(subtitle: found.path.isEmpty
-                                       ? nil
-                                       : found.path.joined(separator: " › "))
+                return found.item.foundAt(path: found.path.isEmpty
+                                          ? nil
+                                          : found.path.joined(separator: " › "))
             }
         }
         if resettingSelection {

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -1735,6 +1735,17 @@ h.test("a branch found by searching is still a branch") { t in
     t.equal(m.activate(), .pushed, "and it descends the way it does unfiltered")
 }
 
+h.test("a searched list carries no icons") { t in
+    var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 20)
+    t.expect(m.visible.contains { $0.icon != nil }, "a level draws its glyphs")
+    m.type("e")
+    t.expect(m.visible.count > 1, "the search turns up rows from several levels")
+    t.expect(m.visible.allSatisfy { $0.icon == nil },
+             "and none of them indents past a glyph the row beneath it has not got")
+    m.backspace()
+    t.expect(m.visible.contains { $0.icon != nil }, "the level gets its glyphs back")
+}
+
 h.test("an empty query is one level at a time, with no paths") { t in
     var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 10)
     m.type("z")


### PR DESCRIPTION
Typing in the quick menu turns one level of the tree into a mix of levels, and the icons stop being a column: the handful of rows that carry a glyph indent past it while the themes, wallpapers and keybindings beside them do not, so the first thing the eye reads is a ragged left edge rather than a title.

A search hit now drops its icon at the same moment it gains the path it was found at — `MenuItem.with(subtitle:)` becomes `foundAt(path:)`, since those are one act. `MenuLayout.titleOrigin(hasIcon:)` already puts the title where the icon would have been for a row without one, so the drawing needed no change.

Covered by a new selftest: a level draws its glyphs, a search draws none, and backspacing brings them back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf1GMBAUjgNPYWxN9YzooC