### PR TITLE
Grow the focused window from the keyboard, and let a dragged edge move the split

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ leaves ⌘S, ⌘F, ⌘T, ⌘W, ⌘1-9 and ⌘Tab untouched.
 | `SUPER` + `SHIFT` + `ENTER` | New browser window |
 | `SUPER` + `W` | Close window |
 | `SUPER` + `J` | Toggle split orientation |
+| `SUPER` + `-` / `=` | Make the window 100 pt narrower / wider |
+| `SUPER` + `SHIFT` + `-` / `=` | Make it 100 pt shorter / taller |
 | `SUPER` + `T` | Cycle floating: 70×80% of the display, 80×90%, back to tiling |
 | `SUPER` + `SPACE` | The quick menu |
 | `SUPER` + `CTRL` + `SPACE` | The background picker, when the theme has pictures |
@@ -87,6 +89,7 @@ leaves ⌘S, ⌘F, ⌘T, ⌘W, ⌘1-9 and ⌘Tab untouched.
 | `SUPER` + `,` | Edit the config |
 | `SUPER` + `SHIFT` + `R` / `Q` | Reload the config / quit toe |
 | Drag a tiled window | Swap it with the tile you drag it over |
+| Drag a tiled window's edge | Resize it; the neighbours follow when you let go |
 
 **The layout.** A new window splits the focused one and takes the right or bottom half. A split's
 orientation is decided once, from the shape of the space it is in, and then kept, so the layout
@@ -139,8 +142,10 @@ app = "com.apple.ActivityMonitor"
 Binding specs accept the dash spelling and Omarchy's, so `"alt-shift-1"`, `"super+shift+1"` and
 `"SUPER SHIFT, 1"` all mean the same. The commands are `movefocus`, `swapwindow`, `movewindow`,
 `workspace`, `movetoworkspace`, `movetoworkspacesilent`, `killactive`, `togglefloating`,
-`togglesplit`, `swapsplit`, `exec`, `reload`, `menu`, `keybindings`, `theme`, `removetheme`,
-`background`, `nextbackground` and `quit`.
+`togglesplit`, `swapsplit`, `growactive`, `resizeactive`, `exec`, `reload`, `menu`, `keybindings`,
+`theme`, `removetheme`, `background`, `nextbackground` and `quit`. `growactive <dx> <dy>` grows the
+focused window by that much; Hyprland's `resizeactive` moves the split by that much instead, which
+from a right-hand window is the other way round, and is accepted for configs copied from Omarchy.
 
 Other sections worth knowing about:
 
@@ -176,8 +181,8 @@ log stream --predicate 'subsystem == "com.clifmeister.toe"' --level info
 
 ## Not included
 
-By design: no scratchpads, no binding modes, no scripting API, no resize bindings, no window
-groups. It is a layout engine and the bindings that drive it.
+By design: no scratchpads, no binding modes, no scripting API, no window groups. It is a
+layout engine and the bindings that drive it.
 
 ## License
 

