### PR TITLE
Move between workspaces with a sideways dock swipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ as the defaults.
 | `SUPER` + `1`…`9`, `0` | Switch to workspace 1…10 |
 | `SUPER` + `SHIFT` + `1`…`9`, `0` | Move window to workspace and follow it |
 | `SUPER` + `TAB` / `SHIFT`+`TAB` / `CTRL`+`TAB` | Next / previous workspace in use, former workspace |
+| Sideways swipe on the trackpad | Next / previous workspace in use, the way it moves between Spaces |
 | `SUPER` + `ENTER` | New terminal window — Ghostty |
 | `SUPER` + `SHIFT` + `ENTER` | New browser window — Safari |
 | `SUPER` + `W` | Close window |
@@ -202,10 +203,19 @@ anything that does not positively identify itself as a dock swipe is passed stra
 worst a wrong guess there can do is drop a gesture: no keystroke, click or scroll can reach a tap
 masked this way. `gestures.swallow_dock_swipes = false` turns it off.
 
+The sideways swipe is not left doing nothing: its destination was the problem, not the gesture,
+so toe points it at its own workspaces. One swipe is one step to the next or previous workspace
+in use — the same ring `SUPER`+`TAB` walks, so on a session with everything on one workspace it
+stays put and says so in the log — and it follows *Natural scrolling* the way the Spaces swipe
+does. The tap already had to read the gesture's phase and direction to swallow it as a unit, so
+this reads no new field; the one-step-per-gesture latch is `DockSwipe` in ToeCore, where the
+selftest can reach it. The swipe up stays swallowed and silent, because Mission Control is what
+shows the stash and toe has nothing to put in its place.
+
 The cost is that swiping between Spaces is gone, including swiping out of a natively-fullscreen
 app's Space — and natively-fullscreen windows are one of the things toe leaves alone. `Ctrl`+`←`/`→`
 still switches Spaces and `⌃⌘F` still leaves fullscreen; the config key is there for anyone who
-would rather have the swipe.
+would rather have macOS's swipe than toe's.
 
 The swipe is not the only way in: `Ctrl`+`↑` and `Ctrl`+`↓` open the same two views. Those are
 *symbolic hotkeys*, resolved inside the window server well before any event tap sees a key, so the

