### PR TITLE
Move the focus to the other display when workspace <n> names what it is showing

### DIFF
--- a/Sources/ToeCore/Layout/WorkspaceManager.swift
+++ b/Sources/ToeCore/Layout/WorkspaceManager.swift
@@ -138,9 +138,22 @@ public final class WorkspaceManager {
         workspaces.first { $0.value.windows.contains(id) }?.key
     }
 
+    /// The window every command acts on: the most recently focused window on the workspace the
+    /// focused monitor is showing.
+    ///
+    /// That workspace and not every visible one. `visibleWindows()` is the union across every
+    /// monitor, and on two displays it therefore held the other display's windows too — so
+    /// bringing an empty workspace up on one monitor handed the focus to whichever window on
+    /// the *other* was most recently used, and `movefocus`, `swapwindow`, `movetoworkspace` and
+    /// `killactive` all worked from there. On one display the two sets are the same set, which
+    /// is why this went unnoticed.
+    ///
+    /// An empty workspace therefore has no focused window and those commands do nothing on it,
+    /// which is what Hyprland does: `workspace` moves the focus to the monitor, and an empty
+    /// workspace has no window to give it to. It is also what one display already did.
     public var focusedWindow: WindowID? {
-        let visible = visibleWindows()
-        return focusHistory.first { visible.contains($0) }
+        let mine = focusedWorkspace.windows
+        return focusHistory.first { mine.contains($0) }
     }
 
     public func visibleWindows() -> Set<WindowID> {
@@ -458,10 +471,17 @@ public final class WorkspaceManager {
         }
     }
 
+    /// Focus the most recently used window on the workspace `focusedMonitorID` is now showing.
+    ///
+    /// Scoped to that workspace, not to everything visible: `visibleWindows()` spans every
+    /// monitor, and the window you are standing on is by definition the head of the history and
+    /// still visible on its own display — so an unscoped scan re-selected the window it was
+    /// supposed to be moving away from, and `workspace <n>` aimed at the other display moved
+    /// the strip's marker and nothing else. On an empty workspace this finds nothing and leaves
+    /// the history alone; `focusedWindow` then answers nil, and the coordinator focuses nothing.
     private func refocusVisible() {
-        // Focus the most recently used window that is now visible.
-        let visible = visibleWindows()
-        if let next = focusHistory.first(where: { visible.contains($0) }) {
+        let mine = focusedWorkspace.windows
+        if let next = focusHistory.first(where: { mine.contains($0) }) {
             noteFocusWithoutMonitorChange(next)
         }
     }

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -645,15 +645,59 @@ h.test("a workspace follows its monitor") { t in
     t.equalBox(wm.workspaces[5]?.layout.idealBox(of: 1), wm.monitor(id: home)!.usable,
                "the window fills its monitor's usable area")
 
-    // Switching to the other monitor's active workspace moves focus there.
+    // Switching to the other monitor's active workspace moves focus there — to a window on it,
+    // not just to the monitor. With a window on each side this used to leave `focusedWindow` on
+    // the display the focus was supposed to be leaving: `refocusVisible` picked the most recent
+    // window across *every* monitor, and the one you were standing on always won.
     let otherMonitor = wm.monitors.first { $0.id != home }!.id
     let otherWorkspace = wm.activeWorkspace[otherMonitor]!
     wm.switchTo(workspace: otherWorkspace)
+    wm.addWindow(2)
+    wm.switchTo(workspace: 5)
+    t.equal(wm.focusedWindow, 1, "back on workspace 5, its window has the focus")
+    wm.switchTo(workspace: otherWorkspace)
     t.equal(wm.focusedMonitorID, otherMonitor, "focus moved to the monitor owning that workspace")
+    t.equal(wm.focusedWindow, 2, "and to the window on it, not the one it came from")
+    t.equal(wm.render().focus, 2, "which is what the coordinator is told to focus")
 
     // And coming back to workspace 5 returns to its own monitor.
     wm.switchTo(workspace: 5)
     t.equal(wm.focusedMonitorID, home, "workspace 5 pulled focus back to its monitor")
+    t.equal(wm.focusedWindow, 1, "and its window has the focus again")
+    t.equal(wm.render().focus, 1, "for the coordinator too")
+}
+
+h.test("an empty workspace has no focused window, on either monitor") { t in
+    let left = box(0, 0, 1512, 982)
+    let right = box(1512, 0, 1920, 1080)
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: left, usable: left),
+                    Monitor(id: 2, frame: right, usable: right)])
+    wm.switchTo(workspace: 2); wm.addWindow(20)       // a window on monitor 2
+    wm.switchTo(workspace: 1); wm.addWindow(10)       // a window on monitor 1
+
+    // Bringing an empty workspace up on monitor 1 used to hand the focus to monitor 2's window:
+    // `focusedWindow` was the most recent window visible *anywhere*, and with w10 stashed that
+    // was w20. Every command then acted on a window on a display the focus had not gone to.
+    wm.switchTo(workspace: 5)
+    t.equal(wm.focusedMonitorID, 1, "workspace 5 came up on the monitor that asked for it")
+    t.equal(wm.focusedWindow, nil, "an empty workspace has nothing to focus")
+    t.equal(wm.render().focus, nil, "so the coordinator is told to focus nothing")
+    t.equal(wm.windowInDirection(.right), nil, "movefocus has nowhere to start from")
+    t.equal(wm.swapWindow(.right), false, "swapwindow has nothing to swap")
+    wm.moveFocusedWindow(toWorkspace: 6, follow: false)
+    t.equal(wm.workspaceIndex(of: 20), 2, "movetoworkspace did not reach across to w20")
+
+    // Clicking into the other display is a real focus notification, and that still lands.
+    wm.noteFocus(20)
+    t.equal(wm.focusedMonitorID, 2, "a real focus on w20 moves to its monitor")
+    t.equal(wm.focusedWindow, 20, "and w20 is the focused window")
+
+    // The same empty workspace already showing on the *other* monitor: focus goes there and
+    // stops, rather than staying on w20.
+    wm.switchTo(workspace: 5)
+    t.equal(wm.focusedMonitorID, 1, "workspace 5 is on monitor 1, so the focus went there")
+    t.equal(wm.focusedWindow, nil, "with nothing on it to focus")
 }
 
 // MARK: - Stacking


