### PR TITLE
Follow a window back to its workspace when it leaves fullscreen

### DIFF
--- a/Sources/toe/AX/WindowTracker.swift
+++ b/Sources/toe/AX/WindowTracker.swift
@@ -11,7 +11,16 @@ final class ManagedWindow {
     /// Where the window sat before it was stashed off-screen, so floating windows come back
     /// to exactly where they were.
     var frameBeforeStash: Box?
-    var isStashed = false
+    var isStashed = false {
+        // One place rather than at each of the three sites that bring a window back, because a
+        // debt owed by a window that is on screen again is not a debt at all.
+        didSet { if !isStashed { stashPending = false } }
+    }
+    /// The window belongs to a hidden workspace but is still where the user can see it: it was
+    /// in native fullscreen when its workspace was hidden, and a fullscreen window is on a Space
+    /// of its own and refuses a position. `Coordinator.settleFullscreenReturns` puts that right
+    /// the moment it becomes an ordinary window again.
+    var stashPending = false
 
     init(id: CGWindowID, element: AXUIElement, pid: pid_t,
          bundleID: String?, title: String?) {

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -795,6 +795,61 @@ final class Coordinator: WindowTrackerDelegate {
         return CGPoint(x: origin.x, y: origin.y)
     }
 
+    /// Parks a window off-screen, where its hidden workspace keeps its windows.
+    private func park(_ window: ManagedWindow) {
+        window.frameBeforeStash = window.element.frame
+        window.isStashed = true
+        desired.removeValue(forKey: window.id)
+        corrections.removeValue(forKey: window.id)
+        WindowMover.setPosition(stashPoint(for: window), element: window.element, pid: window.pid)
+    }
+
+    /// Settles the stashes `apply` could not make, once the windows owing them have left native
+    /// fullscreen.
+    ///
+    /// The sequence this exists for: fullscreen a tiled window, switch workspace while it is
+    /// fullscreen, then leave fullscreen. macOS closes the fullscreen Space and restores the
+    /// window to the frame it had before — its old tile, on a workspace that is no longer
+    /// showing — so it lands on top of the workspace that is, managed by nothing.
+    ///
+    /// The window is not pushed away: its workspace is brought to it. Leaving fullscreen is the
+    /// user saying they want this window back at its ordinary size, and hiding it a frame later
+    /// answers a question nobody asked — where a workspace switch says plainly which window they
+    /// are looking at, and puts it in its tile with the rest of its workspace around it. This is
+    /// `moveToWorkspace`'s `follow`, arrived at from the other end.
+    ///
+    /// A second window owing a stash cannot also be followed, so it is parked as `apply` would
+    /// have parked it. Two windows leaving fullscreen in the same breath is not a real sequence;
+    /// leaving one of them on top of a workspace it does not belong to is the bug above.
+    private func settleFullscreenReturns(preferring preferred: WindowID? = nil) {
+        guard tracker.windows.values.contains(where: { $0.stashPending }) else { return }
+
+        // Sorted, because `tracker.windows` is a dictionary and which window gets followed must
+        // not depend on its hashing. The window the caller heard from wins outright.
+        var returned = tracker.windows.values
+            .filter { $0.stashPending && !$0.element.isFullscreen }
+            .sorted { $0.id < $1.id }
+        if let preferred, let at = returned.firstIndex(where: { $0.id == preferred }) {
+            returned.insert(returned.remove(at: at), at: 0)
+        }
+        guard let follow = returned.first else { return }
+        for window in returned { window.stashPending = false }
+        for window in returned.dropFirst() { park(window) }
+
+        guard let index = workspaces.workspaceIndex(of: follow.id) else {
+            park(follow)
+            return
+        }
+        workspaces.switchTo(workspace: index)
+        // After the switch, which refocuses the workspace's own last window: the one that just
+        // came back from fullscreen is the window the user is actually looking at.
+        workspaces.noteFocus(follow.id)
+        // `apply` clears `isStashed` and writes the tile. The window may still be animating out
+        // of fullscreen and clobber that frame on the way — which is the ordinary case
+        // `corrections` handles, on the move notification that follows.
+        apply(refocus: true)
+    }
+
     // MARK: - WindowTrackerDelegate
 
     func windowAppeared(_ window: ManagedWindow, shouldFloat: Bool) {
@@ -839,7 +894,15 @@ final class Coordinator: WindowTrackerDelegate {
     /// move/resize notification is what actually makes those apps tile — and it doubles as
     /// snap-back when a window is dragged out of its tile.
     func windowFrameChangedExternally(_ id: WindowID) {
-        guard let window = tracker.window(id), !window.isStashed else { return }
+        guard let window = tracker.window(id) else { return }
+        guard !window.isStashed else {
+            // Coming out of fullscreen is a move and a resize, and it arrives after the Space
+            // change rather than with it — by which point the window has finished animating back
+            // to a frame worth remembering. `activeSpaceChanged` usually gets there first; this
+            // is the one that is right about the frame.
+            if window.stashPending { settleFullscreenReturns(preferring: id) }
+            return
+        }
         // A move the user is making by hand hides the border until they let go; see DragMonitor.
         if id == workspaces.focusedWindow { drag.noteExternalFrameChange(id) }
 
@@ -905,6 +968,10 @@ final class Coordinator: WindowTrackerDelegate {
     /// so the floats are left exactly where they are — the border is the only thing that cares,
     /// because the window now in front may be a fullscreen one it must not draw over.
     func activeSpaceChanged() {
+        // Before the border, because it may be about to change which workspace is showing:
+        // leaving a fullscreen Space is a Space change, and it is the moment a window that went
+        // fullscreen on a since-hidden workspace asks for its workspace back.
+        settleFullscreenReturns()
         updateBorder()
         // With *Displays have separate Spaces* on — the macOS default — a desktop picture is set
         // per Space and not per screen, so a Space that has not been visited since the theme
@@ -920,11 +987,25 @@ final class Coordinator: WindowTrackerDelegate {
 
         for id in plan.stashed {
             guard let window = tracker.window(id), !window.isStashed else { continue }
-            window.frameBeforeStash = window.element.frame
-            window.isStashed = true
-            desired.removeValue(forKey: id)
-            corrections.removeValue(forKey: id)
-            WindowMover.setPosition(stashPoint(for: window), element: window.element, pid: window.pid)
+            // A native-fullscreen window is on a Space of its own and will not take a position,
+            // so parking it fails silently — and the window then walks back onto whichever
+            // workspace is showing the moment the user leaves fullscreen, tiled by nobody. The
+            // stash is owed instead, and `settleFullscreenReturns` calls it in — by bringing the
+            // workspace back to the window. No frame is remembered: the one it is wearing now is
+            // the display, not the tile it came from.
+            //
+            // The AX round trip costs nothing on the common path — the guard above has already
+            // dropped every window that is parked, so this only asks about the handful a
+            // workspace switch is actually moving.
+            if window.element.isFullscreen {
+                window.frameBeforeStash = nil
+                window.isStashed = true
+                window.stashPending = true
+                desired.removeValue(forKey: id)
+                corrections.removeValue(forKey: id)
+                continue
+            }
+            park(window)
         }
 
         // Floating frames deliberately bypass `desired` / `corrections`: that machinery exists


### PR DESCRIPTION
Fullscreen a tiled window, switch workspace while it is fullscreen, then leave fullscreen: the window landed on top of whichever workspace was showing, tiled by nobody and with no border, until its own workspace came back and re-adopted it.

## Why

Hiding a workspace parks its windows off-screen with `WindowMover.setPosition`, and a native-fullscreen window is on a Space of its own and refuses a position — so the write failed silently while `isStashed` was set anyway, and the frame recorded to come back to was the display rather than the tile. macOS then restored the window to its pre-fullscreen frame on the ordinary Space, where every path that could have corrected it — `windowFrameChangedExternally`, `updateBorder` — is guarded by `!isStashed`.

## What changed

- The stash is recorded as *owed* (`stashPending`) rather than pretended, and no display-sized frame is remembered as somewhere to restore to.
- `settleFullscreenReturns` calls the debt in the moment the window is an ordinary one again, from both the Space change (which fires three times over 0.4s, since the exit animates) and the move notification behind it — the first to find it out of fullscreen wins, the rest bail on the cheap pending check.
- It settles by bringing the workspace to the window rather than pushing the window away: leaving fullscreen is the user saying they want this window back at its ordinary size, and hiding it a frame later answers a question nobody asked. This is `moveToWorkspace`'s `follow`, arrived at from the other end.
- `isStashed`'s `didSet` clears the pending flag, so the three sites that bring a window back cannot leave a stale debt behind — including returning to the workspace while the window is *still* fullscreen and exiting there.
- Extracted `park(_:)` so `apply` and the settle path stash a window the same way.

## Testing

`make test` — 979 assertions pass. The change is entirely in `Sources/toe` (it turns on `element.isFullscreen` and the AX notification order), so there is no arithmetic to lift into ToeCore for coverage. Verified by hand against a running toe: the reported sequence, exiting fullscreen while still on the window's own workspace, and returning to that workspace before exiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf1GMBAUjgNPYWxN9YzooC