--- a/Sources/ToeCore/Config/Config.swift
+++ b/Sources/ToeCore/Config/Config.swift
@@ -51,8 +51,11 @@ public struct FloatingSize: Equatable {
 /// Trackpad gestures toe takes off macOS's hands.
 public struct GestureConfig: Equatable {
     /// Swallow the Dock's swipe gestures — Mission Control, App Exposé and the sideways Spaces
-    /// switch — before the window server acts on them. Keyed off the gesture's event type rather
-    /// than a finger count, so it covers the three-finger setting as well as the four-finger one.
+    /// switch — before the window server acts on them, and give the sideways one to toe's
+    /// workspaces (`DockSwipe`). Keyed off the gesture's event type rather than a finger count,
+    /// so it covers the three-finger setting as well as the four-finger one. One key for both,
+    /// deliberately: it means *toe owns the trackpad's swipes*, and a swallowed swipe that goes
+    /// nowhere is not a setting anyone would choose.
     public var swallowDockSwipes: Bool = true
     public init() {}
 }

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -103,11 +103,13 @@ large_height = 0.90
 max_aspect_ratio = 1.6
 
 [gestures]
-# Swallow the Dock's swipe gestures before macOS acts on them. A swipe up would open Mission
-# Control, which puts the windows on hidden workspaces — parked off-screen, since macOS has no
-# public API for virtual desktops — back on display; a sideways swipe would change the macOS
-# Space out from under toe. Ctrl+←/→ still switches Spaces, which is also the way out of a
-# fullscreen app now that swiping is not.
+# Take the Dock's swipe gestures before macOS acts on them. A sideways swipe then moves between
+# toe's workspaces — the ones in use, as SUPER+TAB does — rather than changing the macOS Space
+# out from under toe, and follows System Settings' Natural scrolling the way the Spaces swipe
+# does. A swipe up is swallowed and does nothing: Mission Control would put the windows on
+# hidden workspaces — parked off-screen, since macOS has no public API for virtual desktops —
+# back on display, and toe has nothing to show in its place. Ctrl+←/→ still switches Spaces,
+# which is also the way out of a fullscreen app now that swiping is not.
 swallow_dock_swipes = true
 
 [misc]

--- a/Sources/ToeCore/Input/DockSwipe.swift
+++ b/Sources/ToeCore/Input/DockSwipe.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// The decision behind a sideways dock swipe, kept apart from the event tap for the reason
+/// `BorderGeometry` is kept apart from the border panel: this is the part the selftest can reach.
+/// `DockSwipeTap` reads three integers off a `CGEvent` it has already identified as a dock swipe
+/// and hands them here; this answers whether that event is the moment the gesture committed to a
+/// horizontal direction — once per gesture, and never for a vertical one.
+///
+/// A dock swipe is continuous: `began`, then a run of `changed`, then `ended` or `cancelled`. The
+/// `changed` events arrive at the trackpad's report rate, so acting on each of them would run
+/// through all ten workspaces on one flick. Instead the gesture is *armed* by `began`, steps
+/// exactly once — on the first event, `began` included, that reports a horizontal motion and a
+/// left-or-right mask — and is disarmed by that step or by `ended` / `cancelled`, whichever comes
+/// first. Stepping as soon as the direction is known, rather than on `ended`, is what macOS does
+/// with the Spaces swipe (it commits when the threshold is crossed, not when the fingers lift),
+/// and it also means a missed `ended` — a tap re-armed after a timeout has lost whatever it did
+/// not see — costs nothing: the next `began` arms afresh.
+///
+/// A stepping variant — one workspace per threshold crossed, so a long swipe travels further —
+/// wants a real gesture-amount field and is left until this one has been lived with.
+public struct DockSwipe: Equatable {
+
+    /// Where the fingers went. Physical, before any scrolling preference: which workspace that
+    /// asks for is `WorkspaceTarget.swipe`'s question.
+    public enum Direction: Equatable {
+        case left
+        case right
+    }
+
+    /// The values the tap's private fields read, named once here so the selftest feeds the state
+    /// machine the same numbers the tap does. Static constants rather than enums with raw values
+    /// so that an unrecognised number — a renumbered field on some future macOS — falls through
+    /// the `switch` as "neither arms nor releases" rather than failing to construct at all.
+    public enum Phase {
+        public static let began: Int64 = 1
+        public static let changed: Int64 = 2
+        public static let ended: Int64 = 4
+        public static let cancelled: Int64 = 8
+    }
+
+    public enum Motion {
+        public static let none: Int64 = 0
+        public static let horizontal: Int64 = 1
+        public static let vertical: Int64 = 2
+    }
+
+    /// A bit set, though a swipe only ever reports one of them.
+    public enum Mask {
+        public static let up: Int64 = 1
+        public static let down: Int64 = 2
+        public static let left: Int64 = 4
+        public static let right: Int64 = 8
+    }
+
+    /// True between `began` and whichever comes first of the step, `ended` and `cancelled`.
+    private var armed = false
+
+    public init() {}
+
+    /// Feed every dock swipe event, in order. Answers the direction on the one event that steps.
+    ///
+    /// Everything short of a positive identification stays quiet *and* stays armed: a horizontal
+    /// motion whose mask has not settled yet, a mask with no motion, or both bits set are all
+    /// "not yet" rather than "no", and the next `changed` gets to answer. An event with no `began`
+    /// before it — the tap was started mid-gesture — is dropped, as is anything after the step.
+    public mutating func feed(phase: Int64, swipeMask: Int64, motion: Int64) -> Direction? {
+        switch phase {
+        case Phase.began: armed = true
+        case Phase.ended, Phase.cancelled:
+            armed = false
+            return nil
+        default: break              // `changed`, or a number this code does not know
+        }
+
+        guard armed, motion == Motion.horizontal else { return nil }
+        let direction: Direction
+        switch swipeMask {
+        case Mask.left: direction = .left
+        case Mask.right: direction = .right
+        default: return nil
+        }
+        armed = false
+        return direction
+    }
+}
+
+extension WorkspaceTarget {
+    /// The workspace a sideways swipe asks for: `workspace e+1` / `e-1`, the keyboard's own
+    /// next-and-previous-in-use, from the trackpad.
+    ///
+    /// macOS's Spaces swipe follows System Settings' *Natural scrolling* — content tracks the
+    /// fingers, so fingers moving left drag the desktop left and pull the next Space in from the
+    /// right — and reverses along with it, which is what anyone who has turned the setting off
+    /// expects a sideways swipe to do. So this takes the preference and does the same.
+    public static func swipe(_ direction: DockSwipe.Direction, naturalScrolling: Bool) -> WorkspaceTarget {
+        switch (direction, naturalScrolling) {
+        case (.left, true), (.right, false): return .next
+        case (.right, true), (.left, false): return .previous
+        }
+    }
+}

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -818,6 +818,103 @@ h.test("only tiled windows are dragged, and only onto tiles") { t in
             "a pointer on no monitor at all is not a drop target")
 }
 