### PR DESCRIPTION
Closes #88.

## What

With two displays, `workspace <n>` aimed at a workspace already showing on the other monitor now moves the keyboard focus to the most recently used window on it, and everything downstream (`movefocus`, `swapwindow`, `movetoworkspace`, `killactive`, the border) works from that window rather than the one you left.

## How

Both `refocusVisible()` and `focusedWindow` are scoped to the workspace `focusedMonitorID` is showing, instead of the union of every visible workspace. On one display those were the same set, which is why this went unnoticed.

## The design call

The issue asked for the empty-workspace behaviour to be decided deliberately, and named two options. This takes the second: **an empty workspace has no focused window.** `focusedWindow` answers nil there, so `render().focus` is nil and the coordinator focuses nothing, the commands that need a window do nothing, and the border hides.

Why that one:

- It is what Hyprland does. `workspace` moves the focus to the monitor, and an empty workspace has no window to give it to.
- It is what one display already did. Switch to an empty workspace on a single monitor and `visibleWindows()` is empty, so `focusedWindow` was already nil. Two displays now behave the same way, rather than borrowing a window from the other one.
- The blast radius is small. I read every reader of `focusedWindow` in `Coordinator`: `killActive`, `toggleFloating`, `toggleSplit`, `swapSplit`, `windowInDirection`, `swapWindow`, `moveWindow`, `moveFocusedWindow` all guard on it and become no-ops; `updateBorder` hides; the `id == workspaces.focusedWindow` comparisons in the frame-change paths compare false; the slide's border cutout takes an optional already. None of them did anything sensible with the other display's window.

A real focus notification from the other display still lands: `noteFocus` sets `focusedMonitorID` from the window's workspace, so clicking into the other monitor moves both together. The test covers that.

## Tests

Written first, and they fail on `main` exactly as the issue describes (`focusedWindow` reads `2`, want `1`; on the empty workspace it reads `20`, want nil).

- "a workspace follows its monitor" now puts a window on **each** side and asserts `focusedWindow` and `render().focus` in both directions, not only `focusedMonitorID`.
- "an empty workspace has no focused window, on either monitor" covers the second shape: the empty workspace on the same monitor, the same one already showing on the other monitor, that `movefocus` / `swapwindow` / `movetoworkspace` do not reach across, and that a real focus on the other display still moves there.

`make test`: 1108 assertions pass (15 new). `swift build -c release` clean. Not tried live on two displays; the model is what the issue reproduced and what the tests pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X483aXCBgNCMP13tKvJqNj
