### PR TITLE
Widen the default gaps to 8 inside and 15 out

### DIFF
--- a/Sources/ToeCore/Config/Config.swift
+++ b/Sources/ToeCore/Config/Config.swift
@@ -181,7 +181,7 @@ public struct Config: Equatable {
     public static let fileName = "toe.toml"
 
     public var superKey: Modifiers = .option
-    public var gaps: Gaps = Gaps(inner: 5, outer: 10)
+    public var gaps: Gaps = Gaps(inner: 8, outer: 15)
     public var dwindle: DwindleOptions = DwindleOptions()
     public var border: BorderConfig = BorderConfig()
     public var bar: BarConfig = BarConfig()

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -1,8 +1,10 @@
 /// The config written to ~/.config/toe/toe.toml on first run.
 ///
-/// Values match Omarchy's Hyprland defaults exactly:
-///   default/hypr/looknfeel.conf  →  gaps_in = 5, gaps_out = 10, border 2px, dwindle
-///                                   preserve_split = true, force_split = 2
+/// Values match Omarchy's Hyprland defaults, with one deliberate departure:
+///   default/hypr/looknfeel.conf  →  border 2px, dwindle, preserve_split = true, force_split = 2
+///                                   (Omarchy's gaps_in = 5, gaps_out = 10 are widened to 8 / 15:
+///                                   macOS windows carry their own rounded corners and shadows,
+///                                   and at 5 / 10 the tiles read as touching)
 ///   default/hypr/bindings/tiling.conf → the bindings below
 let defaultConfigText = #"""
 # toe — The Opinionated Experience
@@ -21,9 +23,10 @@ let defaultConfigText = #"""
 # it leaves ⌘S ⌘F ⌘T ⌘W ⌘1-9 ⌘Tab alone. Also accepts "cmd" or "ctrl".
 super_key = "alt"
 
-# Omarchy: gaps_in = 5, gaps_out = 10
-gaps_in  = 5
-gaps_out = 10
+# Omarchy ships gaps_in = 5, gaps_out = 10; a little wider here, since macOS windows bring
+# their own rounded corners and shadows and the tiles read as touching at Omarchy's values.
+gaps_in  = 8
+gaps_out = 15
 
 [dwindle]
 # Both of these are Omarchy's settings, and together they are what makes dwindle feel right:

--- a/Sources/ToeCore/Layout/DwindleLayout.swift
+++ b/Sources/ToeCore/Layout/DwindleLayout.swift
@@ -4,7 +4,7 @@ import Foundation
 public struct Gaps: Equatable, Sendable {
     public var inner: Double
     public var outer: Double
-    public init(inner: Double = 5, outer: Double = 10) {
+    public init(inner: Double = 8, outer: Double = 15) {
         self.inner = inner
         self.outer = outer
     }

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -932,7 +932,7 @@ h.test("the shipped default config parses cleanly") { t in
     let c = try Config.parse(Config.defaultTOML)
     t.equal(c.warnings, [], "no warnings")
     t.equal(c.superKey, Modifiers.option, "SUPER is Option")
-    t.equal(c.gaps, Gaps(inner: 5, outer: 10), "Omarchy gaps")
+    t.equal(c.gaps, Gaps(inner: 8, outer: 15), "the shipped gaps")
     t.equal(c.bar.persistentWorkspaces, 5, "Omarchy's persistent-workspaces 1-5")
     t.equal(c.dwindle.preserveSplit, true, "preserve_split")
     t.equal(c.dwindle.forceSplit, 2, "force_split")
@@ -1179,14 +1179,14 @@ h.test("nan and infinity are refused rather than reaching the layout") { t in
     // never resets, and the NaN is passed to other applications over Accessibility.
     for spelling in ["nan", "inf", "-inf", "+inf"] {
         let c = try Config.parse("[general]\ngaps_in = \(spelling)\n")
-        t.equal(c.gaps.inner, 5, "gaps_in = \(spelling) keeps the default")
+        t.equal(c.gaps.inner, 8, "gaps_in = \(spelling) keeps the default")
         t.equal(c.gaps.inner.isFinite, true, "gaps_in = \(spelling) leaves a finite gap")
         t.equal(c.warnings.contains { $0.contains("general.gaps_in") }, true,
                 "gaps_in = \(spelling) warns")
     }
 
     let out = try Config.parse("[general]\ngaps_out = nan\n")
-    t.equal(out.gaps.outer, 10, "gaps_out = nan keeps the default")
+    t.equal(out.gaps.outer, 15, "gaps_out = nan keeps the default")
     t.equal(out.warnings.contains { $0.contains("general.gaps_out") }, true, "and says so")
 
     let border = try Config.parse("[border]\nwidth = nan\nangle = inf\nradius = nan\n")
@@ -1205,7 +1205,7 @@ h.test("numbers outside a sensible range are refused too") { t in
     // Swift's Double(_: String) takes hex floats, which TOML has no notion of, so this used
     // to parse as a 1024 point gap with no warning at all.
     let hex = try Config.parse("[general]\ngaps_in = 0x1p10\n")
-    t.equal(hex.gaps.inner, 5, "a 1024 point gap keeps the default")
+    t.equal(hex.gaps.inner, 8, "a 1024 point gap keeps the default")
     t.equal(hex.warnings.contains { $0.contains("general.gaps_in") }, true, "and says so")
 
     let negative = try Config.parse("[border]\nwidth = -5\n")
@@ -1607,8 +1607,8 @@ h.test("a snapshot restored onto a different display reflows into it") { t in
     restored.restore(snapshot, monitorID: { _ in nil })
 
     t.equal(restored.workspaceIndex(of: 1), restored.focusedWorkspaceIndex, "the workspace came home to the focused monitor")
-    t.equalBox(restored.render().frames[1], box(10, 10, 1705, 1380), "w1 fills half the new display")
-    t.equalBox(restored.render().frames[2], box(1725, 10, 1705, 1380), "w2 the other half")
+    t.equalBox(restored.render().frames[1], box(15, 15, 1697, 1370), "w1 fills half the new display")
+    t.equalBox(restored.render().frames[2], box(1728, 15, 1697, 1370), "w2 the other half")
 }
 
 h.test("a damaged snapshot is repaired rather than trusted") { t in

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -14,9 +14,10 @@
 # it leaves ⌘S ⌘F ⌘T ⌘W ⌘1-9 ⌘Tab alone. Also accepts "cmd" or "ctrl".
 super_key = "alt"
 
-# Omarchy: gaps_in = 5, gaps_out = 10
-gaps_in  = 5
-gaps_out = 10
+# Omarchy ships gaps_in = 5, gaps_out = 10; a little wider here, since macOS windows bring
+# their own rounded corners and shadows and the tiles read as touching at Omarchy's values.
+gaps_in  = 8
+gaps_out = 15
 
 [dwindle]
 # Both of these are Omarchy's settings, and together they are what makes dwindle feel right:


### PR DESCRIPTION
Omarchy ships `gaps_in = 5`, `gaps_out = 10`, and toe copied them. On macOS the windows bring their own rounded corners and shadows, and at those values the tiles read as touching.

- `DefaultConfig.swift`: the first-run config now writes `gaps_in = 8`, `gaps_out = 15`, and the header names the departure from Omarchy instead of claiming an exact match.
- `Gaps` init and `Config.gaps`: the code-level fallback moves with it, so a missing or unparseable value keeps the same numbers the shipped file carries.
- `toe.example.toml`: regenerated with `make example-config`.
- Selftest: the four assertions that hard-coded 5 / 10 updated, including the reflow frames in the restored-snapshot test.

Existing users are unaffected: their `toe.toml` already carries explicit values.

`make test`: 1093 assertions pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X483aXCBgNCMP13tKvJqNj