+// MARK: - Dock swipes
+
+// The numbers `DockSwipeTap` reads off the event, by name.
+let began = DockSwipe.Phase.began, changed = DockSwipe.Phase.changed
+let ended = DockSwipe.Phase.ended, cancelled = DockSwipe.Phase.cancelled
+let horizontal = DockSwipe.Motion.horizontal, vertical = DockSwipe.Motion.vertical
+
+h.test("a sideways swipe steps once, however long it runs") { t in
+    var swipe = DockSwipe()
+    t.equal(swipe.feed(phase: began, swipeMask: 0, motion: DockSwipe.Motion.none), nil,
+            "began, before the trackpad has settled on an axis")
+    t.equal(swipe.feed(phase: changed, swipeMask: DockSwipe.Mask.left, motion: horizontal), .left,
+            "the first horizontal report is the step")
+    for _ in 0..<40 {
+        t.equal(swipe.feed(phase: changed, swipeMask: DockSwipe.Mask.left, motion: horizontal), nil,
+                "the rest of the run is silent — one flick is not ten workspaces")
+    }
+    t.equal(swipe.feed(phase: ended, swipeMask: DockSwipe.Mask.left, motion: horizontal), nil, "ended")
+}
+
+h.test("a swipe whose direction is known on began steps on began") { t in
+    var swipe = DockSwipe()
+    t.equal(swipe.feed(phase: began, swipeMask: DockSwipe.Mask.right, motion: horizontal), .right,
+            "no need to wait for a changed")
+    t.equal(swipe.feed(phase: changed, swipeMask: DockSwipe.Mask.right, motion: horizontal), nil, "and only once")
+}
+
+h.test("a vertical swipe is swallowed and never steps") { t in
+    var swipe = DockSwipe()
+    t.equal(swipe.feed(phase: began, swipeMask: 0, motion: DockSwipe.Motion.none), nil, "began")
+    for mask in [DockSwipe.Mask.up, DockSwipe.Mask.down] {
+        for _ in 0..<5 {
+            t.equal(swipe.feed(phase: changed, swipeMask: mask, motion: vertical), nil, "vertical, mask \(mask)")
+        }
+    }
+    t.equal(swipe.feed(phase: ended, swipeMask: DockSwipe.Mask.up, motion: vertical), nil, "ended")
+}
+
+h.test("the axis and the direction have to agree before a swipe steps") { t in
+    var swipe = DockSwipe()
+    _ = swipe.feed(phase: began, swipeMask: 0, motion: DockSwipe.Motion.none)
+    t.equal(swipe.feed(phase: changed, swipeMask: 0, motion: horizontal), nil,
+            "horizontal, but no direction yet — not yet, rather than no")
+    t.equal(swipe.feed(phase: changed, swipeMask: DockSwipe.Mask.left, motion: DockSwipe.Motion.none), nil,
+            "a direction with no motion behind it")
+    t.equal(swipe.feed(phase: changed, swipeMask: DockSwipe.Mask.left | DockSwipe.Mask.right, motion: horizontal), nil,
+            "both bits is not a direction")
+    t.equal(swipe.feed(phase: changed, swipeMask: DockSwipe.Mask.up, motion: horizontal), nil,
+            "an up mask on a horizontal motion is nothing this code knows")
+    t.equal(swipe.feed(phase: changed, swipeMask: DockSwipe.Mask.right, motion: horizontal), .right,
+            "still armed through all of that, so the first real answer steps")
+}
+
+h.test("ended and cancelled both release the latch for the next gesture") { t in
+    var swipe = DockSwipe()
+    for release in [ended, cancelled] {
+        _ = swipe.feed(phase: began, swipeMask: 0, motion: DockSwipe.Motion.none)
+        t.equal(swipe.feed(phase: changed, swipeMask: DockSwipe.Mask.left, motion: horizontal), .left, "steps")
+        _ = swipe.feed(phase: release, swipeMask: DockSwipe.Mask.left, motion: horizontal)
+        t.equal(swipe.feed(phase: changed, swipeMask: DockSwipe.Mask.left, motion: horizontal), nil,
+                "a changed after \(release) belongs to no gesture")
+    }
+    _ = swipe.feed(phase: began, swipeMask: 0, motion: DockSwipe.Motion.none)
+    t.equal(swipe.feed(phase: changed, swipeMask: DockSwipe.Mask.right, motion: horizontal), .right,
+            "the next began arms afresh")
+}
+
+h.test("a gesture the tap joined half-way through does not step") { t in
+    var swipe = DockSwipe()
+    t.equal(swipe.feed(phase: changed, swipeMask: DockSwipe.Mask.left, motion: horizontal), nil,
+            "no began was seen — the tap was started mid-swipe")
+    _ = swipe.feed(phase: ended, swipeMask: DockSwipe.Mask.left, motion: horizontal)
+    _ = swipe.feed(phase: began, swipeMask: 0, motion: DockSwipe.Motion.none)
+    t.equal(swipe.feed(phase: changed, swipeMask: DockSwipe.Mask.left, motion: horizontal), .left,
+            "the next whole gesture does")
+}
+
+h.test("a phase this code does not know neither arms nor releases") { t in
+    var swipe = DockSwipe()
+    _ = swipe.feed(phase: began, swipeMask: 0, motion: DockSwipe.Motion.none)
+    t.equal(swipe.feed(phase: 16, swipeMask: DockSwipe.Mask.left, motion: horizontal), .left,
+            "an unknown phase is treated as changed: still armed, so a horizontal report steps")
+    _ = swipe.feed(phase: 16, swipeMask: DockSwipe.Mask.left, motion: horizontal)
+    var fresh = DockSwipe()
+    t.equal(fresh.feed(phase: 16, swipeMask: DockSwipe.Mask.left, motion: horizontal), nil,
+            "but it does not arm — a renumbered phase field degrades to swallow-only")
+}
+
+h.test("the swipe follows Natural scrolling the way the Spaces swipe does") { t in
+    t.equal(WorkspaceTarget.swipe(.left, naturalScrolling: true), .next,
+            "content tracks the fingers: dragging the desktop left pulls the next workspace in from the right")
+    t.equal(WorkspaceTarget.swipe(.right, naturalScrolling: true), .previous, "and the other way")
+    t.equal(WorkspaceTarget.swipe(.left, naturalScrolling: false), .previous,
+            "with the setting off macOS reverses its Spaces swipe, and so does toe")
+    t.equal(WorkspaceTarget.swipe(.right, naturalScrolling: false), .next, "and the other way")
+}
+
 // MARK: - Config
 
 h.test("the second floating size is configurable, and a bad one warns") { t in

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -160,6 +160,25 @@ final class Coordinator: WindowTrackerDelegate {
         }
         drag.onEnd = { [weak self] id in self?.endDrag(id) }
         hideBlocker.onRestored = { [weak self] pid in self?.relayoutAfterUnhide(pid) }
+        // A sideways dock swipe is `workspace e+1` / `e-1` from the trackpad. Only while
+        // `gestures.swallow_dock_swipes` is on, and no `if` here says so: `applyDockSwipeSetting`
+        // stops the tap when the setting is off, so there is no event to arrive. The handler is
+        // already off the tap's callback (see `DockSwipeTap.onSwipe`), so `apply()`'s AX round
+        // trips are safe from here.
+        dockSwipes.onSwipe = { [weak self] direction in
+            guard let self else { return }
+            let natural = NaturalScrolling.isOn
+            let target = WorkspaceTarget.swipe(direction, naturalScrolling: natural)
+            let before = self.workspaces.focusedWorkspaceIndex
+            self.dispatch(.workspace(target))
+            let after = self.workspaces.focusedWorkspaceIndex
+            // `.next` / `.previous` walk the workspaces in use, as SUPER+TAB does, so a fresh
+            // session with everything on one workspace has nowhere to go — say so, or the first
+            // swipe anyone tries reads as broken.
+            Log.info("dock swipe \(direction) (natural scrolling \(natural ? "on" : "off")): "
+                     + (before == after ? "no other workspace in use, staying on \(before)"
+                                        : "workspace \(before) → \(after)"))
+        }
 
         guard waitForAccessibility() else {
             Log.error("no Accessibility permission — hotkeys are live but windows cannot be moved. "
@@ -664,6 +683,9 @@ final class Coordinator: WindowTrackerDelegate {
 
     /// Starts and stops the dock swipe tap as the config flips, on every reload as well as at
     /// startup. A no-op until Accessibility has landed; `beginManaging()` calls it again then.
+    /// This is also the whole of the gate on the swipe *switching workspaces*: with the setting
+    /// off the tap does not exist, so `onSwipe` cannot fire, and a second check anywhere else
+    /// would be a redundancy waiting to drift.
     private func applyDockSwipeSetting() {
         guard isManaging else { return }
         runtimeWarnings.removeAll()

--- a/Sources/toe/Input/DockSwipeTap.swift
+++ b/Sources/toe/Input/DockSwipeTap.swift
@@ -1,13 +1,18 @@
 import CoreGraphics
 import Foundation
+import ToeCore
 
-/// Swallows the Dock's swipe gestures before the window server acts on them.
+/// Swallows the Dock's swipe gestures before the window server acts on them, and points the
+/// sideways one at toe's workspaces instead.
 ///
 /// toe keeps its own ten workspaces, and a hidden one's windows are parked off-screen rather
 /// than on a macOS Space — see `Stash`. A four-finger swipe up opens Mission Control, which puts
 /// that stash on display; a sideways swipe changes the Space out from under toe, leaving its
 /// model describing windows that are no longer on screen. Both are better prevented than
-/// recovered from.
+/// recovered from. But the sideways swipe is the most natural gesture on the trackpad, and toe
+/// has ten workspaces to point it at — so it is swallowed *and* reported through `onSwipe`, as
+/// `workspace e+1` / `e-1`. The vertical swipe stays swallowed and silent: Mission Control is
+/// what shows the stash, and toe has nothing to offer in its place.
 ///
 /// The two event types in the mask and the fields the callback reads are private and
 /// version-sensitive. `CGEvent.tapCreate` itself is public API, so this needs no entitlement, no
@@ -20,6 +25,14 @@ final class DockSwipeTap {
     private var tap: CFMachPort?
     private var source: CFRunLoopSource?
     private var swallowed = 0
+    /// Which event of a gesture is the one to act on — the decision lives in ToeCore, where the
+    /// selftest can reach it. Reset with the tap, so a stop mid-gesture cannot leave it armed.
+    private var gesture = DockSwipe()
+    /// A sideways swipe, once per gesture, with the direction the fingers went. Delivered on the
+    /// main queue *after* the tap callback has returned, never from inside it: a filtering tap
+    /// whose callback is slow is switched off by the system (see `handle`), and the handler ends
+    /// in `Coordinator.apply()`, which writes frames over Accessibility at up to 250 ms each.
+    var onSwipe: ((DockSwipe.Direction) -> Void)?
     /// Read once here rather than per event: the hot path does no dictionary lookups.
     private let verbose = ProcessInfo.processInfo.environment["TOE_VERBOSE"] != nil
 
@@ -44,9 +57,9 @@ final class DockSwipeTap {
     /// index Apple has not declared — which is all of these. The enum's layout is its raw value,
     /// so a bit cast is the way in. Resolved once, at type initialisation, never per event.
     private static let hidTypeField = field(110)     // kCGEventGestureHIDType
-    private static let swipeMaskField = field(115)   // up 1, down 2, left 4, right 8 — diagnostics
-    private static let motionField = field(123)      // 0 none, 1 horizontal, 2 vertical — diagnostics
-    private static let phaseField = field(132)       // 1 began, 2 changed, 4 ended, 8 cancelled
+    private static let swipeMaskField = field(115)   // up 1, down 2, left 4, right 8 — `DockSwipe.Mask`
+    private static let motionField = field(123)      // 0 none, 1 horizontal, 2 vertical — `DockSwipe.Motion`
+    private static let phaseField = field(132)       // 1 began, 2 changed, 4 ended, 8 cancelled — `DockSwipe.Phase`
     private static let subtypeField = field(55)      // kCGSEventTypeField — diagnostics
 
     private static func field(_ raw: UInt32) -> CGEventField {
@@ -96,6 +109,7 @@ final class DockSwipeTap {
         tap = nil
         source = nil
         swallowed = 0
+        gesture = DockSwipe()
         Log.info("dock swipe tap: stopped")
     }
 
@@ -124,11 +138,23 @@ final class DockSwipeTap {
 
         if swallowed == 0 { Log.info("dock swipe tap: swallowing dock swipes") }
         swallowed &+= 1
+
+        // Three more field reads, only for an event already known to be a dock swipe — a few
+        // dozen per gesture, nothing on the scale of what `dump` does. The state machine is fed
+        // whether or not anyone is listening, so its arming stays in step with the gesture.
+        if let direction = gesture.feed(phase: event.getIntegerValueField(Self.phaseField),
+                                        swipeMask: event.getIntegerValueField(Self.swipeMaskField),
+                                        motion: event.getIntegerValueField(Self.motionField)),
+           let onSwipe {
+            DispatchQueue.main.async { onSwipe(direction) }
+        }
         return nil                      // the event never reaches the Dock
     }
 
     /// `TOE_VERBOSE=1` only. The bring-up tool for the day a macOS release renumbers a field:
-    /// swipe, watch the numbers, compare them with the constants above.
+    /// swipe, watch the numbers, compare them with the constants above and `DockSwipe`'s. Also
+    /// the way to check which way the fingers went — `swipe=4` is left — against what the
+    /// workspace did, with System Settings' *Natural scrolling* set both ways.
     private func dump(type: CGEventType, event: CGEvent) {
         Log.info("gesture event: type=\(type.rawValue)"
                  + " subtype=\(event.getIntegerValueField(Self.subtypeField))"

--- a/Sources/toe/Input/NaturalScrolling.swift
+++ b/Sources/toe/Input/NaturalScrolling.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// System Settings › Trackpad › *Natural scrolling*, the one preference the sideways dock swipe
+/// has to honour: macOS reverses its own Spaces swipe with it, and so `WorkspaceTarget.swipe`.
+enum NaturalScrolling {
+    /// The key is `defaults read -g com.apple.swipescrolldirection`, in the global domain, which
+    /// `UserDefaults.standard` searches after toe's own. Absent until the setting has been touched,
+    /// and the untouched default is on. Read per swipe rather than cached: cheap, once a gesture,
+    /// and it is the way a change in System Settings lands without a restart.
+    static var isOn: Bool {
+        UserDefaults.standard.object(forKey: "com.apple.swipescrolldirection") as? Bool ?? true
+    }
+}

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -96,11 +96,13 @@ large_height = 0.90
 max_aspect_ratio = 1.6
 
 [gestures]
-# Swallow the Dock's swipe gestures before macOS acts on them. A swipe up would open Mission
-# Control, which puts the windows on hidden workspaces — parked off-screen, since macOS has no
-# public API for virtual desktops — back on display; a sideways swipe would change the macOS
-# Space out from under toe. Ctrl+←/→ still switches Spaces, which is also the way out of a
-# fullscreen app now that swiping is not.
+# Take the Dock's swipe gestures before macOS acts on them. A sideways swipe then moves between
+# toe's workspaces — the ones in use, as SUPER+TAB does — rather than changing the macOS Space
+# out from under toe, and follows System Settings' Natural scrolling the way the Spaces swipe
+# does. A swipe up is swallowed and does nothing: Mission Control would put the windows on
+# hidden workspaces — parked off-screen, since macOS has no public API for virtual desktops —
+# back on display, and toe has nothing to show in its place. Ctrl+←/→ still switches Spaces,
+# which is also the way out of a fullscreen app now that swiping is not.
 swallow_dock_swipes = true
 
 [misc]


### PR DESCRIPTION
Closes #92.

## What

With `gestures.swallow_dock_swipes = true` a sideways dock swipe now steps to the next or previous workspace in use — `workspace e+1` / `e-1` from the trackpad — and follows System Settings' *Natural scrolling* the way the Spaces swipe does. The swipe up stays swallowed and silent. With the setting off nothing changes: the tap is stopped, so there is no event to act on, and no second `if` was added anywhere (the comment on `applyDockSwipeSetting` says so).

## How

- **`ToeCore/Input/DockSwipe.swift`** — the one-step-per-gesture latch, fed `(phase, swipeMask, motion)`. Armed on `began`, steps on the first event (began included) reporting a horizontal motion and a left-or-right mask, released by that step or by `ended` / `cancelled`. Anything short of a positive identification stays quiet and stays armed. `WorkspaceTarget.swipe(_:naturalScrolling:)` maps fingers-left to `.next` with the setting on and to `.previous` with it off.
- **`DockSwipeTap`** — reads the three fields it already read for `dump()`, feeds the latch, and delivers `onSwipe` through `DispatchQueue.main.async` so the tap callback returns immediately. The latch is reset in `stop()`.
- **`Coordinator`** — wires `onSwipe` beside the other callbacks, dispatches `.workspace(target)`, and logs the outcome, including the "no other workspace in use" case the issue flagged as the one that will read as broken.
- **`NaturalScrolling`** — reads `com.apple.swipescrolldirection` from the global domain, once per swipe.
- Docs: `[gestures]` comment (and `toe.example.toml`), `GestureConfig` doc, README table row and **Dock swipes** section.

## Decisions from the issue

- **One step per gesture, taken as soon as the direction is known** rather than on `ended`. That is what macOS does with the Spaces swipe (commits at the threshold, not at finger-lift), and a missed `ended` from a re-armed tap then costs nothing. The stepping variant is left for later, as suggested.
- **The ring is the in-use ring**, same as `SUPER+TAB`, rather than all ten. Logged when it has nowhere to go.
- **No new config key.** `swallow_dock_swipes` means *toe owns the trackpad's swipes*; a swallowed swipe that goes nowhere is not a setting anyone would pick.

## Verified on hardware

Six swipes on a trackpad with Natural scrolling on, from `log stream`: one step per gesture, both directions, no double-firing, tap alive throughout.

```
dock swipe right (natural scrolling on): workspace 3 → 2
dock swipe right (natural scrolling on): workspace 2 → 1
dock swipe left  (natural scrolling on): workspace 1 → 2
dock swipe left  (natural scrolling on): workspace 2 → 3
dock swipe right (natural scrolling on): workspace 3 → 2
dock swipe left  (natural scrolling on): workspace 2 → 3
```

Still unmeasured: whether the mask is physical or already inverted by Natural scrolling. With the setting on (the default) the result is right either way. If the system already inverts it, users with the setting **off** would get the reverse, and the fix is to drop the `naturalScrolling` parameter.

The selftest that pins the setting-to-behaviour coupling the issue asked for is not here: the coupling is in `Coordinator.applyDockSwipeSetting`, which the selftest cannot reach; the eight new `DockSwipe` tests cover the latch itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X483aXCBgNCMP13tKvJqNj

