### PR TITLE
Grow a detached window from its centre, and keep it inside the outer gap

### DIFF
--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -252,7 +252,9 @@ font_size  = 18
 # is on — = is always bigger, - always smaller. Omarchy binds Hyprland's resizeactive here
 # instead, where the number is how far the *split* moves, so = grows a left-hand window and
 # shrinks a right-hand one; that verb works too, for a config copied across. Dragging a tiled
-# window's edge with the mouse does the same thing without a key.
+# window's edge with the mouse does the same thing without a key. A detached window grows
+# about its centre, so it gets bigger where it is rather than sliding off to one side, and
+# stops at gaps_out like a tile would.
 "super-minus"       = "growactive -100 0"
 "super-equal"       = "growactive 100 0"
 "super-shift-minus" = "growactive 0 -100"

--- a/Sources/ToeCore/Layout/WorkspaceManager.swift
+++ b/Sources/ToeCore/Layout/WorkspaceManager.swift
@@ -386,9 +386,9 @@ public final class WorkspaceManager {
     }
 
     /// `resizeactive`, and the settling of a mouse resize. A tiled window moves its splits; a
-    /// floating one grows or shrinks in place, which is what Hyprland's `resizeActiveWindow`
-    /// does for a window with no node — the delta goes onto its real size, top-left corner
-    /// staying put. Returns true if anything changed, so the caller can skip the render.
+    /// floating one grows or shrinks in place about its centre — see `growFloat` for why not
+    /// the top-left corner Hyprland's `resizeActiveWindow` keeps. Returns true if anything
+    /// changed, so the caller can skip the render.
     ///
     /// The float branch is the keyboard's: a mouse resize of a float is already the user's own
     /// business, and the coordinator never brings one here.
@@ -412,14 +412,68 @@ public final class WorkspaceManager {
         return growFloat(id, on: ws, dx: dx, dy: dy)
     }
 
+    /// The centre stays put, not the top-left corner. Hyprland keeps the corner, and for a
+    /// tile the question does not arise — its split moves and the far edges are pinned by the
+    /// display. A float has no such anchor, and growing it from the corner reads as the
+    /// window sliding down and to the right rather than getting bigger: the same key that
+    /// widens a tile symmetrically about its content lurched a float off to one side. Sharing
+    /// the delta between the two edges is what makes the four keys feel like one command.
+    ///
+    /// Growing about the centre can push an edge past the display where the corner never
+    /// would have, which is `settleFloat`'s job to undo.
     private func growFloat(_ id: WindowID, on ws: Workspace, dx: Double, dy: Double) -> Bool {
         // A float that has not been rendered yet has no frame of its own; grow the one it is
         // about to get, which is the frame the user is looking at.
         guard ws.floating.contains(id), let m = monitor(id: ws.monitorID) else { return false }
-        var frame = floatingFrames[id] ?? floatingBox(for: id, on: m)
-        frame.w = max(Self.minimumFloatingSide, frame.w + dx)
-        frame.h = max(Self.minimumFloatingSide, frame.h + dy)
-        floatingFrames[id] = frame
+        let before = floatingFrames[id] ?? floatingBox(for: id, on: m)
+        var frame = before
+        frame.w = max(Self.minimumFloatingSide, before.w + dx)
+        frame.h = max(Self.minimumFloatingSide, before.h + dy)
+        // Half of what was actually applied, so hitting the minimum does not slide the window.
+        frame.x = before.x - (frame.w - before.w) / 2
+        frame.y = before.y - (frame.h - before.h) / 2
+        floatingFrames[id] = frame.rounded()
+        settleFloat(id)
+        return true
+    }
+
+    /// Brings a floating window back inside the outer gap of the display it is on: slid in
+    /// when it fits, cut to the gap's edges when it does not. Called when the user lets go of
+    /// a float, and after the keyboard has grown one. Returns true if the frame changed.
+    ///
+    /// The line is `gaps_out`, not the display edge. A float left flush with the edge sits
+    /// where every tile around it keeps the margin clear, and reads as the one window that
+    /// missed it — and a float dragged half off the display is never where the user wanted it
+    /// to stay, only where the hand stopped. Hyprland leaves a float wherever it is dropped;
+    /// toe has the margin already and the snap costs nothing on release, when the window is
+    /// being written anyway.
+    ///
+    /// The display is its workspace's, which is the one `floatingBox` holds it to: a float
+    /// dragged onto the other display keeps its workspace, and the next render already brings
+    /// it back — by recentring it, since that rule was written for a display that has gone.
+    /// Settling first means it comes back to the nearest edge instead, which is where the
+    /// hand was heading.
+    @discardableResult
+    public func settleFloat(_ id: WindowID) -> Bool {
+        guard let index = workspaceIndex(of: id), let ws = workspaces[index],
+              ws.floating.contains(id), let frame = floatingFrames[id],
+              let m = monitor(id: ws.monitorID)
+        else { return false }
+        let usable = m.usable
+        var margin = usable.inset(top: gaps.outer, left: gaps.outer,
+                                  bottom: gaps.outer, right: gaps.outer)
+        // A gap wider than half the display leaves nothing to put a window in; the display
+        // itself is the next best thing.
+        if margin.w <= 0 || margin.h <= 0 { margin = usable }
+
+        var settled = frame
+        settled.w = min(frame.w, margin.w)
+        settled.h = min(frame.h, margin.h)
+        settled.x = min(max(frame.x, margin.minX), margin.maxX - settled.w)
+        settled.y = min(max(frame.y, margin.minY), margin.maxY - settled.h)
+        settled = settled.rounded()
+        guard settled != frame else { return false }
+        floatingFrames[id] = settled
         return true
     }
 