--- a/Sources/ToeCore/Config/Config.swift
+++ b/Sources/ToeCore/Config/Config.swift
@@ -210,8 +210,8 @@ public struct Config: Equatable {
     /// competing with yours, so the bar is high: either the binding is an escape hatch — a config
     /// which forgot it leaves you stuck, in the same spirit as keeping the last good config when
     /// a new one will not parse — or it is a key that has no other way of ever reaching an
-    /// install that predates it *and* is worth that. Four of the five below are the first kind;
-    /// `nextbackground` is the second, and the note beside it says why it cleared the bar.
+    /// install that predates it *and* is worth that. The first four below are the first kind;
+    /// the rest are the second, and the notes beside them say why they cleared the bar.
     ///
     /// The bar matters more than the list. Every binding toe adds from here on will have this
     /// same argument available to it — "existing configs will never see it" is true of all of
@@ -242,7 +242,28 @@ public struct Config: Equatable {
         // never had the key gets Omarchy's picker.
         ("super-ctrl-space", .menu(.background)),
         ("super-shift-ctrl-space", .menu(.theme)),
+        // The resize keys, for the reason the two above are here: they arrived after every
+        // existing config was written, and a way of changing a window's size is the sort of thing
+        // a tiling window manager is expected to have on a key without a trip to the file. All
+        // four go together — `-` without `=` is half a feature — and they stand aside for any
+        // resizing verb at all, not only for one with these amounts; see `bound(_:in:)`.
+        ("super-minus", .growActive(dx: -100, dy: 0)),
+        ("super-equal", .growActive(dx: 100, dy: 0)),
+        ("super-shift-minus", .growActive(dx: 0, dy: -100)),
+        ("super-shift-equal", .growActive(dx: 0, dy: 100)),
     ]
+
+    /// Whether a binding already answers for a fallback's command. Equality, except that any
+    /// resizing verb answers for every resizing verb: the four resize fallbacks differ only in
+    /// their amounts, and a config that has `resizeactive 50 0` on a key of its own has already
+    /// decided how it resizes — handing it `growactive 100 0` on four more keys would be the
+    /// second config competing with yours that the list exists not to be.
+    static func bound(_ command: Command, in bindings: [Binding]) -> Bool {
+        bindings.contains { existing in
+            if existing.command.resizes && command.resizes { return true }
+            return existing.command == command
+        }
+    }
 
     public static let defaultFloatRules: [FloatRule] = [
         FloatRule(app: "com.apple.systempreferences"),
@@ -586,8 +607,12 @@ public struct Config: Equatable {
         // A fallback whose own combination you have already used for something else is dropped
         // rather than registered twice: your binding wins, and the alternative is a duplicate the
         // system would refuse anyway.
-        for fallback in Config.fallbackBindings
-        where !config.bindings.contains(where: { $0.command == fallback.command }) {
+        //
+        // Whether a command is bound is asked of the bindings *you* wrote, not of the list as it
+        // grows: the resize fallbacks answer for one another, and asked of the growing list the
+        // first to land would have kept the other three out.
+        let own = config.bindings
+        for fallback in Config.fallbackBindings where !Config.bound(fallback.command, in: own) {
             guard let (mods, code, keyName) = try? BindingParser.parse(fallback.spec,
                                                                        superKey: config.superKey),
                   !config.bindings.contains(where: { $0.modifiers == mods && $0.keyCode == code })

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -247,6 +247,17 @@ font_size  = 18
 "super-j"       = "togglesplit"
 "super-t"       = "togglefloating"
 
+# ── Resize — SUPER + - / =, SHIFT for the vertical axis ───────────────────────
+# growactive: the number is how much the focused window grows, whichever side of its split it
+# is on — = is always bigger, - always smaller. Omarchy binds Hyprland's resizeactive here
+# instead, where the number is how far the *split* moves, so = grows a left-hand window and
+# shrinks a right-hand one; that verb works too, for a config copied across. Dragging a tiled
+# window's edge with the mouse does the same thing without a key.
+"super-minus"       = "growactive -100 0"
+"super-equal"       = "growactive 100 0"
+"super-shift-minus" = "growactive 0 -100"
+"super-shift-equal" = "growactive 0 100"
+
 # ── toe itself ────────────────────────────────────────────────────────────────
 # The menu bar item is only the workspace strip — waybar's has nothing behind it either — so
 # these are the way in to everything toe can do to itself.

--- a/Sources/ToeCore/Dispatch/Command.swift
+++ b/Sources/ToeCore/Dispatch/Command.swift
@@ -18,6 +18,14 @@ public enum Command: Equatable {
     case toggleFloating
     case toggleSplit
     case swapSplit
+    /// `resizeactive <dx> <dy>`: how far the focused window's splits move, in points, right and
+    /// down when positive. Hyprland's numbers and Hyprland's meaning — see
+    /// `DwindleLayout.resizeActive` for why the split moves rather than the window growing.
+    case resizeActive(dx: Double, dy: Double)
+    /// `growactive <dx> <dy>`: how much the focused window grows, in points, whichever side of
+    /// its splits it is on — so `=` is always bigger and `-` always smaller. toe's own verb,
+    /// bound by default; `resizeactive` is kept for configs copied from Omarchy.
+    case growActive(dx: Double, dy: Double)
     case exec(String)
     case reload
     /// The quick menu, at a level. One case with a route rather than one per door: the
@@ -58,6 +66,15 @@ public extension Command {
     var opensConfig: Bool {
         guard case .exec(let line) = self else { return false }
         return line.contains(Config.fileName)
+    }
+
+    /// True for the two verbs that change a window's size. They answer for one another where
+    /// the question is "has this config got resizing on a key" — see `Config.bound(_:in:)`.
+    var resizes: Bool {
+        switch self {
+        case .resizeActive, .growActive: return true
+        default:                         return false
+        }
     }
 
     /// Whether the quick menu stays up after running this.
@@ -142,6 +159,18 @@ public enum CommandParser {
         case "togglefloating", "float":     return .toggleFloating
         case "togglesplit":                 return .toggleSplit
         case "swapsplit":                   return .swapSplit
+        case "resizeactive", "growactive":
+            // Two numbers, and only two: Hyprland's `exact` and percentage forms are not ported,
+            // because a tile's size is the tree's to decide and an exact size has no meaning in
+            // it. They fail as a bad argument rather than an unknown verb so the warning points
+            // at the right word. Commas and spaces both separate, as `resizeactive, 100 0`
+            // copied from an Omarchy config has both.
+            let parts = argument.split { $0.isWhitespace || $0 == "," }.map(String.init)
+            guard !parts.isEmpty else { throw CommandError.missingArgument(name) }
+            guard parts.count == 2, let dx = Double(parts[0]), let dy = Double(parts[1]),
+                  dx.isFinite, dy.isFinite
+            else { throw CommandError.badArgument(name, argument) }
+            return name == "growactive" ? .growActive(dx: dx, dy: dy) : .resizeActive(dx: dx, dy: dy)
         case "reload":                      return .reload
         case "quit", "exit":                return .quit
 

--- a/Sources/ToeCore/Dispatch/CommandLabel.swift
+++ b/Sources/ToeCore/Dispatch/CommandLabel.swift
@@ -22,6 +22,8 @@ public enum CommandLabel {
         case .toggleFloating:       return "Cycle floating"
         case .toggleSplit:          return "Toggle split orientation"
         case .swapSplit:            return "Swap the split"
+        case .resizeActive(let dx, let dy): return resize(dx: dx, dy: dy)
+        case .growActive(let dx, let dy):   return grow(dx: dx, dy: dy)
         case .exec(let line):
             // The one exec the list can name for you: `SUPER`+`,` read as "Edit the config"
             // while toe owned the command, and a row that reads `Run open -a "Visual Studio
@@ -47,6 +49,42 @@ public enum CommandLabel {
         case .removeTheme(let slug): return "Remove the theme \(Slug.title(slug))"
         case .background(let file):  return "Background: \(ellipsised(file))"
         case .nextBackground:        return "Next background"
+        }
+    }
+
+    /// "Move the split 100 pt right" — where the split goes, not what happens to the window,
+    /// because the window is the half of it that depends on which side you are on. Someone who
+    /// pressed `=` and watched their window shrink comes to this list to find out why, and the
+    /// answer is the split.
+    private static func resize(dx: Double, dy: Double) -> String {
+        func travel(_ v: Double, _ positive: String, _ negative: String) -> String {
+            let n = abs(v)
+            let amount = n == n.rounded() ? String(Int(n)) : String(n)
+            return "\(amount) pt \(v < 0 ? negative : positive)"
+        }
+        switch (dx != 0, dy != 0) {
+        case (true, false):  return "Move the split " + travel(dx, "right", "left")
+        case (false, true):  return "Move the split " + travel(dy, "down", "up")
+        case (true, true):   return "Move the splits " + travel(dx, "right", "left")
+                                    + " and " + travel(dy, "down", "up")
+        case (false, false): return "Move the split nowhere"
+        }
+    }
+
+    /// "Make the window 100 pt wider" — what happens to the window you are in, which for this
+    /// verb is the whole of the meaning.
+    private static func grow(dx: Double, dy: Double) -> String {
+        func change(_ v: Double, _ more: String, _ less: String) -> String {
+            let n = abs(v)
+            let amount = n == n.rounded() ? String(Int(n)) : String(n)
+            return "\(amount) pt \(v < 0 ? less : more)"
+        }
+        switch (dx != 0, dy != 0) {
+        case (true, false):  return "Make the window " + change(dx, "wider", "narrower")
+        case (false, true):  return "Make the window " + change(dy, "taller", "shorter")
+        case (true, true):   return "Make the window " + change(dx, "wider", "narrower")
+                                    + " and " + change(dy, "taller", "shorter")
+        case (false, false): return "Leave the window its size"
         }
     }
 

--- a/Sources/ToeCore/Layout/DwindleLayout.swift
+++ b/Sources/ToeCore/Layout/DwindleLayout.swift
@@ -10,6 +10,17 @@ public struct Gaps: Equatable, Sendable {
     }
 }
 
+/// Which edges of a window are being pulled. Empty is Hyprland's `CORNER_NONE`: the keyboard
+/// case, where the nearest split of each orientation is the one that moves.
+public struct ResizeEdges: OptionSet, Sendable, Hashable {
+    public let rawValue: UInt8
+    public init(rawValue: UInt8) { self.rawValue = rawValue }
+    public static let left   = ResizeEdges(rawValue: 1 << 0)
+    public static let right  = ResizeEdges(rawValue: 1 << 1)
+    public static let top    = ResizeEdges(rawValue: 1 << 2)
+    public static let bottom = ResizeEdges(rawValue: 1 << 3)
+}
+
 /// One dwindle tree. There is exactly one of these per workspace.
 ///
 /// Direct port of `CHyprDwindleLayout` restricted to a single workspace, since on macOS
@@ -271,6 +282,143 @@ public final class DwindleLayout {
         let newRatio = exact ? delta : parent.splitRatio + delta
         parent.splitRatio = clampf(newRatio, 0.1, 1.9)
         parent.recalcSizePosRecursive(options)
+    }
+
+    /// Port of `resizeActiveWindow` — `resizeactive`, and the tiled half of a mouse resize.
+    ///
+    /// `dx` and `dy` are how far an edge moves, in points, positive right and down. That is the
+    /// pointer delta Hyprland feeds this from `IHyprLayout::onMouseMove`, and it is *not* the
+    /// change in the window's size: pulling a left edge leftwards is a negative `dx`, and the
+    /// `LEFT` branch below turns it into the left-hand neighbour giving up that much. With no
+    /// edges — the keyboard — the split moves by the amount, whichever side of it this window is
+    /// on, so `resizeactive 100 0` grows a left-hand window and shrinks a right-hand one. That
+    /// is Omarchy's binding and it is kept as it is.
+    ///
+    /// Hyprland ships `dwindle:smart_resizing = 1` and Omarchy leaves it, so this is that branch
+    /// and only that branch. The walk up the tree finds, per orientation, the *outer* split —
+    /// the first ancestor where this window's subtree sits on the near side of the edge being
+    /// pulled, so that moving the split moves the edge — and, on the way to it, an *inner*
+    /// split of the same orientation, whose ratio is then re-solved so the window's opposite
+    /// edge stays where it was. Without that correction the whole subtree would stretch in
+    /// proportion and the edge the user is not holding would drift, which is the difference
+    /// between a drag and a zoom. With no edges the first ancestor of each orientation is the
+    /// outer one and there is no inner.
+    ///
+    /// Measured on the un-gapped node boxes, the way Hyprland measures against the monitor's
+    /// reserved area: a gap is a constant inset, so an edge's displacement is the same number in
+    /// either space, and the node box is the one whose width the ratio is a fraction of.
+    ///
+    /// Returns false when nothing could move — the only window on the workspace, or a
+    /// side-by-side pair asked for the vertical axis — so the caller can skip the render.
+    @discardableResult
+    public func resizeActive(_ id: WindowID, dx: Double, dy: Double, edges: ResizeEdges) -> Bool {
+        guard let node = nodes[id] else { return false }
+
+        // An edge that is the display's edge cannot move, so pulling it pulls the other one —
+        // Hyprland's DISPLAYLEFT and friends, which is also why a `Super`+right-drag on a
+        // leftmost window resizes it from the right. A window spanning the full width has no
+        // horizontal freedom at all, and that axis is dropped rather than left to move a split.
+        let displayLeft   = STICKS(node.box.minX, area.minX)
+        let displayRight  = STICKS(node.box.maxX, area.maxX)
+        let displayTop    = STICKS(node.box.minY, area.minY)
+        let displayBottom = STICKS(node.box.maxY, area.maxY)
+
+        let dx = displayLeft && displayRight ? 0 : dx
+        let dy = displayTop && displayBottom ? 0 : dy
+
+        let none   = edges.isEmpty
+        let left   = edges.contains(.left)   || displayRight
+        let top    = edges.contains(.top)    || displayBottom
+        let right  = edges.contains(.right)  || displayLeft
+        let bottom = edges.contains(.bottom) || displayTop
+
+        // PVOUTER / PVINNER / PHOUTER / PHINNER. Each is the *child* on the path, not the split
+        // itself, because which child it is decides how the inner ratio is re-solved.
+        var vOuter: DwindleNode?, vInner: DwindleNode?
+        var hOuter: DwindleNode?, hInner: DwindleNode?
+
+        var current = node
+        while let parent = current.parent {
+            let first = parent.children.first === current
+            if vOuter == nil, parent.splitTop, none || (top && !first) || (bottom && first) {
+                vOuter = current
+            } else if vOuter == nil, vInner == nil, parent.splitTop {
+                vInner = current
+            } else if hOuter == nil, !parent.splitTop, none || (left && !first) || (right && first) {
+                hOuter = current
+            } else if hOuter == nil, hInner == nil, !parent.splitTop {
+                hInner = current
+            }
+            if vOuter != nil && hOuter != nil { break }
+            current = parent
+        }
+
+        var moved = false
+
+        if dx != 0, let outer = hOuter, let split = outer.parent, split.box.w > 0 {
+            split.splitRatio = clampf(split.splitRatio + dx * 2.0 / split.box.w, 0.1, 1.9)
+            if let inner = hInner, let innerSplit = inner.parent, innerSplit.box.w > 0 {
+                // Re-solve the inner split from what the inner child measured *before* the
+                // outer one moved: that width plus (or minus) the pull is the width that keeps
+                // the far edge still, and the ratio is that width as a fraction of the half.
+                let original = inner.box.w
+                split.recalcSizePosRecursive(options)
+                if innerSplit.children.first === inner {
+                    innerSplit.splitRatio = clampf((original - dx) / innerSplit.box.w * 2.0, 0.1, 1.9)
+                } else {
+                    innerSplit.splitRatio = clampf(2.0 - (original + dx) / innerSplit.box.w * 2.0, 0.1, 1.9)
+                }
+                innerSplit.recalcSizePosRecursive(options)
+            } else {
+                split.recalcSizePosRecursive(options)
+            }
+            moved = true
+        }
+
+        if dy != 0, let outer = vOuter, let split = outer.parent, split.box.h > 0 {
+            split.splitRatio = clampf(split.splitRatio + dy * 2.0 / split.box.h, 0.1, 1.9)
+            if let inner = vInner, let innerSplit = inner.parent, innerSplit.box.h > 0 {
+                let original = inner.box.h
+                split.recalcSizePosRecursive(options)
+                if innerSplit.children.first === inner {
+                    innerSplit.splitRatio = clampf((original - dy) / innerSplit.box.h * 2.0, 0.1, 1.9)
+                } else {
+                    innerSplit.splitRatio = clampf(2.0 - (original + dy) / innerSplit.box.h * 2.0, 0.1, 1.9)
+                }
+                innerSplit.recalcSizePosRecursive(options)
+            } else {
+                split.recalcSizePosRecursive(options)
+            }
+            moved = true
+        }
+
+        return moved
+    }
+
+    /// `growactive`: `dx` and `dy` are how much *this window* grows, whichever side of its
+    /// splits it is on. Not a Hyprland dispatcher — `resizeactive` moves the split, and from the
+    /// right-hand window the key labelled `=` therefore shrinks the window you are in, which is
+    /// the surprise this exists to remove. It is `resizeActive` with the sign settled here: a
+    /// window on the first side of a split (left, top) grows when the split moves away from it
+    /// in the positive direction, a window on the second side grows when it moves the other
+    /// way. The split found is the same one `resizeActive` finds with no edges — the nearest
+    /// ancestor of that orientation — so the two verbs never disagree about *which* split.
+    @discardableResult
+    public func growActive(_ id: WindowID, dx: Double, dy: Double) -> Bool {
+        guard let node = nodes[id] else { return false }
+        // Which child of the nearest split of an orientation this window's subtree is. Nil when
+        // there is none — that axis then has nothing to move, and `resizeActive` says so.
+        func onFirstSide(ofSplitTop splitTop: Bool) -> Bool? {
+            var current = node
+            while let parent = current.parent {
+                if parent.splitTop == splitTop { return parent.children.first === current }
+                current = parent
+            }
+            return nil
+        }
+        let h = onFirstSide(ofSplitTop: false)
+        let v = onFirstSide(ofSplitTop: true)
+        return resizeActive(id, dx: h == false ? -dx : dx, dy: v == false ? -dy : dy, edges: [])
     }
 
     // MARK: - Output

--- a/Sources/ToeCore/Layout/ResizeGesture.swift
+++ b/Sources/ToeCore/Layout/ResizeGesture.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// The arithmetic of a mouse resize, kept out of `Sources/toe` for the reason `BorderGeometry`
+/// is: the frame is read through Accessibility and the tile comes from the coordinator, but
+/// what the two say together is geometry, and geometry can be tested.
+public enum ResizeGesture {
+
+    /// Which edges moved between the tile a drag started from and the frame it let go with, and
+    /// how far each went.
+    ///
+    /// Edges are compared as edges, not as origin plus size: a left-edge drag changes both `x`
+    /// and `w` while leaving `maxX` alone, and it is the left edge that moved. `dx` and `dy` are
+    /// the displacement of the edge that moved, positive right and down — the pointer delta
+    /// `DwindleLayout.resizeActive` expects — and deliberately *not* the change in width, which
+    /// is the obvious wrong answer: pulling the left edge outwards makes the window wider and
+    /// gives a negative `dx`.
+    ///
+    /// An axis counts as resized only when the size along it changed by `tolerance` — the 2pt
+    /// the coordinator's `settled` allows an app for its own rounding. Both edges moving by the
+    /// same amount is a move, not a resize, and a drag that was taken for a resize because a
+    /// Resized notification arrived can still be one: that axis is left out, and if neither is
+    /// left the answer is nil and the window snaps back to its tile as it always did. When the
+    /// size did change, the edge that travelled further is the one in the user's hand.
+    public static func delta(from origin: Box, to final: Box, tolerance: Double = 2.0)
+        -> (edges: ResizeEdges, dx: Double, dy: Double)? {
+        var edges: ResizeEdges = []
+        var dx = 0.0
+        var dy = 0.0
+
+        let left = final.minX - origin.minX
+        let right = final.maxX - origin.maxX
+        if abs(right - left) >= tolerance {
+            if abs(right) >= abs(left) { edges.insert(.right); dx = right }
+            else                       { edges.insert(.left);  dx = left }
+        }
+
+        let top = final.minY - origin.minY
+        let bottom = final.maxY - origin.maxY
+        if abs(bottom - top) >= tolerance {
+            if abs(bottom) >= abs(top) { edges.insert(.bottom); dy = bottom }
+            else                       { edges.insert(.top);    dy = top }
+        }
+
+        return edges.isEmpty ? nil : (edges, dx, dy)
+    }
+}

--- a/Sources/ToeCore/Layout/WorkspaceManager.swift
+++ b/Sources/ToeCore/Layout/WorkspaceManager.swift
@@ -385,6 +385,48 @@ public final class WorkspaceManager {
         return true
     }
 
+    /// `resizeactive`, and the settling of a mouse resize. A tiled window moves its splits; a
+    /// floating one grows or shrinks in place, which is what Hyprland's `resizeActiveWindow`
+    /// does for a window with no node — the delta goes onto its real size, top-left corner
+    /// staying put. Returns true if anything changed, so the caller can skip the render.
+    ///
+    /// The float branch is the keyboard's: a mouse resize of a float is already the user's own
+    /// business, and the coordinator never brings one here.
+    @discardableResult
+    public func resizeWindow(_ id: WindowID, dx: Double, dy: Double, edges: ResizeEdges = []) -> Bool {
+        guard let index = workspaceIndex(of: id), let ws = workspaces[index] else { return false }
+        if ws.layout.contains(id) {
+            return ws.layout.resizeActive(id, dx: dx, dy: dy, edges: edges)
+        }
+        return growFloat(id, on: ws, dx: dx, dy: dy)
+    }
+
+    /// `growactive`: the same, with the sign relative to the window rather than to the split.
+    /// For a float the two are one thing — it has no split, and the delta is already its size.
+    @discardableResult
+    public func growWindow(_ id: WindowID, dx: Double, dy: Double) -> Bool {
+        guard let index = workspaceIndex(of: id), let ws = workspaces[index] else { return false }
+        if ws.layout.contains(id) {
+            return ws.layout.growActive(id, dx: dx, dy: dy)
+        }
+        return growFloat(id, on: ws, dx: dx, dy: dy)
+    }
+
+    private func growFloat(_ id: WindowID, on ws: Workspace, dx: Double, dy: Double) -> Bool {
+        // A float that has not been rendered yet has no frame of its own; grow the one it is
+        // about to get, which is the frame the user is looking at.
+        guard ws.floating.contains(id), let m = monitor(id: ws.monitorID) else { return false }
+        var frame = floatingFrames[id] ?? floatingBox(for: id, on: m)
+        frame.w = max(Self.minimumFloatingSide, frame.w + dx)
+        frame.h = max(Self.minimumFloatingSide, frame.h + dy)
+        floatingFrames[id] = frame
+        return true
+    }
+
+    /// Small enough that a run of `resizeactive` cannot shrink a float out of reach of the
+    /// mouse, and no larger — an app with a bigger minimum will hold its own line.
+    private static let minimumFloatingSide = 100.0
+
     /// `movewindow <dir>` — reparent the focused window towards a direction.
     @discardableResult
     public func moveWindow(_ dir: Direction) -> Bool {

--- a/Sources/ToeCore/Menu/MenuModel.swift
+++ b/Sources/ToeCore/Menu/MenuModel.swift
@@ -489,7 +489,7 @@ public enum MenuModel {
         case .workspace(.index): return 3
         case .moveToWorkspace:  return 4
         case .workspace:        return 5
-        case .killActive, .toggleFloating, .toggleSplit, .swapSplit: return 6
+        case .killActive, .toggleFloating, .toggleSplit, .swapSplit, .resizeActive, .growActive: return 6
         case .theme, .removeTheme, .background, .nextBackground: return 7
         case .menu:             return 8
         case .reload, .quit:    return 9

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -273,6 +273,128 @@ h.test("togglesplit flips the parent split") { t in
     t.equalBox(l.idealBox(of: 2), box(0, 491, 1512, 491), "now stacked")
 }
 
+// MARK: - resizeactive
+
+h.test("resizeactive moves the split, whichever side of it the window is on") { t in
+    let l = omarchyLayout()
+    l.insert(1, anchor: nil)
+    l.insert(2, anchor: 1)
+    t.equal(l.resizeActive(2, dx: 100, dy: 0, edges: []), true, "from the right-hand window")
+    t.equalBox(l.idealBox(of: 1), box(0, 0, 856, 982), "the split went 100 right: w1 grew")
+    t.equalBox(l.idealBox(of: 2), box(856, 0, 656, 982), "and w2 shrank — Omarchy's =, not 'grow me'")
+
+    let m = omarchyLayout()
+    m.insert(1, anchor: nil)
+    m.insert(2, anchor: 1)
+    m.resizeActive(1, dx: 100, dy: 0, edges: [])
+    t.equalBox(m.idealBox(of: 1), box(0, 0, 856, 982), "the same press from the left-hand window")
+    t.equalBox(m.idealBox(of: 2), box(856, 0, 656, 982), "is the same result")
+
+    t.equal(m.resizeActive(1, dx: 0, dy: 50, edges: []), false,
+            "a side-by-side pair has no vertical split to move")
+    t.equalBox(m.idealBox(of: 1), box(0, 0, 856, 982), "and nothing moved")
+    t.equal(m.resizeActive(9, dx: 50, dy: 0, edges: []), false, "a window the tree does not hold")
+
+    let one = omarchyLayout()
+    one.insert(1, anchor: nil)
+    t.equal(one.resizeActive(1, dx: 50, dy: 50, edges: []), false, "the only window has no split at all")
+    t.equalBox(one.idealBox(of: 1), AREA, "and keeps the whole area")
+}
+
+h.test("growactive grows the window you are in, whichever side of the split it is on") { t in
+    let l = omarchyLayout()
+    l.insert(1, anchor: nil)
+    l.insert(2, anchor: 1)
+    t.equal(l.growActive(2, dx: 100, dy: 0), true, "from the right-hand window")
+    t.equalBox(l.idealBox(of: 2), box(656, 0, 856, 982), "w2 grew: the split went *left*")
+    t.equalBox(l.idealBox(of: 1), box(0, 0, 656, 982), "at w1's expense")
+    t.equal(l.growActive(1, dx: 100, dy: 0), true, "and from the left-hand one")
+    t.equalBox(l.idealBox(of: 1), box(0, 0, 756, 982), "w1 grew back: the split went right")
+    t.equal(l.growActive(1, dx: 0, dy: 100), false, "no vertical split, nothing to grow into")
+
+    // w1 | (w2 / w3): w3 is the bottom child, so taller means the split above it moving up.
+    let m = omarchyLayout()
+    m.insert(1, anchor: nil)
+    m.insert(2, anchor: 1)
+    m.insert(3, anchor: 2)
+    m.growActive(3, dx: 0, dy: 50)
+    t.equalBox(m.idealBox(of: 3), box(756, 441, 756, 541), "w3 is 50 taller")
+    t.equalBox(m.idealBox(of: 2), box(756, 0, 756, 441), "w2 gave it up")
+    m.growActive(2, dx: 0, dy: 50)
+    t.equalBox(m.idealBox(of: 2), box(756, 0, 756, 491), "and takes it back — the split goes down for w2")
+    m.growActive(3, dx: 100, dy: 0)
+    t.equalBox(m.idealBox(of: 1), box(0, 0, 656, 982),
+               "wider for w3 is the root split moving left, though w3 is not its direct child")
+    t.equalBox(m.idealBox(of: 3), box(656, 491, 856, 491), "and w3 has the width")
+}
+
+h.test("resizeactive finds the nearest split of each orientation") { t in
+    // w1 | (w2 / w3): the vertical axis lives one level down, the horizontal one at the root.
+    let l = omarchyLayout()
+    l.insert(1, anchor: nil)
+    l.insert(2, anchor: 1)
+    l.insert(3, anchor: 2)
+    t.equalBox(l.idealBox(of: 3), box(756, 491, 756, 491), "fixture: w3 under w2")
+
+    t.equal(l.resizeActive(3, dx: 0, dy: -50, edges: []), true, "up")
+    t.equalBox(l.idealBox(of: 2), box(756, 0, 756, 441), "the w2/w3 split went 50 up")
+    t.equalBox(l.idealBox(of: 3), box(756, 441, 756, 541), "so w3 grew")
+    t.equalBox(l.idealBox(of: 1), box(0, 0, 756, 982), "and w1 never noticed")
+
+    let m = omarchyLayout()
+    m.insert(1, anchor: nil)
+    m.insert(2, anchor: 1)
+    m.insert(3, anchor: 2)
+    t.equal(m.resizeActive(3, dx: 40, dy: 0, edges: []), true, "right")
+    t.equalBox(m.idealBox(of: 1), box(0, 0, 796, 982), "the root split went 40 right")
+    t.equalBox(m.idealBox(of: 2), box(796, 0, 716, 491), "w2 gave the width up")
+    t.equalBox(m.idealBox(of: 3), box(796, 491, 716, 491), "and so did w3, its height untouched")
+}
+
+h.test("pulling an edge keeps the far edge still — Hyprland's smart_resizing") { t in
+    // w1 | (w2 | w3) on a wide display, so the second split is side by side too. Pulling
+    // w2's left edge outwards has to move the root split *and* re-solve the inner one, or w3
+    // would stretch along with everything under that split.
+    let l = omarchyLayout(area: box(0, 0, 3000, 600))
+    l.insert(1, anchor: nil)
+    l.insert(2, anchor: 1)
+    l.insert(3, anchor: 2)
+    t.equalBox(l.idealBox(of: 2), box(1500, 0, 750, 600), "fixture: w2")
+    t.equalBox(l.idealBox(of: 3), box(2250, 0, 750, 600), "fixture: w3")
+
+    t.equal(l.resizeActive(2, dx: -100, dy: 0, edges: [.left]), true, "w2's left edge, 100 outwards")
+    t.equalBox(l.idealBox(of: 1), box(0, 0, 1400, 600), "w1 gave up the 100")
+    t.equalBox(l.idealBox(of: 2), box(1400, 0, 850, 600), "w2 took it")
+    t.equalBox(l.idealBox(of: 3), box(2250, 0, 750, 600), "and w3 is exactly where it was")
+}
+
+h.test("an edge on the display's edge pulls the other one, as Hyprland's does") { t in
+    let l = omarchyLayout()
+    l.insert(1, anchor: nil)
+    l.insert(2, anchor: 1)
+    // The left edge of the leftmost window cannot move; DISPLAYLEFT turns the pull into a
+    // RIGHT one and the split on its other side moves instead. That is what a Super+right-drag
+    // does at a screen edge upstream, and it is kept on purpose rather than special-cased.
+    t.equal(l.resizeActive(1, dx: 50, dy: 0, edges: [.left]), true, "w1's left edge, 50 inwards")
+    t.equalBox(l.idealBox(of: 1), box(0, 0, 806, 982), "the split on its right went 50 right")
+    t.equalBox(l.idealBox(of: 2), box(806, 0, 706, 982), "at w2's expense")
+
+    l.toggleSplit(2)
+    t.equal(l.resizeActive(2, dx: 50, dy: 0, edges: []), false,
+            "a window spanning the full width has no horizontal freedom, and that axis is dropped")
+}
+
+h.test("resizeactive clamps at Hyprland's 0.1 … 1.9") { t in
+    let l = omarchyLayout()
+    l.insert(1, anchor: nil)
+    l.insert(2, anchor: 1)
+    l.resizeActive(1, dx: 5000, dy: 0, edges: [])
+    t.equal(l.node(for: 1)?.parent?.splitRatio, 1.9, "as far right as it goes")
+    t.equalBox(l.idealBox(of: 2), box(1436.4, 0, 75.6, 982), "w2 keeps a sliver")
+    l.resizeActive(1, dx: -9000, dy: 0, edges: [])
+    t.equal(l.node(for: 1)?.parent?.splitRatio, 0.1, "and as far left")
+}
+
 // MARK: - Workspaces
 
 h.test("workspaces stash and restore exactly") { t in
@@ -862,6 +984,63 @@ h.test("only tiled windows are dragged, and only onto tiles") { t in
             "a pointer on no monitor at all is not a drop target")
 }
 
+// MARK: - Resizing by hand
+
+h.test("a resize gesture names the edge that moved, and how far it went") { t in
+    let tile = box(15, 15, 733, 952)
+    func d(_ frame: Box) -> (edges: ResizeEdges, dx: Double, dy: Double)? {
+        ResizeGesture.delta(from: tile, to: frame)
+    }
+    t.equal(d(box(15, 15, 833, 952))?.edges, [.right], "the right edge pulled out")
+    t.equal(d(box(15, 15, 833, 952))?.dx, 100, "by 100")
+    t.equal(d(box(65, 15, 683, 952))?.edges, [.left], "the left edge pulled in: x and w both change")
+    t.equal(d(box(65, 15, 683, 952))?.dx, 50, "and the edge went 50 right — not 'the width lost 50'")
+    t.equal(d(box(-35, 15, 783, 952))?.dx, -50, "pulled out, the same edge goes left")
+    t.equal(d(box(15, 15, 833, 1052))?.edges, [.right, .bottom], "a corner")
+    t.equal(d(box(15, 15, 833, 1052))?.dy, 100, "with its own amount")
+    t.equal(d(box(315, 215, 733, 952)) == nil, true, "a move is not a resize, however far it went")
+    t.equal(d(box(15, 15, 734, 952)) == nil, true, "an app rounding a point off is not one either")
+    t.equal(d(box(-35, 15, 784, 952))?.edges, [.left],
+            "the left edge dragged while the right one drifts a point: still the left edge")
+}
+
+h.test("letting go of an edge moves the split to where the window now ends") { t in
+    let wm = draggingFixture()
+    let before = wm.render().frames
+    t.equalBox(before[1], box(15, 15, 733, 952), "fixture: w1's frame, gaps applied")
+    t.equalBox(before[2], box(764, 15, 733, 468), "fixture: w2's")
+
+    // The user pulled w1's right edge 100 to the right and let go.
+    let held = box(15, 15, 833, 952)
+    guard let gesture = ResizeGesture.delta(from: before[1]!, to: held) else {
+        t.expect(false, "the gesture reads as a resize"); return
+    }
+    t.equal(wm.resizeWindow(1, dx: gesture.dx, dy: gesture.dy, edges: gesture.edges), true, "it moved")
+
+    let after = wm.render().frames
+    t.equalBox(after[1], held, "w1's tile is the frame the user let go of")
+    t.equalBox(after[2], box(864, 15, 633, 468), "w2's left edge followed by the same 100")
+    t.equalBox(after[3], box(864, 499, 312, 468), "so did w3's")
+    t.equal(after[4]?.maxX, before[4]?.maxX, "and nothing on the far side of the display moved")
+}
+
+h.test("resizeactive grows a floating window in place") { t in
+    let wm = draggingFixture()
+    wm.toggleFloating(4)
+    guard let before = wm.render().floating[4] else { t.expect(false, "w4 floats"); return }
+    t.equal(wm.resizeWindow(4, dx: 50, dy: 20), true, "a float takes the delta as size")
+    guard let after = wm.render().floating[4] else { t.expect(false, "w4 still floats"); return }
+    t.equal(after.w, before.w + 50, "wider by 50")
+    t.equal(after.h, before.h + 20, "taller by 20")
+    t.equal(after.x, before.x, "the corner stayed where it was")
+    t.equal(after.y, before.y, "in both axes")
+
+    wm.resizeWindow(4, dx: -5000, dy: -5000)
+    t.equal(wm.render().floating[4]?.w, 100, "and it cannot be shrunk out of reach")
+    t.equal(wm.growWindow(4, dx: 30, dy: 0), true, "growactive on a float")
+    t.equal(wm.render().floating[4]?.w, 130, "is the same thing — a float has no split to be relative to")
+}
+
 // MARK: - Dock swipes
 
 // The numbers `DockSwipeTap` reads off the event, by name.
@@ -1006,6 +1185,12 @@ h.test("the shipped default config parses cleanly") { t in
 
     t.equal(binding("super-t")?.command, .toggleFloating, "SUPER+T floats")
     t.equal(binding("super-t")?.keyCode, 0x11, "T key code")
+    t.equal(binding("super-equal")?.command, .growActive(dx: 100, dy: 0), "SUPER+= makes the window wider")
+    t.equal(binding("super-equal")?.keyCode, 0x18, "= key code")
+    t.equal(binding("super-minus")?.command, .growActive(dx: -100, dy: 0), "SUPER+- narrower")
+    t.equal(binding("super-shift-minus")?.command, .growActive(dx: 0, dy: -100), "SHIFT for the vertical axis")
+    t.equal(binding("super-shift-minus")?.modifiers, [.option, .shift], "SUPER+SHIFT")
+    t.equal(binding("super-shift-equal")?.command, .growActive(dx: 0, dy: 100), "Omarchy's four keys")
     t.equal(binding("super-shift-v"), nil, "SUPER+SHIFT+V is no longer bound")
 
     // Everything the menu bar item used to offer, now that it offers nothing.
@@ -1190,7 +1375,8 @@ h.test("the escape hatches are bound even when the config forgets them") { t in
 
     // The shipped config binds them itself, so nothing should be duplicated.
     let shipped = try Config.parse(Config.defaultTOML)
-    for command in [Command.quit, .reload, .menu(.background), .menu(.theme)] {
+    for command in [Command.quit, .reload, .menu(.background), .menu(.theme),
+                    .growActive(dx: 100, dy: 0), .growActive(dx: 0, dy: 100)] {
         t.equal(shipped.bindings.filter { $0.command == command }.count, 1,
                 "the shipped config binds \(command) exactly once")
     }
@@ -1214,6 +1400,25 @@ h.test("the escape hatches are bound even when the config forgets them") { t in
     t.equal(moved.bindings.filter { $0.command == .menu(.background) }.count, 1, "and not twice")
     let taken = try Config.parse("[binds]\n\"super-ctrl-space\" = \"killactive\"\n")
     t.equal(binding(taken, .menu(.background)), nil, "and a key you already use is left alone")
+
+    // The resize keys are on the list on the same terms. All four of them, because a config that
+    // predates them has none, and one without the other would be half a feature.
+    t.equal(binding(old, .growActive(dx: 100, dy: 0))?.source, "super-equal",
+            "a config written before resizing existed still gets Omarchy's key for it")
+    t.equal(binding(old, .growActive(dx: -100, dy: 0))?.source, "super-minus", "and its pair")
+    t.equal(binding(old, .growActive(dx: 0, dy: -100))?.source, "super-shift-minus", "and the vertical pair")
+    t.equal(binding(old, .growActive(dx: 0, dy: 100))?.source, "super-shift-equal", "all four")
+    // Any resizing verb at all is an answer, whatever its amount or its sign convention: a
+    // config that has Hyprland's resizeactive by 50 on its own keys has decided how it resizes
+    // and is not handed growactive 100 on four more.
+    let fifty = try Config.parse("[binds]\n\"super-l\" = \"resizeactive 50 0\"\n")
+    t.equal(fifty.bindings.filter { $0.command.resizes }.count, 1, "your own resize binding stands alone")
+    t.equal(binding(fifty, .resizeActive(dx: 50, dy: 0))?.source, "super-l", "on your key")
+    // And a resize key already used for something else stays that way; the other three land.
+    let equal = try Config.parse("[binds]\n\"super-equal\" = \"killactive\"\n")
+    t.equal(binding(equal, .killActive)?.source, "super-equal", "SUPER+= stays yours")
+    t.equal(binding(equal, .growActive(dx: 100, dy: 0)), nil, "and is not given the resize on top")
+    t.equal(binding(equal, .growActive(dx: -100, dy: 0))?.source, "super-minus", "while SUPER+- still lands")
     t.equal(binding(taken, .killActive)?.source, "super-ctrl-space", "still doing what you asked")
 }
 
@@ -2393,7 +2598,8 @@ h.test("every command has a label a reader could use") { t in
         .moveFocus(.left), .swapWindow(.up), .moveWindow(.down),
         .workspace(.index(3)), .workspace(.next), .workspace(.previous), .workspace(.former),
         .moveToWorkspace(5, follow: true), .moveToWorkspace(5, follow: false),
-        .killActive, .toggleFloating, .toggleSplit, .swapSplit,
+        .killActive, .toggleFloating, .toggleSplit, .swapSplit, .resizeActive(dx: 100, dy: 0),
+        .growActive(dx: 100, dy: 0),
         .exec("open -a Safari"), .reload, .quit,
         .menu(.root), .menu(.keybindings), .menu(.theme), .menu(.background),
         .theme("gruvbox"), .theme(""), .removeTheme("gruvbox"),
@@ -2417,6 +2623,16 @@ h.test("every command has a label a reader could use") { t in
     t.equal(CommandLabel.describe(.theme("")), "Use your own colours",
             "clearing the theme reads as what it does, not as an empty name")
     t.equal(CommandLabel.describe(.nextBackground), "Next background", "and the cycle")
+    t.equal(CommandLabel.describe(.resizeActive(dx: 100, dy: 0)), "Move the split 100 pt right",
+            "a resize names where the split goes — the window's fate depends on which side you are on")
+    t.equal(CommandLabel.describe(.resizeActive(dx: 0, dy: -100)), "Move the split 100 pt up", "and up")
+    t.equal(CommandLabel.describe(.resizeActive(dx: 100, dy: 50)),
+            "Move the splits 100 pt right and 50 pt down", "both axes, both named")
+    t.equal(CommandLabel.describe(.growActive(dx: 100, dy: 0)), "Make the window 100 pt wider",
+            "growactive names what happens to the window, which is the whole of its meaning")
+    t.equal(CommandLabel.describe(.growActive(dx: 0, dy: -100)), "Make the window 100 pt shorter", "and shorter")
+    t.equal(CommandLabel.describe(.growActive(dx: -100, dy: 50)),
+            "Make the window 100 pt narrower and 50 pt taller", "both axes")
 }
 
 h.test("the binding that opens the config is named rather than spelled out") { t in
@@ -2594,6 +2810,23 @@ h.test("a menu binding opens the level Omarchy's own key opens") { t in
             "slugified at the door, because the name is about to be joined onto a path")
     t.expect((try? CommandParser.parse("removetheme")) == nil,
              "and it needs an argument — there is no theme called nothing to delete")
+}
+
+h.test("resizeactive takes Hyprland's two numbers and nothing else") { t in
+    t.equal(try CommandParser.parse("resizeactive 100 0"), .resizeActive(dx: 100, dy: 0), "plain")
+    t.equal(try CommandParser.parse("resizeactive, -100 0"), .resizeActive(dx: -100, dy: 0),
+            "Hyprland's comma after the verb")
+    t.equal(try CommandParser.parse("resizeactive 0, 100"), .resizeActive(dx: 0, dy: 100),
+            "or between the numbers")
+    t.expect((try? CommandParser.parse("resizeactive")) == nil, "it needs an argument")
+    t.expect((try? CommandParser.parse("resizeactive 100")) == nil, "two of them")
+    t.expect((try? CommandParser.parse("resizeactive exact 100 100")) == nil,
+             "and not Hyprland's exact form: a tile's size is the tree's to decide")
+    t.expect((try? CommandParser.parse("resizeactive 10% 0")) == nil, "nor a percentage")
+    t.expect((try? CommandParser.parse("resizeactive 1e309 0")) == nil, "nor a number that overflowed")
+    t.equal(try CommandParser.parse("growactive 100 0"), .growActive(dx: 100, dy: 0),
+            "growactive takes the same two numbers, meaning the window rather than the split")
+    t.expect((try? CommandParser.parse("growactive 100")) == nil, "and is as strict about them")
 }
 
 // MARK: - Themes

--- a/Sources/toe/AX/WindowTracker.swift
+++ b/Sources/toe/AX/WindowTracker.swift
@@ -37,8 +37,13 @@ protocol WindowTrackerDelegate: AnyObject {
     func windowDisappeared(_ id: CGWindowID)
     func windowFocused(_ id: CGWindowID)
     /// The window moved or resized without toe asking — an app restoring its own remembered
-    /// geometry, or the user dragging it.
-    func windowFrameChangedExternally(_ id: CGWindowID)
+    /// geometry, or the user dragging it. `resized` is which of the two Accessibility
+    /// notifications this was: AppKit posts Moved when the origin changes and Resized when the
+    /// size does, per frame write, so a title-bar drag is Moved only, a right- or bottom-edge
+    /// drag Resized only, and a left- or top-edge drag both. That is the one fact telling a
+    /// window being resized by hand from one being moved by hand, and it is not recoverable
+    /// from the frame — see `DragMonitor.Kind`.
+    func windowFrameChangedExternally(_ id: CGWindowID, resized: Bool)
     func screensChanged()
     /// Something moved in the window stack that toe does not manage: another application came
     /// forward, or one opened a window toe will never tile. Neither changes the layout, but
@@ -244,7 +249,7 @@ final class WindowTracker {
 
         case kAXWindowMovedNotification, kAXWindowResizedNotification:
             guard let id = windows.first(where: { CFEqual($0.value.element, element) })?.key else { return }
-            delegate?.windowFrameChangedExternally(id)
+            delegate?.windowFrameChangedExternally(id, resized: notification == kAXWindowResizedNotification)
 
         case kAXUIElementDestroyedNotification, kAXWindowMiniaturizedNotification:
             guard let id = windows.first(where: { CFEqual($0.value.element, element) })?.key else { return }

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -206,10 +206,17 @@ final class Coordinator: WindowTrackerDelegate {
         // Dragging a tiled window over another one trades their places, live, the way
         // Hyprland's `IHyprLayout::onMouseMove` does.
         drag.onMove = { [weak self] id, point in
-            guard let self, self.workspaces.swapWithWindow(at: point, dragging: id) else { return }
+            // Not while an edge is in hand: the pointer is on the seam between two tiles, which
+            // is to say at the neighbour's edge, and a swap there would trade the two windows
+            // the user is trying to resize. For a left- or top-edge drag both Accessibility
+            // notifications are queued ahead of the first `mouseDragged` the monitor sees, so
+            // the promotion lands first; if it ever did not, the cost is one swap — today's
+            // behaviour, not a new one.
+            guard let self, self.drag.kind == .move,
+                  self.workspaces.swapWithWindow(at: point, dragging: id) else { return }
             self.apply(refocus: false)
         }
-        drag.onEnd = { [weak self] id in self?.endDrag(id) }
+        drag.onEnd = { [weak self] id, kind, origin in self?.endDrag(id, kind: kind, origin: origin) }
         hideBlocker.onRestored = { [weak self] pid in self?.relayoutAfterUnhide(pid) }
         // A sideways dock swipe is `workspace e+1` / `e-1` from the trackpad. Only while
         // `gestures.swallow_dock_swipes` is on, and no `if` here says so: `applyDockSwipeSetting`
@@ -1201,7 +1208,7 @@ final class Coordinator: WindowTrackerDelegate {
     /// after the window is created, clobbering the frame toe just wrote. Re-asserting on the
     /// move/resize notification is what actually makes those apps tile — and it doubles as
     /// snap-back when a window is dragged out of its tile.
-    func windowFrameChangedExternally(_ id: WindowID) {
+    func windowFrameChangedExternally(_ id: WindowID, resized: Bool) {
         guard let window = tracker.window(id) else { return }
         guard !window.isStashed else {
             // Coming out of fullscreen is a move and a resize, and it arrives after the Space
@@ -1212,7 +1219,11 @@ final class Coordinator: WindowTrackerDelegate {
             return
         }
         // A move the user is making by hand hides the border until they let go; see DragMonitor.
-        if id == workspaces.focusedWindow { drag.noteExternalFrameChange(id) }
+        // `desired[id]` is the tile they took hold of, and a float — which has none — passes nil,
+        // so a resize of one is never measured against anything.
+        if id == workspaces.focusedWindow {
+            drag.noteExternalFrameChange(id, resized: resized, tile: desired[id])
+        }
 
         if workspaces.isFloating(id) {
             workspaces.floatingFrames[id] = window.element.frame
@@ -1380,6 +1391,17 @@ final class Coordinator: WindowTrackerDelegate {
             return
         }
 
+        // An edge in the user's hand gets no border at all, and the decision is made here,
+        // before the round trip below, because `windowFrameChangedExternally` comes through on
+        // every notification of a live resize. The tile is the one thing the user is changing,
+        // so a ring around it would mark exactly the wrong rectangle, and the window trails its
+        // notifications by too much to follow — the same reasoning that leaves a floating drag
+        // without one. The `apply` in `endDrag` brings it back.
+        if focused == draggedWindow, drag.kind == .resize {
+            border.hide()
+            return
+        }
+
         // Read once, after the cheap conditions rather than among them: it costs a
         // cross-process Accessibility round trip, and the guard above already turns the border
         // off in every case where there was nothing to draw. Both `show` paths below test
@@ -1486,7 +1508,19 @@ final class Coordinator: WindowTrackerDelegate {
     /// clearing `desired` is what makes `apply` write it into whichever tile it now owns —
     /// its own, if the drag never crossed another one. `apply` ends in `updateBorder`, which
     /// brings the focus border back now that the drag is over.
-    private func endDrag(_ id: WindowID) {
+    ///
+    /// An edge that was let go of moves the split first, so that the tile `apply` then writes
+    /// is the frame the window already has, give or take the ratio clamp and the rounding in
+    /// `frames(gaps:)` — and every neighbour is written once, into the space that is left. The
+    /// frame is read here, after the fact, whichever way the drag ended: the mouse-up monitor,
+    /// or a trailing notification that found the button already up. Nothing to move — a
+    /// window with no neighbour on that axis, or a drag that turned out to be a move after all
+    /// — falls through to the snap-back this always was.
+    private func endDrag(_ id: WindowID, kind: DragMonitor.Kind, origin: Box?) {
+        if kind == .resize, let origin, let have = tracker.window(id)?.element.frame,
+           let gesture = ResizeGesture.delta(from: origin, to: have) {
+            workspaces.resizeWindow(id, dx: gesture.dx, dy: gesture.dy, edges: gesture.edges)
+        }
         desired.removeValue(forKey: id)
         corrections.removeValue(forKey: id)
         apply(refocus: false)
@@ -1669,6 +1703,26 @@ final class Coordinator: WindowTrackerDelegate {
             guard let id = workspaces.focusedWindow,
                   let index = workspaces.workspaceIndex(of: id) else { return }
             workspaces.workspaces[index]?.layout.swapSplit(id)
+            apply(refocus: false)
+
+        case .resizeActive(let dx, let dy), .growActive(let dx, let dy):
+            // A float grows in place and `apply` writes the new frame the way it writes any
+            // floating one — on a real difference, outside `desired`.
+            guard let id = workspaces.focusedWindow else { return }
+            let moved: Bool
+            if case .growActive = command {
+                moved = workspaces.growWindow(id, dx: dx, dy: dy)
+            } else {
+                moved = workspaces.resizeWindow(id, dx: dx, dy: dy)
+            }
+            guard moved else {
+                // The one command whose doing nothing is easy to mistake for not working: the
+                // only window on a workspace has no split to move, and neither has a
+                // side-by-side pair asked for the vertical axis. Say so where `log stream`
+                // can see it.
+                Log.info("\(CommandLabel.describe(command)): nothing to move for window \(id) — no split on that axis")
+                return
+            }
             apply(refocus: false)
 
         case .exec(let commandLine):

--- a/Sources/toe/Input/DragMonitor.swift
+++ b/Sources/toe/Input/DragMonitor.swift
@@ -12,14 +12,36 @@ import ToeCore
 /// over, the way Hyprland's `IHyprLayout::onMouseMove` does.
 final class DragMonitor {
 
+    /// What the user has hold of: the window, or one of its edges.
+    ///
+    /// A drag starts as a move and is *promoted* to a resize by the first Resized notification
+    /// that arrives while it is live — never the other way — because the alternative, comparing
+    /// sizes when the drag begins, does not work: the first notification of a slow edge-drag is
+    /// a pixel in, under any tolerance, and `begin` runs once, so a resize taken for a move
+    /// would stay one for the whole drag while `onMove` traded the window with every tile the
+    /// pointer touched. The notification is the fact; the frame is only a consequence of it.
+    enum Kind {
+        case move
+        case resize
+    }
+
     /// Fires for each pointer move while a drag is live, with the window being dragged.
     var onMove: ((WindowID, Point) -> Void)?
-    /// Fires when the user lets go, so whatever was hidden can come back.
-    var onEnd: ((WindowID) -> Void)?
+    /// Fires when the user lets go, so whatever was hidden can come back — with what the drag
+    /// knew, because `end` has cleared it by the time the closure runs.
+    var onEnd: ((WindowID, Kind, Box?) -> Void)?
 
     private(set) var isDragging = false
     /// The window in the user's hand, for as long as they have hold of it.
     private(set) var window: WindowID?
+    private(set) var kind: Kind = .move
+    /// The tile the window was in when the user took hold of it. A resize is measured against
+    /// this on release rather than against the tile the coordinator currently wants, because
+    /// that one moves under a live drag — a window opening next to the dragged one, or a
+    /// neighbour closing, re-lays the tree out and the dragged window's tile with it. What
+    /// the user's hand did is relative to what they saw when they reached for the edge;
+    /// Hyprland's `m_vBeginDragSizeXY` is the same idea. Nil for a float, which has no tile.
+    private(set) var origin: Box?
     private var monitors: [Any] = []
 
     /// Records a window moving or resizing on its own, and reports whether the user is dragging
@@ -27,16 +49,28 @@ final class DragMonitor {
     ///
     /// Polling the button here rather than tracking mouse-downs keeps the state honest — the
     /// answer is read from the system every time, so a missed release cannot strand the drag.
+    ///
+    /// - Parameters:
+    ///   - resized: whether this was the Resized notification rather than the Moved one; see
+    ///     `Kind` for why one of them is enough to promote the drag for good.
+    ///   - tile: the frame the coordinator had written for the window. Read once, at `begin`.
     @discardableResult
-    func noteExternalFrameChange(_ id: WindowID) -> Bool {
-        if NSEvent.pressedMouseButtons != 0 { begin(id) } else { end() }
+    func noteExternalFrameChange(_ id: WindowID, resized: Bool, tile: Box?) -> Bool {
+        if NSEvent.pressedMouseButtons != 0 {
+            begin(id, tile: tile)
+            if resized, id == window { kind = .resize }
+        } else {
+            end()
+        }
         return isDragging
     }
 
-    private func begin(_ id: WindowID) {
+    private func begin(_ id: WindowID, tile: Box?) {
         guard !isDragging else { return }
         isDragging = true
         window = id
+        kind = .move
+        origin = tile
         // toe never sees the drag itself: the events all belong to the window's own application.
         // Global monitors are read-only and consume nothing, which keeps the pointer readable
         // without widening the one tap toe does run — `DockSwipeTap`, whose mask admits gesture
@@ -56,10 +90,13 @@ final class DragMonitor {
 
     private func end() {
         guard isDragging, let dragged = window else { return }
+        let (how, from) = (kind, origin)
         isDragging = false
         window = nil
+        kind = .move
+        origin = nil
         for monitor in monitors { NSEvent.removeMonitor(monitor) }
         monitors.removeAll()
-        onEnd?(dragged)
+        onEnd?(dragged, how, from)
     }
 }

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -238,6 +238,17 @@ font_size  = 18
 "super-j"       = "togglesplit"
 "super-t"       = "togglefloating"
 
+# ── Resize — SUPER + - / =, SHIFT for the vertical axis ───────────────────────
+# growactive: the number is how much the focused window grows, whichever side of its split it
+# is on — = is always bigger, - always smaller. Omarchy binds Hyprland's resizeactive here
+# instead, where the number is how far the *split* moves, so = grows a left-hand window and
+# shrinks a right-hand one; that verb works too, for a config copied across. Dragging a tiled
+# window's edge with the mouse does the same thing without a key.
+"super-minus"       = "growactive -100 0"
+"super-equal"       = "growactive 100 0"
+"super-shift-minus" = "growactive 0 -100"
+"super-shift-equal" = "growactive 0 100"
+
 # ── toe itself ────────────────────────────────────────────────────────────────
 # The menu bar item is only the workspace strip — waybar's has nothing behind it either — so
 # these are the way in to everything toe can do to itself.


### PR DESCRIPTION
## What

- `SUPER`+`-` / `=` make the focused window 100 pt narrower / wider; `SUPER`+`SHIFT`+`-` / `=` make it shorter / taller. Bound by default and filled in as fallbacks, so a config written before this still gets the keys (all four, and none if the config already resizes on keys of its own).
- Dragging a tiled window's own edge with the mouse moves the split on release instead of snapping the window back. Neighbours re-tile once.
- Two verbs: `growactive <dx> <dy>` (toe's own — the number is how much the focused window grows, whichever side of its split it is on) and Hyprland's `resizeactive <dx> <dy>` (the number is how far the *split* moves), accepted for configs copied from Omarchy.
- The README's "no resize bindings" line is gone.

## How

- `DwindleLayout.resizeActive` ports the `smart_resizing` branch of Hyprland's `CHyprDwindleLayout::resizeActiveWindow` (v0.45.0, lines 631–688), including the outer/inner split pair that keeps the far edge still while an edge is pulled. `growActive` is that with the sign settled by which child of the nearest split the window sits under.
- `ResizeGesture.delta` (ToeCore, testable) turns the tile a drag started from and the frame it let go with into an edge set and a displacement. The sign is the edge's movement, not the width change — the pointer delta Hyprland's function expects.
- `WindowTracker` now says whether the notification was Moved or Resized; `DragMonitor` starts every drag as a move, promotes it to a resize on the first Resized notification, never demotes, and remembers the tile the drag began from — `desired` is not stable across a drag, since a window opening or closing next to the dragged one re-lays the tree out.
- `Coordinator`: the swap-on-drag path stands aside for a resize drag, the border hides for its duration, and `endDrag` moves the split before the usual `apply`. A resize that found nothing to move is logged.

## Tests

`make test`: 1239 assertions, up from ~1180. New coverage: the split arithmetic from both sides, the inner/outer case on a nested split, the display-edge case (kept as Hyprland does it), the clamp, `growactive` through a nested split, the gesture helper, an end-to-end drag through `WorkspaceManager`, floats, the parser, the labels, the default config and the fallback rules.

Measured live on a 2-window and a 3-window workspace with the window server's bounds before and after each key press: the focused window grows and shrinks from either side, and its neighbour's edge follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAmqYC3aTfnEJfTMLHzv3E
