### PR TITLE
Bring a float macOS has snapped to an edge back inside the outer gap

### DIFF
--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -107,6 +107,24 @@ final class Coordinator: WindowTrackerDelegate {
     private var isSettlingSession = false
     /// Pending debounced write. See `scheduleSessionSave`.
     private var sessionSave: DispatchWorkItem?
+    /// Pending settles, one per floating window. See `scheduleFloatSettle`.
+    private var floatSettle: [WindowID: DispatchWorkItem] = [:]
+    /// How many times in a row a float has been brought back inside the margin without it
+    /// staying there. `corrections` is the same idea for tiles, and is deliberately not reused:
+    /// that one re-asserts a frame toe chose, and pointing it at a float would fight the user's
+    /// drags. This only ever moves a window that is out of bounds, and only counts so that an
+    /// app which insists on its own position is left to it rather than ping-ponged with.
+    private var floatSettleAttempts: [WindowID: Int] = [:]
+    /// How long a float's frame has to hold still before the frame it landed on is taken as
+    /// final. Not the length of macOS's edge-snap animation but a quiet period after it: the
+    /// deadline is pushed back by every notification that arrives.
+    ///
+    /// Measured, not reasoned about. 0.1 is too tight — macOS's edge-snap does not deliver a
+    /// notification every animation frame, and the gaps in the middle of one are long enough
+    /// to be taken for its end, at which point toe writes the margin under a window that is
+    /// still moving and macOS puts it back flush. The window twitches and the correction is
+    /// lost, since the attempt cap counts a write that landed nowhere. 0.2 clears those gaps.
+    private static let floatSettleLatency: TimeInterval = 0.2
     /// The window the user has hold of. Its frame is theirs until they let go: toe neither
     /// re-asserts its tile nor writes it a new one, the same courtesy `apply` already extends
     /// to a floating window.
@@ -1188,6 +1206,8 @@ final class Coordinator: WindowTrackerDelegate {
         workspaces.floatingFrames.removeValue(forKey: id)
         desired.removeValue(forKey: id)
         corrections.removeValue(forKey: id)
+        floatSettle.removeValue(forKey: id)?.cancel()
+        floatSettleAttempts.removeValue(forKey: id)
         if focusApplied == id { focusApplied = nil }
         apply(refocus: false)
     }
@@ -1227,6 +1247,7 @@ final class Coordinator: WindowTrackerDelegate {
 
         if workspaces.isFloating(id) {
             workspaces.floatingFrames[id] = window.element.frame
+            scheduleFloatSettle(id)
             if id == workspaces.focusedWindow { updateBorder() }
             return
         }
@@ -1253,6 +1274,50 @@ final class Coordinator: WindowTrackerDelegate {
         corrections[id] = attempts + 1
         WindowMover.setFrame(want, element: window.element, pid: window.pid)
         if id == workspaces.focusedWindow { updateBorder() }
+    }
+
+    /// Brings a float back inside `gaps_out` once whatever moved it has finished.
+    ///
+    /// `endDrag` already settles the frame the user let go of, and for a drag that is the end of
+    /// it. macOS's own edge-snap is what this is for: dragging a window to the side of the
+    /// display tiles it to that half — and dragging it to the top fills the screen — *after* the
+    /// mouse comes up, over the top of the frame the release settled, flush with the display
+    /// edge where every tile around it keeps the margin clear. That frame arrives here like any
+    /// other external move, so it is settled like any other: the snap keeps the half of the
+    /// display it chose, inset to the margin.
+    ///
+    /// Debounced, because the snap animates and each frame of it arrives separately — settling
+    /// the first would have toe writing one position while macOS writes the next, and would
+    /// spend the attempt cap below on frames of an animation that had not finished moving.
+    /// Debouncing
+    /// also keeps it clear of a live drag: the guard below is what actually decides, but a
+    /// user who pauses mid-drag would otherwise reach the deadline while still holding on.
+    private func scheduleFloatSettle(_ id: WindowID) {
+        floatSettle[id]?.cancel()
+        let work = DispatchWorkItem { [weak self] in self?.settleFloat(id) }
+        floatSettle[id] = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.floatSettleLatency, execute: work)
+    }
+
+    private func settleFloat(_ id: WindowID) {
+        floatSettle.removeValue(forKey: id)
+        guard id != draggedWindow, workspaces.isFloating(id),
+              let window = tracker.window(id), !window.isStashed
+        else { return }
+        // Read afresh: the deadline is long enough for the frame recorded on the notification
+        // that scheduled this to be a frame of an animation that has since finished.
+        if let have = window.element.frame { workspaces.floatingFrames[id] = have }
+        guard workspaces.settleFloat(id) else {
+            floatSettleAttempts.removeValue(forKey: id)
+            return
+        }
+        let attempts = floatSettleAttempts[id, default: 0]
+        guard attempts < 3 else { return }   // the app will not comply; stop fighting it
+        floatSettleAttempts[id] = attempts + 1
+        // A window moving with nobody touching it is the kind of thing that wants an answer in
+        // the log rather than a guess: this is the one place toe moves a float of its own accord.
+        Log.info("brought floating window \(id) back inside gaps_out")
+        apply(refocus: false)
     }
 
     /// Apps round and clamp the frames they are given; two frames within 2pt of each other are


### PR DESCRIPTION
Follow-up to #106, which brought a float dropped past the margin back inside `gaps_out` when the user lets go. macOS's own edge-snap slipped through it.

Dragging a window to the side of the display tiles it to that half, and dragging it to the top fills the screen. Both land *after* the mouse comes up, so they write over the frame the release had already settled, flush with the display edge where every tile around them keeps the margin clear.

That frame reaches toe as an ordinary external move, so it is now settled like any other: the snap keeps the half of the display it chose, inset to the outer gap.

**Debounced**, because the snap animates and each step of it arrives as its own notification. Settling the first would have toe writing one position while macOS writes the next, and would spend the three-attempt cap on frames of an animation that had not finished moving — so the correction would never land. The deadline is pushed back by every notification, making it a quiet period rather than a guess at the animation's length. It also skips a window the user has hold of, so a pause mid-drag does not yank it.

**On the 0.2s.** 0.1 was tried on the machine and is too tight: the snap does not deliver a notification every animation frame, and the gaps within one animation are long enough to read as its end. The window twitches to the margin, macOS puts it straight back, and the attempt cap counts a write that landed nowhere. 0.2 clears those gaps. The constant's comment records that, since the first version of it reasoned from a 16ms frame interval that turned out not to hold.

An ordinary drag is unaffected and still settles the instant the mouse comes up — no timer is involved on that path.

## Testing

`make test` — 1253 assertions, unchanged. The change is entirely in `Sources/toe`, which the selftest cannot reach; `settleFloat`'s own arithmetic in ToeCore is covered by #106's tests.

Tried by hand at each latency: Super+T a window, then drag it to the left edge, the right edge and the top. `log stream --predicate 'subsystem == "com.clifmeister.toe"' --level info` logs the correction, since a window moving with nobody touching it wants an answer in the log rather than a guess.

**Known limit:** a window snapped to the left half gets the margin on its outer three sides and stays flush at the middle seam. Confining a float to the display cannot tell that a given edge is a seam rather than a chosen position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X483aXCBgNCMP13tKvJqNj