### PR TITLE
Remove a dead parameter, two unread variables and a comment naming the wrong mechanism

### DIFF
--- a/Sources/ToeCore/Layout/DirectionalSearch.swift
+++ b/Sources/ToeCore/Layout/DirectionalSearch.swift
@@ -16,6 +16,13 @@ import Foundation
 ///     un-gapped node boxes, otherwise the gaps break every adjacency.
 ///  2. Among qualifying candidates, the winner is the most recently focused one, not the
 ///     one with the largest shared edge.
+///
+/// That second rule is `focus_preferred_method = 0` and nothing else: there is no switch here
+/// for `= 1` (longest shared edge). One used to be declared and never passed, and its branch
+/// had quietly diverged from this one — it accepted a candidate whose edges merely touched at a
+/// corner, where the live path demands a real overlap. In the one file whose whole point is
+/// fidelity to upstream, an untested second mode is a liability; it can come back with its test
+/// on the day it is wanted.
 public enum DirectionalSearch {
 
     public static func windowInDirection(
@@ -23,8 +30,7 @@ public enum DirectionalSearch {
         ignoring: WindowID?,
         candidates: [(id: WindowID, box: Box)],
         direction: Direction,
-        focusHistory: [WindowID],
-        preferLongestSharedEdge: Bool = false
+        focusHistory: [WindowID]
     ) -> WindowID? {
 
         var leaderValue: Double = -1
@@ -55,20 +61,14 @@ public enum DirectionalSearch {
                 }
             }
 
-            if preferLongestSharedEdge {
-                if intersectLength > leaderValue {
-                    leaderValue = intersectLength
-                    leader = candidate.id
-                }
-            } else {
-                guard intersectLength > 0 else { continue }
-                // Most recently focused wins. History is ordered most-recent-first.
-                let idx = focusHistory.firstIndex(of: candidate.id) ?? focusHistory.count
-                let score = Double(focusHistory.count - idx)
-                if score > leaderValue {
-                    leaderValue = score
-                    leader = candidate.id
-                }
+            // A real shared edge, not a corner that happens to touch.
+            guard intersectLength > 0 else { continue }
+            // Most recently focused wins. History is ordered most-recent-first.
+            let idx = focusHistory.firstIndex(of: candidate.id) ?? focusHistory.count
+            let score = Double(focusHistory.count - idx)
+            if score > leaderValue {
+                leaderValue = score
+                leader = candidate.id
             }
         }
 

--- a/Sources/toe/HideBlocker.swift
+++ b/Sources/toe/HideBlocker.swift
@@ -26,7 +26,10 @@ final class HideBlocker {
     /// The applications toe is in the middle of putting back. An unhide toe did not ask for — the
     /// user picking the app out of the Dock — must be left entirely alone.
     private var pending: Set<pid_t> = []
-    private var unhidden = 0
+    /// Whether the first unhide since `start()` has been logged. Once per run rather than once
+    /// per hide: `⌘⌥H` arrives as one notification per application, and a line for each would be
+    /// noise saying the same thing.
+    private var announced = false
 
     var isRunning: Bool { !observers.isEmpty }
 
@@ -41,8 +44,10 @@ final class HideBlocker {
             // The notification arrives after the hide, so this is an undo rather than a veto: the
             // windows are gone for a frame before they come back.
             app.unhide()
-            if self.unhidden == 0 { Log.info("hide blocker: unhiding applications as they are hidden") }
-            self.unhidden &+= 1
+            if !self.announced {
+                Log.info("hide blocker: unhiding applications as they are hidden")
+                self.announced = true
+            }
         }
 
         observe(NSWorkspace.didUnhideApplicationNotification) { [weak self] app in
@@ -60,7 +65,7 @@ final class HideBlocker {
         for observer in observers { NSWorkspace.shared.notificationCenter.removeObserver(observer) }
         observers.removeAll()
         pending.removeAll()
-        unhidden = 0
+        announced = false
         Log.info("hide blocker: stopped")
     }
 

--- a/Sources/toe/UI/QuickMenu.swift
+++ b/Sources/toe/UI/QuickMenu.swift
@@ -55,9 +55,10 @@ final class QuickMenu {
     /// launchd's answer, read once when the menu opened.
     ///
     /// Held rather than re-read by `update(config:style:)`, because that runs six times a second
-    /// for as long as a download lasts and `LoginItem.state()` shells out to `launchctl`. Nothing can change it
-    /// while the menu is up except the toggle itself, which rebuilds its own level with the fresh
-    /// answer and does not come through here.
+    /// for as long as a download lasts and `LoginItem.state()` is not free: `SMAppService.status`
+    /// is an XPC round trip to launchd, and the checks before it touch `Bundle.main` and the
+    /// filesystem. Nothing can change it while the menu is up except the toggle itself, which
+    /// rebuilds its own level with the fresh answer and does not come through here.
     private var loginItem: LoginItemState = .off
     private var usable: Box?
     private var metrics = MenuMetrics(lineHeight: 22)

--- a/Sources/toe/UI/Wallpaper.swift
+++ b/Sources/toe/UI/Wallpaper.swift
@@ -25,7 +25,6 @@ final class Wallpaper {
     /// `SessionStore.monitorKey` derives — a `CGDirectDisplayID` is handed out per connection and
     /// would name the wrong screen after a replug.
     private var previous: [String: String] = [:]
-    private var didJournal = false
 
     /// What toe last set, so a new display or a Space that has not seen it yet can be caught up.
     private var current: URL?
@@ -79,7 +78,6 @@ final class Wallpaper {
         defer {
             previous.removeAll()
             current = nil
-            didJournal = false
             Self.clearJournal()
         }
         guard !saved.isEmpty else { return }
@@ -128,7 +126,6 @@ final class Wallpaper {
             added = true
         }
         guard added else { return }
-        didJournal = true
         Self.writeJournal(previous)                    // before the change, never after
     }
 


### PR DESCRIPTION
Closes #91.

None of this changes behaviour. All four are the drift the issue describes: something beside the code that says more, or other, than the code does.

- **`DirectionalSearch.preferLongestSharedEdge`** — declared, branched on, never passed by anyone. Removed along with its branch, which had diverged from the live one (it accepted a candidate whose edges merely touched at a corner, where the live path demands a real overlap). The doc comment now says this file is `focus_preferred_method = 0` and nothing else, and why a second mode should arrive with its test rather than as a dormant option.
- **`Wallpaper.didJournal`** — set true and false, read nowhere. `journalIfNeeded` already gates per display on `previous[key] == nil`, which is the gate its comment describes. Deleted.
- **`HideBlocker.unhidden`** — an overflow-guarded counter whose only reader was `== 0`, to log one line once. Now a `Bool` named `announced`, with a comment on why once per run rather than once per hide.
- **`QuickMenu.loginItem`'s comment** said `LoginItem.state()` shells out to `launchctl`. It reads `SMAppService.mainApp.status`, which is an XPC round trip to launchd plus a `Bundle.main` and filesystem check, so the caching stays and the reason is corrected.

`swift build -c release` clean; `make test`: 1093 assertions pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X483aXCBgNCMP13tKvJqNj