@@ -545,8 +599,8 @@ public final class WorkspaceManager {
     /// the window is dragged.
     ///
     /// A frame is taken as-is only while a usable amount of the window is still on the
-    /// monitor, so dragging one half off an edge is never undone on the next render. Anything
-    /// less is pulled back. Hyprland never has to think about this; toe does, because hiding a
+    /// monitor — a render never moves a float on its own; `settleFloat`, on release, is where
+    /// one dragged off the edge is brought back. Anything less is pulled back here. Hyprland never has to think about this; toe does, because hiding a
     /// workspace parks its windows with a single pixel inside the monitor's corner — a frame
     /// captured from a parked window overlaps by 1×1pt, and handing that back would make the
     /// window vanish.

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -1024,21 +1024,97 @@ h.test("letting go of an edge moves the split to where the window now ends") { t
     t.equal(after[4]?.maxX, before[4]?.maxX, "and nothing on the far side of the display moved")
 }
 
-h.test("resizeactive grows a floating window in place") { t in
+h.test("resizeactive grows a floating window about its centre") { t in
     let wm = draggingFixture()
     wm.toggleFloating(4)
-    guard let before = wm.render().floating[4] else { t.expect(false, "w4 floats"); return }
+    wm.floatingFrames[4] = box(400, 300, 600, 400)
     t.equal(wm.resizeWindow(4, dx: 50, dy: 20), true, "a float takes the delta as size")
-    guard let after = wm.render().floating[4] else { t.expect(false, "w4 still floats"); return }
-    t.equal(after.w, before.w + 50, "wider by 50")
-    t.equal(after.h, before.h + 20, "taller by 20")
-    t.equal(after.x, before.x, "the corner stayed where it was")
-    t.equal(after.y, before.y, "in both axes")
+    t.equalBox(wm.render().floating[4], box(375, 290, 650, 420),
+               "split between both edges — the centre is where it was")
 
-    wm.resizeWindow(4, dx: -5000, dy: -5000)
-    t.equal(wm.render().floating[4]?.w, 100, "and it cannot be shrunk out of reach")
+    wm.floatingFrames[4] = box(400, 300, 600, 400)
     t.equal(wm.growWindow(4, dx: 30, dy: 0), true, "growactive on a float")
-    t.equal(wm.render().floating[4]?.w, 130, "is the same thing — a float has no split to be relative to")
+    t.equalBox(wm.render().floating[4], box(385, 300, 630, 400),
+               "is the same thing — a float has no split to be relative to")
+
+    wm.floatingFrames[4] = box(400, 300, 600, 400)
+    wm.growWindow(4, dx: -5000, dy: -5000)
+    t.equalBox(wm.render().floating[4], box(650, 450, 100, 100),
+               "it cannot be shrunk out of reach, and the floor is centred like any other size")
+
+    wm.floatingFrames[4] = box(400, 300, 601, 401)
+    wm.growWindow(4, dx: 0, dy: 0)
+    t.equalBox(wm.render().floating[4], box(400, 300, 601, 401), "nothing to share out, nothing moves")
+}
+
+h.test("a float growing about its centre is kept on the display, inside gaps_out") { t in
+    let wm = draggingFixture()   // Gaps() — gaps_out is 15
+    wm.toggleFloating(4)
+    wm.floatingFrames[4] = box(0, 0, 600, 400)   // flush with the top-left corner
+    wm.growWindow(4, dx: 100, dy: 100)
+    t.equalBox(wm.render().floating[4], box(15, 15, 700, 500),
+               "it grew, it did not slide off — and it landed on the gap, not the edge")
+
+    wm.floatingFrames[4] = box(912, 582, 600, 400)   // flush with the bottom-right corner
+    wm.growWindow(4, dx: 100, dy: 100)
+    t.equalBox(wm.render().floating[4], box(797, 467, 700, 500), "and the same at the far corner")
+
+    wm.floatingFrames[4] = box(100, 100, 1400, 800)
+    wm.growWindow(4, dx: 400, dy: 0)
+    t.equalBox(wm.render().floating[4], box(15, 100, 1482, 800),
+               "asked to outgrow the display, it fills the display inside gaps_out instead")
+    wm.growWindow(4, dx: 100, dy: 0)
+    t.equalBox(wm.render().floating[4], box(15, 100, 1482, 800), "and stops there")
+    wm.growWindow(4, dx: -100, dy: 0)
+    t.equalBox(wm.render().floating[4], box(65, 100, 1382, 800), "shrinking back is still centred")
+
+    wm.gaps = Gaps(inner: 8, outer: 40)
+    wm.floatingFrames[4] = box(100, 100, 1400, 800)
+    wm.growWindow(4, dx: 400, dy: 0)
+    t.equalBox(wm.render().floating[4], box(40, 100, 1432, 800), "the margin is the configured gaps_out")
+}
+
+h.test("a float let go of past the margin snaps back inside it") { t in
+    let wm = draggingFixture()   // Gaps() — gaps_out is 15
+    wm.toggleFloating(4)
+    wm.floatingFrames[4] = box(300, 200, 600, 400)
+    t.equal(wm.settleFloat(4), false, "well inside: nothing to do, and nothing to write")
+    t.equalBox(wm.render().floating[4], box(300, 200, 600, 400), "left exactly where it was")
+
+    wm.floatingFrames[4] = box(-100, -50, 600, 400)   // dropped past the top-left corner
+    t.equal(wm.settleFloat(4), true, "past the corner, it moves")
+    t.equalBox(wm.render().floating[4], box(15, 15, 600, 400), "onto the gap, its size untouched")
+
+    wm.floatingFrames[4] = box(1000, 700, 600, 400)   // and past the bottom-right one
+    wm.settleFloat(4)
+    t.equalBox(wm.render().floating[4], box(897, 567, 600, 400), "the same at the far corner")
+
+    wm.floatingFrames[4] = box(5, 300, 600, 400)   // dropped inside the gap band
+    wm.settleFloat(4)
+    t.equalBox(wm.render().floating[4], box(15, 300, 600, 400), "the band is out of bounds too")
+
+    wm.floatingFrames[4] = box(-100, 100, 1600, 400)   // wider than the display
+    wm.settleFloat(4)
+    t.equalBox(wm.render().floating[4], box(15, 100, 1482, 400), "too big to fit is cut to the margin")
+
+    t.equal(wm.settleFloat(1), false, "a tile has no float to settle")
+}
+
+h.test("a float dropped on the other display comes back to its workspace's display") { t in
+    let left = box(0, 0, 1512, 982)
+    let right = box(1512, 0, 1920, 1080)
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: left, usable: left),
+                    Monitor(id: 2, frame: right, usable: right)])
+    wm.switchTo(workspace: wm.activeWorkspace[1]!)
+    wm.addWindow(1); wm.addWindow(2)
+    wm.toggleFloating(2)
+
+    wm.floatingFrames[2] = box(3000, 800, 600, 400)   // dragged onto the right display
+    wm.settleFloat(2)
+    t.equalBox(wm.render().floating[2], box(897, 567, 600, 400),
+               "back on its own display, at the nearest edge — where the render would have recentred it")
+    t.equal(wm.workspaceIndex(of: 2), wm.activeWorkspace[1], "its workspace is unchanged")
 }
 
 // MARK: - Dock swipes

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -1516,9 +1516,18 @@ final class Coordinator: WindowTrackerDelegate {
     /// or a trailing notification that found the button already up. Nothing to move — a
     /// window with no neighbour on that axis, or a drag that turned out to be a move after all
     /// — falls through to the snap-back this always was.
+    ///
+    /// A float has no tile to snap back to, but it has a margin: `settleFloat` brings one that
+    /// was dropped past `gaps_out` back inside it, and `apply` writes the result the way it
+    /// writes any floating frame that differs from what the window has. The frame is read
+    /// afresh rather than trusted to `floatingFrames`, which holds whatever the last Moved
+    /// notification said — and the last one of a drag can arrive after the mouse-up.
     private func endDrag(_ id: WindowID, kind: DragMonitor.Kind, origin: Box?) {
-        if kind == .resize, let origin, let have = tracker.window(id)?.element.frame,
-           let gesture = ResizeGesture.delta(from: origin, to: have) {
+        if workspaces.isFloating(id) {
+            if let have = tracker.window(id)?.element.frame { workspaces.floatingFrames[id] = have }
+            workspaces.settleFloat(id)
+        } else if kind == .resize, let origin, let have = tracker.window(id)?.element.frame,
+                  let gesture = ResizeGesture.delta(from: origin, to: have) {
             workspaces.resizeWindow(id, dx: gesture.dx, dy: gesture.dy, edges: gesture.edges)
         }
         desired.removeValue(forKey: id)

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -243,7 +243,9 @@ font_size  = 18
 # is on — = is always bigger, - always smaller. Omarchy binds Hyprland's resizeactive here
 # instead, where the number is how far the *split* moves, so = grows a left-hand window and
 # shrinks a right-hand one; that verb works too, for a config copied across. Dragging a tiled
-# window's edge with the mouse does the same thing without a key.
+# window's edge with the mouse does the same thing without a key. A detached window grows
+# about its centre, so it gets bigger where it is rather than sliding off to one side, and
+# stops at gaps_out like a tile would.
 "super-minus"       = "growactive -100 0"
 "super-equal"       = "growactive 100 0"
 "super-shift-minus" = "growactive 0 -100"


### PR DESCRIPTION
`growactive` on a floating window put the whole delta on the right and bottom edges, the way Hyprland's `resizeActiveWindow` does for a window with no node. On a tile the question never arises — its split moves and the far edges are pinned by the display — but a float has no such anchor, so the same key that widens a tile symmetrically about its content made a float lurch down and to the right.

**Centred growth.** The delta is now shared between both edges, computed off the size actually applied so that hitting the 100 pt floor does not slide the window. Both `growactive` and `resizeactive` reach a float through `growFloat`, so both keys behave the same.

**The outer gap is the boundary.** Centring can push an edge past the display where the corner never would have, so `settleFloat` confines a float to its display's usable area inset by `gaps_out`: slid in while it still fits, cut to the margin when it does not. The line is the gap rather than the display edge because a float left flush with the edge is the one window missing the margin every tile around it keeps clear. A gap wider than half the display would leave nowhere to put a window, so that case falls back to the display itself.

**Snap on release.** `endDrag` settles a float as well, so one dropped half off an edge comes back inside the margin when the user lets go. It reads the window's frame afresh rather than trusting `floatingFrames`, since the last Moved notification of a drag can arrive after the mouse-up. A float that wandered onto the other display already came back on the next render, by recentring; settling first means it lands at the nearest edge instead, which is where the hand was heading.

The shipped config comment above the four resize bindings says so, and `toe.example.toml` is regenerated.

## Testing

`make test` — 1253 assertions, up 12. The float-growth test was rewritten and two added, covering the centred delta, the minimum-size floor, a zero delta, both display corners, the gap band, a window asked to outgrow the display, holding at the cap, shrinking back off it, a non-default `gaps_out`, a tile passed to `settleFloat` by mistake, and a float dropped on the other display.

Tried by hand: Super+T a window, then Super+= / Super+- and Super+Shift+= / Super+Shift+-, and dragging a float off each edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X483aXCBgNCMP13tKvJqNj