### PR TITLE
Say in the README that the workspace slide wants Screen Recording, and that it is optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ The two-argument `brew tap` is needed because the cask lives in this repository.
 On first launch, grant **System Settings → Privacy & Security → Accessibility** when asked. That
 is the only permission toe needs.
 
+There is one optional extra. The workspace slide — the screen sliding sideways under a dock
+swipe, the way Spaces does — is drawn from a picture of the display, and taking that picture is
+**Screen Recording**, a second permission. It is off by default, and it is a gimmick: toe tiles,
+focuses and switches exactly the same without it. Turn it on from the quick menu under
+**Trigger › Toggle › Workspace slide** (or `slide_on_swipe = true` under `[animations]`) and macOS
+asks for the grant then, not before. If you would rather not give it, leave the slide off and
+nothing else changes.
+
 ### What the defaults assume
 
 Three of the shipped bindings launch an application. toe has no terminal, browser or editor of its


### PR DESCRIPTION
A paragraph under the first-launch Accessibility note, where someone deciding what to grant is already reading. It says the workspace slide is drawn from a picture of the display, which is Screen Recording, a second permission; that it is off by default and a gimmick rather than part of tiling; where to turn it on (Trigger › Toggle › Workspace slide, or `slide_on_swipe`); and that leaving it off changes nothing else.

README only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X483aXCBgNCMP13tKvJqNj
