### PR TITLE
Warn about a force_split or split_bias off the list, and a number that is not one

### DIFF
--- a/Sources/ToeCore/Config/Config.swift
+++ b/Sources/ToeCore/Config/Config.swift
@@ -278,7 +278,7 @@ public struct Config: Equatable {
     /// a gap of 1024 points) along with the non-finite.
     static func number(_ raw: TOMLValue?, _ path: String, in range: ClosedRange<Double>,
                        keeping current: Double, warnings: inout [String]) -> Double? {
-        guard let value = raw?.doubleValue else { return nil }
+        guard let value = numeric(raw, path, keeping: current, warnings: &warnings) else { return nil }
         guard value.isFinite, range.contains(value) else {
             warnings.append("\(path): must be a number from \(brief(range.lowerBound)) to "
                             + "\(brief(range.upperBound)), using \(brief(current))")
@@ -287,9 +287,60 @@ public struct Config: Equatable {
         return value
     }
 
+    /// The number a key holds, before any question of range — or nil, which means one of two
+    /// things and says which.
+    ///
+    /// A key that is absent is nil and silent: the default is what was asked for. A key that is
+    /// present and *not a number* — `gaps_in = "5"`, a number in quotes, is the one people
+    /// actually write — is nil with a warning, because from the outside it is indistinguishable
+    /// from "toe ignored my config", which is the failure the warnings exist to prevent. Before
+    /// this the two collapsed into one `raw?.doubleValue`, so a wrong type was dropped without
+    /// a word while a number merely out of range got a good one. `[misc]` and `[gestures]` had
+    /// already taken the trouble to tell absent from wrong for their booleans; this is the same
+    /// distinction for every numeric key.
+    static func numeric(_ raw: TOMLValue?, _ path: String,
+                        keeping current: Double, warnings: inout [String]) -> Double? {
+        guard let raw else { return nil }
+        guard let value = raw.doubleValue else {
+            warnings.append("\(path): must be a number, using \(brief(current))")
+            return nil
+        }
+        return value
+    }
+
+    /// One whole number from a short list of allowed values, or nil — with a warning naming the
+    /// list — when the key is present and holds anything else.
+    ///
+    /// For the keys that are a choice rather than a quantity: `force_split` is 0, 1 or 2 and
+    /// `force_split = 7` is a typo, not a large split. Without this it fell through to the
+    /// `else` in `DwindleLayout.insert` and behaved exactly like 2, so a mistake was
+    /// indistinguishable from the default. A float that is a whole number still reads as the
+    /// integer it is (`intValue` truncates toward zero), so `force_split = 2.0` keeps working;
+    /// a string, a bool, or a number off the list warns and keeps `current`.
+    static func choice(_ raw: TOMLValue?, _ path: String, among allowed: ClosedRange<Int>,
+                       keeping current: Int, warnings: inout [String]) -> Int? {
+        guard let raw else { return nil }
+        guard let value = raw.intValue, allowed.contains(value) else {
+            warnings.append("\(path): must be \(spell(allowed)), using \(current)")
+            return nil
+        }
+        return value
+    }
+
     /// `5` rather than `5.0`, so the warnings read the way the config file is written.
     private static func brief(_ value: Double) -> String {
         value == value.rounded() && abs(value) < 1e15 ? String(Int(value)) : String(value)
+    }
+
+    /// `0, 1 or 2` when the list is short enough to be read as one, since a typo wants to see
+    /// the values it could have been; `a whole number from 0 to 10` when it is not.
+    private static func spell(_ allowed: ClosedRange<Int>) -> String {
+        let values = Array(allowed)
+        guard values.count <= 3, let last = values.last else {
+            return "a whole number from \(allowed.lowerBound) to \(allowed.upperBound)"
+        }
+        guard values.count > 1 else { return String(last) }
+        return values.dropLast().map(String.init).joined(separator: ", ") + " or \(last)"
     }
 
     public static func parse(_ text: String) throws -> Config {
@@ -317,7 +368,10 @@ public struct Config: Equatable {
 
         if let d = root["dwindle"]?.tableValue {
             if let v = d["preserve_split"]?.boolValue { config.dwindle.preserveSplit = v }
-            if let v = d["force_split"]?.intValue { config.dwindle.forceSplit = v }
+            if let v = choice(d["force_split"], "dwindle.force_split", among: 0...2,
+                              keeping: config.dwindle.forceSplit, warnings: &config.warnings) {
+                config.dwindle.forceSplit = v
+            }
             if let v = d["smart_split"]?.boolValue { config.dwindle.smartSplit = v }
             if let v = number(d["split_width_multiplier"], "dwindle.split_width_multiplier", in: 0.1...10,
                               keeping: config.dwindle.splitWidthMultiplier, warnings: &config.warnings) {
@@ -329,7 +383,10 @@ public struct Config: Equatable {
                               keeping: config.dwindle.defaultSplitRatio, warnings: &config.warnings) {
                 config.dwindle.defaultSplitRatio = v
             }
-            if let v = d["split_bias"]?.intValue { config.dwindle.splitBias = v }
+            if let v = choice(d["split_bias"], "dwindle.split_bias", among: 0...2,
+                              keeping: config.dwindle.splitBias, warnings: &config.warnings) {
+                config.dwindle.splitBias = v
+            }
         }
 
         if let b = root["border"]?.tableValue {
@@ -354,38 +411,40 @@ public struct Config: Equatable {
         }
 
         if let b = root["bar"]?.tableValue {
-            if let v = b["persistent_workspaces"]?.intValue {
-                let allowed = 0...WorkspaceManager.workspaceCount
-                if allowed.contains(v) {
-                    config.bar.persistentWorkspaces = v
-                } else {
-                    config.warnings.append("bar.persistent_workspaces: must be 0 ... \(WorkspaceManager.workspaceCount), using \(config.bar.persistentWorkspaces)")
-                }
+            if let v = choice(b["persistent_workspaces"], "bar.persistent_workspaces",
+                              among: 0...WorkspaceManager.workspaceCount,
+                              keeping: config.bar.persistentWorkspaces, warnings: &config.warnings) {
+                config.bar.persistentWorkspaces = v
             }
         }
 
         if let f = root["floating"]?.tableValue {
-            if let v = f["width"]?.doubleValue {
+            if let v = numeric(f["width"], "floating.width",
+                               keeping: config.floating.width, warnings: &config.warnings) {
                 if v > 0, v <= 1 { config.floating.width = v } else {
                     config.warnings.append("floating.width: must be over 0 and at most 1, using \(config.floating.width)")
                 }
             }
-            if let v = f["height"]?.doubleValue {
+            if let v = numeric(f["height"], "floating.height",
+                               keeping: config.floating.height, warnings: &config.warnings) {
                 if v > 0, v <= 1 { config.floating.height = v } else {
                     config.warnings.append("floating.height: must be over 0 and at most 1, using \(config.floating.height)")
                 }
             }
-            if let v = f["large_width"]?.doubleValue {
+            if let v = numeric(f["large_width"], "floating.large_width",
+                               keeping: config.floating.largeWidth, warnings: &config.warnings) {
                 if v > 0, v <= 1 { config.floating.largeWidth = v } else {
                     config.warnings.append("floating.large_width: must be over 0 and at most 1, using \(config.floating.largeWidth)")
                 }
             }
-            if let v = f["large_height"]?.doubleValue {
+            if let v = numeric(f["large_height"], "floating.large_height",
+                               keeping: config.floating.largeHeight, warnings: &config.warnings) {
                 if v > 0, v <= 1 { config.floating.largeHeight = v } else {
                     config.warnings.append("floating.large_height: must be over 0 and at most 1, using \(config.floating.largeHeight)")
                 }
             }
-            if let v = f["max_aspect_ratio"]?.doubleValue {
+            if let v = numeric(f["max_aspect_ratio"], "floating.max_aspect_ratio",
+                               keeping: config.floating.maxAspectRatio, warnings: &config.warnings) {
                 if v > 0 { config.floating.maxAspectRatio = v } else {
                     config.warnings.append("floating.max_aspect_ratio: must be over 0, using \(config.floating.maxAspectRatio)")
                 }

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -1221,6 +1221,71 @@ h.test("numbers outside a sensible range are refused too") { t in
     t.equal(ratio.warnings.contains { $0.contains("dwindle.default_split_ratio") }, true, "and says so")
 }
 
+h.test("force_split and split_bias take only their three values") { t in
+    // Both fell through `intValue` unchecked, so `force_split = 7` behaved exactly like 2 and a
+    // typo was indistinguishable from the default.
+    let c = try Config.parse("[dwindle]\nforce_split = 7\nsplit_bias = 9\n")
+    t.equal(c.dwindle.forceSplit, 2, "force_split = 7 keeps the default")
+    t.equal(c.dwindle.splitBias, 0, "split_bias = 9 keeps the default")
+    t.equal(c.warnings, ["dwindle.force_split: must be 0, 1 or 2, using 2",
+                         "dwindle.split_bias: must be 0, 1 or 2, using 0"],
+            "each names the values it could have been and the one it is keeping")
+
+    let negative = try Config.parse("[dwindle]\nforce_split = -1\n")
+    t.equal(negative.dwindle.forceSplit, 2, "a negative force_split keeps the default")
+    t.equal(negative.warnings.count, 1, "and says so")
+
+    let fine = try Config.parse("[dwindle]\nforce_split = 1\nsplit_bias = 2.0\n")
+    t.equal(fine.dwindle.forceSplit, 1, "1 is read")
+    t.equal(fine.dwindle.splitBias, 2, "a whole float still reads as the integer it is")
+    t.equal(fine.warnings, [], "and neither warns")
+
+    let bar = try Config.parse("[bar]\npersistent_workspaces = 11\n")
+    t.equal(bar.warnings, ["bar.persistent_workspaces: must be a whole number from 0 to 10, using \(bar.bar.persistentWorkspaces)"],
+            "a longer list is spelled as a range")
+}
+
+h.test("a number in quotes warns rather than being read as absent") { t in
+    // `gaps_in = "5"` used to fall through `raw?.doubleValue` as nil — the same nil as a key
+    // that was never written — so it was dropped without a word, while `gaps_in = 999` got a
+    // warning. From the outside both read as "toe ignored my config".
+    let c = try Config.parse("""
+        [general]
+        gaps_in = "5"
+        [border]
+        width = "2"
+        [menu]
+        font_size = "18"
+        [dwindle]
+        force_split = "1"
+        [bar]
+        persistent_workspaces = "3"
+        [floating]
+        width = "0.5"
+        max_aspect_ratio = true
+        """)
+    t.equal(c.gaps.inner, 8, "gaps_in in quotes keeps the default")
+    t.equal(c.border.width, 2, "border.width in quotes keeps the default")
+    t.equal(c.menu.fontSize, 18, "menu.font_size in quotes keeps the default")
+    t.equal(c.dwindle.forceSplit, 2, "force_split in quotes keeps the default")
+    t.equal(c.bar.persistentWorkspaces, WorkspaceStrip.defaultPersistent, "persistent_workspaces in quotes keeps the default")
+    t.equal(c.floating.width, 0.70, "floating.width in quotes keeps the default")
+    t.equal(c.floating.maxAspectRatio, Config().floating.maxAspectRatio, "a boolean where a ratio goes keeps the default")
+    t.equal(c.warnings.count, 7, "one warning each")
+    t.expect(c.warnings.contains("general.gaps_in: must be a number, using 8"), "the number is named, and so is what is kept")
+    t.expect(c.warnings.contains("border.width: must be a number, using 2"), "border.width too")
+    t.expect(c.warnings.contains("menu.font_size: must be a number, using 18"), "menu.font_size too")
+    t.expect(c.warnings.contains("dwindle.force_split: must be 0, 1 or 2, using 2"), "a choice names its values")
+    t.expect(c.warnings.contains { $0.hasPrefix("bar.persistent_workspaces: must be") }, "persistent_workspaces too")
+    t.expect(c.warnings.contains("floating.width: must be a number, using 0.7"), "floating.width too")
+    t.expect(c.warnings.contains { $0.hasPrefix("floating.max_aspect_ratio: must be a number") }, "and the boolean")
+
+    // The regression guard that matters: a key that is simply not there is still silent.
+    let absent = try Config.parse("[general]\n[border]\n[menu]\n[dwindle]\n[bar]\n[floating]\n")
+    t.equal(absent.warnings, [], "an absent key is the default, and nothing to warn about")
+    t.equal(absent.gaps.inner, 8, "with the default in place")
+}
+
 h.test("numbers in range are still read, and warn about nothing") { t in
     let c = try Config.parse("""
     [general]


### PR DESCRIPTION
Closes #90.

## What

Two config mistakes that used to read as "toe ignored my config" now say what went wrong in the menu bar tooltip, in the wording their neighbours already use.

```
dwindle.force_split: must be 0, 1 or 2, using 2
general.gaps_in: must be a number, using 8
```

## How

- **`choice(_:_:among:keeping:warnings:)`** is the new sibling of `number` for keys that are a pick rather than a quantity. `force_split` and `split_bias` go through it with `0...2`; `bar.persistent_workspaces` too, whose eleven-value list is spelled as `a whole number from 0 to 10` rather than enumerated. `intValue` still truncates a whole float, so `force_split = 2.0` keeps working, as the issue asked.
- **`numeric(_:_:keeping:warnings:)`** is the step `number` now takes first: absent is nil and silent, present-and-not-a-number is nil with a warning. Every numeric key in the file reads through one of the two helpers now, including the five `[floating]` keys, which keep their own open-at-zero ranges and gain only the type check. There is no raw `.intValue` or `.doubleValue` left in `Config.parse`.

## Tests

Two new blocks in the selftest:

- An out-of-range `force_split` and `split_bias` each warn and keep the default; a negative one too; `1` and `2.0` are read with no warning; and `persistent_workspaces = 11` shows the range spelling.
- A number in quotes on every table (`[general]`, `[border]`, `[menu]`, `[dwindle]`, `[bar]`, `[floating]`) plus a boolean where a ratio goes: one warning each, the default kept each time. Then the regression guard the issue named: six empty tables with every key absent produce no warning at all.

`make test`: 1119 assertions pass (26 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X483aXCBgNCMP13tKvJqNj
