### PR TITLE
Switch off macOS's drag-to-edge tiling, and put back a window it snapped

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,13 +117,14 @@ across a fullscreen Space unless something stops it. With *Displays have separat
 macOS default) "is anything fullscreen" is never the right question — scope it to a display.
 
 **State that outlives the process.** Symbolic hotkeys (`CGSSetSymbolicHotKeyEnabled`), the
-wallpaper-click preference and the Dock's auto-hide (`CoreDockSetAutoHideEnabled`) belong to the
-window server or the Dock, not to toe, so a `kill -9` during development would leave `Ctrl`+`↑`
-dead — or the Dock hiding itself — with nothing to explain why. All three are journalled to
-`~/.local/state/toe/` *before* the change is made and replayed in reverse at startup. If you add
-another such global toggle, follow that pattern. `CoreDock*` is also the one place toe reaches a
-symbol through `dlsym` instead of declaring it: unexported from every header, and a link-time
-dependency on it would turn its removal into a launch failure.
+wallpaper-click and edge-tiling preferences and the Dock's auto-hide
+(`CoreDockSetAutoHideEnabled`) belong to the window server or the Dock, not to toe, so a `kill -9`
+during development would leave `Ctrl`+`↑` dead — or the Dock hiding itself — with nothing to
+explain why. All four are journalled to `~/.local/state/toe/` *before* the change is made and
+replayed in reverse at startup. If you add another such global toggle, follow that pattern.
+`CoreDock*` is also the one place toe reaches a symbol through `dlsym` instead of declaring it:
+unexported from every header, and a link-time dependency on it would turn its removal into a
+launch failure.
 
 **The session snapshot** (`~/.local/state/toe/session.json`) is keyed on `CGWindowID` plus
 `kern.boottime`, and is restored *before* the tracker starts. A stale snapshot is discarded unread

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ theme, toe's own colours are Tokyo Night's.
 
 **Things toe changes while it runs.** To keep its workspaces intact, toe takes over the Dock's
 swipe gestures, switches off `Ctrl`+`↑`/`↓`, turns off "click wallpaper to show desktop" and
-auto-hides the Dock. Everything is put back when it quits — and restored on the next launch if it
+macOS's own drag-a-window-to-the-edge tiling, and auto-hides the Dock. Everything is put back when it quits — and restored on the next launch if it
 did not get the chance. Each has a switch in the config.
 
 ## Configuration
@@ -153,7 +153,8 @@ Other sections worth knowing about:
   while `[theme] name` is set.
 - `[floating]` — the sizes `SUPER` + `T` cycles through.
 - `[gestures]` and `[misc]` — the switches for the Dock swipes, the Mission Control shortcuts, the
-  wallpaper click, Dock auto-hide, un-hiding ⌘H'd apps and restoring the layout across restarts.
+  wallpaper click, macOS's edge tiling, Dock auto-hide, un-hiding ⌘H'd apps and restoring the
+  layout across restarts.
 - `[animations] slide_on_swipe` — slide the screen on a swipe the way Spaces does. Off by
   default because it needs Screen Recording, a second permission; Trigger › Toggle in the quick
   menu flips it.

--- a/Sources/ToeCore/Config/Config.swift
+++ b/Sources/ToeCore/Config/Config.swift
@@ -125,6 +125,10 @@ public struct MiscConfig: Equatable {
     /// off-screen stash alike, and macOS decides that inside WindowManager rather than from an
     /// event any tap could swallow — so it is switched off through its preference instead.
     public var disableWallpaperClick: Bool = true
+    /// Dragging a window to the side of the display tiles it to that half and dragging it to the
+    /// menu bar fills the screen — macOS placing a window toe is meant to be placing, after the
+    /// mouse has already come up. Switched off through its two preferences; see `EdgeTiling`.
+    public var disableEdgeTiling: Bool = true
     /// A visible Dock is a strip of screen the tiles never get, for something `SUPER`+`SPACE`
     /// reaches instead. Switched on through `CoreDockSetAutoHideEnabled` — see `DockAutoHide`.
     public var autohideDock: Bool = true
@@ -558,6 +562,13 @@ public struct Config: Equatable {
                     config.misc.disableWallpaperClick = v
                 } else {
                     config.warnings.append("misc.disable_wallpaper_click: must be true or false, using \(config.misc.disableWallpaperClick)")
+                }
+            }
+            if let raw = m["disable_edge_tiling"] {
+                if let v = raw.boolValue {
+                    config.misc.disableEdgeTiling = v
+                } else {
+                    config.warnings.append("misc.disable_edge_tiling: must be true or false, using \(config.misc.disableEdgeTiling)")
                 }
             }
             if let raw = m["autohide_dock"] {

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -143,6 +143,15 @@ disable_expose_shortcuts = true
 # "Click wallpaper to show desktop") and puts it back the way it found it when it quits.
 disable_wallpaper_click = true
 
+# Dragging a window to the side of the display tiles it to that half, and dragging it to the menu
+# bar fills the screen — macOS deciding where a window goes, which is toe's job, and deciding it
+# after the mouse has already come up. toe puts the window back either way, but you see it go
+# there and come back, so the two settings behind it are switched off while toe runs and put back
+# when it quits: the ones System Settings › Desktop & Dock calls "Drag windows to screen edges to
+# tile" and "Drag windows to menu bar to fill screen". Holding ⌥ while you drag still tiles, since
+# that is tiling you asked for rather than tiling that happened to you.
+disable_edge_tiling = true
+
 # The Dock takes a strip of screen off one edge that the tiles never get — around 70 points on a
 # default install, for something SUPER+SPACE reaches instead. toe turns on the setting System
 # Settings › Desktop & Dock calls "Automatically hide and show the Dock", which hands the strip

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -1382,10 +1382,11 @@ h.test("the two pictures of a slide stay one width apart") { t in
 }
 
 h.test("the macOS behaviours toe takes over are configurable") { t in
-    let off = try Config.parse("[misc]\ndisable_expose_shortcuts = false\nprevent_hiding = false\ndisable_wallpaper_click = false\nautohide_dock = false\n")
+    let off = try Config.parse("[misc]\ndisable_expose_shortcuts = false\nprevent_hiding = false\ndisable_wallpaper_click = false\ndisable_edge_tiling = false\nautohide_dock = false\n")
     t.equal(off.misc.disableExposeShortcuts, false, "the Exposé shortcuts can be handed back")
     t.equal(off.misc.preventHiding, false, "hiding can be allowed")
     t.equal(off.misc.disableWallpaperClick, false, "the wallpaper click can be handed back")
+    t.equal(off.misc.disableEdgeTiling, false, "and macOS can go on tiling a drag to the edge")
     t.equal(off.misc.autohideDock, false, "the Dock can be left showing")
     t.equal(off.warnings, [], "no warnings")
 
@@ -1393,16 +1394,20 @@ h.test("the macOS behaviours toe takes over are configurable") { t in
     t.equal(absent.misc.disableExposeShortcuts, true, "omitting the table keeps the defaults")
     t.equal(absent.misc.preventHiding, true, "omitting the table keeps the defaults")
     t.equal(absent.misc.disableWallpaperClick, true, "omitting the table keeps the defaults")
+    t.equal(absent.misc.disableEdgeTiling, true, "omitting the table keeps the defaults")
     t.equal(absent.misc.autohideDock, true, "omitting the table keeps the defaults")
 
-    let bad = try Config.parse("[misc]\nprevent_hiding = 1\ndisable_wallpaper_click = \"no\"\nautohide_dock = \"sometimes\"\n")
+    let bad = try Config.parse("[misc]\nprevent_hiding = 1\ndisable_wallpaper_click = \"no\"\ndisable_edge_tiling = \"nope\"\nautohide_dock = \"sometimes\"\n")
     t.equal(bad.misc.preventHiding, true, "a non-boolean keeps the default")
     t.equal(bad.misc.disableWallpaperClick, true, "a non-boolean keeps the default")
+    t.equal(bad.misc.disableEdgeTiling, true, "a non-boolean keeps the default")
     t.equal(bad.misc.autohideDock, true, "a non-boolean keeps the default")
     t.equal(bad.warnings.contains { $0.contains("misc.prevent_hiding") }, true,
             "and says so in the menu bar")
     t.equal(bad.warnings.contains { $0.contains("misc.disable_wallpaper_click") }, true,
             "and says so for the wallpaper click too")
+    t.equal(bad.warnings.contains { $0.contains("misc.disable_edge_tiling") }, true,
+            "and for the edge tiling")
     t.equal(bad.warnings.contains { $0.contains("misc.autohide_dock") }, true,
             "and for the Dock")
 }

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -107,24 +107,25 @@ final class Coordinator: WindowTrackerDelegate {
     private var isSettlingSession = false
     /// Pending debounced write. See `scheduleSessionSave`.
     private var sessionSave: DispatchWorkItem?
-    /// Pending settles, one per floating window. See `scheduleFloatSettle`.
-    private var floatSettle: [WindowID: DispatchWorkItem] = [:]
-    /// How many times in a row a float has been brought back inside the margin without it
-    /// staying there. `corrections` is the same idea for tiles, and is deliberately not reused:
-    /// that one re-asserts a frame toe chose, and pointing it at a float would fight the user's
-    /// drags. This only ever moves a window that is out of bounds, and only counts so that an
-    /// app which insists on its own position is left to it rather than ping-ponged with.
-    private var floatSettleAttempts: [WindowID: Int] = [:]
-    /// How long a float's frame has to hold still before the frame it landed on is taken as
-    /// final. Not the length of macOS's edge-snap animation but a quiet period after it: the
-    /// deadline is pushed back by every notification that arrives.
+    /// Pending settles, one per window. See `scheduleSettle`.
+    private var settleWork: [WindowID: DispatchWorkItem] = [:]
+    /// How many times in a row a window has been put back where toe wants it without it staying
+    /// there. `corrections` is the same idea and is deliberately not reused: that one answers an
+    /// app re-asserting its own geometry the instant it does it, so it is spent on frames that
+    /// are still moving — which is exactly how macOS's edge-snap exhausts it, see `settle`. This
+    /// one is spent only on frames that have already held still, and only counts so that an app
+    /// which insists on its own position is left to it rather than ping-ponged with.
+    private var settleAttempts: [WindowID: Int] = [:]
+    /// How long a frame has to hold still before the place it landed is taken as final. Not the
+    /// length of macOS's edge-snap animation but a quiet period after it: the deadline is pushed
+    /// back by every notification that arrives.
     ///
     /// Measured, not reasoned about. 0.1 is too tight — macOS's edge-snap does not deliver a
     /// notification every animation frame, and the gaps in the middle of one are long enough
-    /// to be taken for its end, at which point toe writes the margin under a window that is
-    /// still moving and macOS puts it back flush. The window twitches and the correction is
-    /// lost, since the attempt cap counts a write that landed nowhere. 0.2 clears those gaps.
-    private static let floatSettleLatency: TimeInterval = 0.2
+    /// to be taken for its end, at which point toe writes under a window that is still moving
+    /// and macOS puts it back flush. The window twitches and the correction is lost, since the
+    /// attempt cap counts a write that landed nowhere. 0.2 clears those gaps.
+    private static let settleLatency: TimeInterval = 0.2
     /// The window the user has hold of. Its frame is theirs until they let go: toe neither
     /// re-asserts its tile nor writes it a new one, the same courtesy `apply` already extends
     /// to a floating window.
@@ -183,7 +184,10 @@ final class Coordinator: WindowTrackerDelegate {
         // Same reasoning, same shape: the reveal-desktop preference is the window server's, not
         // toe's, so a copy that was killed rather than quit may have left it switched off.
         WallpaperClick.repairAfterUncleanExit()
-        // And the third of them: the Dock's auto-hide setting is the Dock's own, so a copy that
+        // And again for macOS's drag-to-edge tiling, which is two more WindowManager preferences
+        // of exactly the same kind.
+        EdgeTiling.repairAfterUncleanExit()
+        // And the last of them: the Dock's auto-hide setting is the Dock's own, so a copy that
         // was killed rather than quit may have left the Dock hiding itself.
         DockAutoHide.repairAfterUncleanExit()
         // Not the same thing as those three — the desktop picture is not given back on the way
@@ -842,6 +846,12 @@ final class Coordinator: WindowTrackerDelegate {
             WallpaperClick.restore()
         }
 
+        if config.misc.disableEdgeTiling {
+            EdgeTiling.disable()
+        } else {
+            EdgeTiling.restore()
+        }
+
         if config.misc.autohideDock {
             DockAutoHide.enable()
         } else {
@@ -1206,8 +1216,8 @@ final class Coordinator: WindowTrackerDelegate {
         workspaces.floatingFrames.removeValue(forKey: id)
         desired.removeValue(forKey: id)
         corrections.removeValue(forKey: id)
-        floatSettle.removeValue(forKey: id)?.cancel()
-        floatSettleAttempts.removeValue(forKey: id)
+        settleWork.removeValue(forKey: id)?.cancel()
+        settleAttempts.removeValue(forKey: id)
         if focusApplied == id { focusApplied = nil }
         apply(refocus: false)
     }
@@ -1247,7 +1257,7 @@ final class Coordinator: WindowTrackerDelegate {
 
         if workspaces.isFloating(id) {
             workspaces.floatingFrames[id] = window.element.frame
-            scheduleFloatSettle(id)
+            scheduleSettle(id)
             if id == workspaces.focusedWindow { updateBorder() }
             return
         }
@@ -1265,9 +1275,19 @@ final class Coordinator: WindowTrackerDelegate {
         guard let want = desired[id], let have = window.element.frame else { return }
         if Self.settled(have, want) {
             corrections[id] = 0
+            settleAttempts.removeValue(forKey: id)
             if id == workspaces.focusedWindow { updateBorder() }
             return
         }
+
+        // The correction below is immediate because the app it is aimed at is: Chromium writes
+        // its remembered geometry once, and answering it a notification later would show the
+        // wrong frame for as long as it took. macOS's edge-snap is the opposite — it animates,
+        // and the three attempts go on frames that had not finished moving, after which toe has
+        // given up and the window stays flush with the display edge while the tree is still laid
+        // out around the tile it left. So the tile is asserted once more when the window has
+        // stopped moving, which is the one moment a write can hold.
+        scheduleSettle(id)
 
         let attempts = corrections[id, default: 0]
         guard attempts < 3 else { return }   // the app will not comply; stop fighting it
@@ -1276,48 +1296,84 @@ final class Coordinator: WindowTrackerDelegate {
         if id == workspaces.focusedWindow { updateBorder() }
     }
 
-    /// Brings a float back inside `gaps_out` once whatever moved it has finished.
+    /// Puts a window back where toe wants it once whatever moved it has finished: a float back
+    /// inside `gaps_out`, a tile back in its tile.
     ///
     /// `endDrag` already settles the frame the user let go of, and for a drag that is the end of
     /// it. macOS's own edge-snap is what this is for: dragging a window to the side of the
     /// display tiles it to that half — and dragging it to the top fills the screen — *after* the
     /// mouse comes up, over the top of the frame the release settled, flush with the display
     /// edge where every tile around it keeps the margin clear. That frame arrives here like any
-    /// other external move, so it is settled like any other: the snap keeps the half of the
-    /// display it chose, inset to the margin.
+    /// other external move, so it is settled like any other. What that means differs by what the
+    /// window is: a float keeps the half of the display the snap chose, inset to the margin,
+    /// because a float is the user's to place — while a tile is not, so it goes back into the
+    /// tile the tree still has it in, which is the only frame that leaves the layout whole.
     ///
     /// Debounced, because the snap animates and each frame of it arrives separately — settling
     /// the first would have toe writing one position while macOS writes the next, and would
     /// spend the attempt cap below on frames of an animation that had not finished moving.
-    /// Debouncing
-    /// also keeps it clear of a live drag: the guard below is what actually decides, but a
-    /// user who pauses mid-drag would otherwise reach the deadline while still holding on.
-    private func scheduleFloatSettle(_ id: WindowID) {
-        floatSettle[id]?.cancel()
-        let work = DispatchWorkItem { [weak self] in self?.settleFloat(id) }
-        floatSettle[id] = work
-        DispatchQueue.main.asyncAfter(deadline: .now() + Self.floatSettleLatency, execute: work)
+    /// Debouncing also keeps it clear of a live drag: the guard below is what actually decides,
+    /// but a user who pauses mid-drag would otherwise reach the deadline while still holding on.
+    private func scheduleSettle(_ id: WindowID) {
+        settleWork[id]?.cancel()
+        let work = DispatchWorkItem { [weak self] in self?.settle(id) }
+        settleWork[id] = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.settleLatency, execute: work)
     }
 
-    private func settleFloat(_ id: WindowID) {
-        floatSettle.removeValue(forKey: id)
-        guard id != draggedWindow, workspaces.isFloating(id),
-              let window = tracker.window(id), !window.isStashed
+    private func settle(_ id: WindowID) {
+        settleWork.removeValue(forKey: id)
+        guard id != draggedWindow, let window = tracker.window(id), !window.isStashed
         else { return }
+        if workspaces.isFloating(id) {
+            settleFloat(id, window)
+        } else {
+            settleTile(id, window)
+        }
+    }
+
+    private func settleFloat(_ id: WindowID, _ window: ManagedWindow) {
         // Read afresh: the deadline is long enough for the frame recorded on the notification
         // that scheduled this to be a frame of an animation that has since finished.
         if let have = window.element.frame { workspaces.floatingFrames[id] = have }
         guard workspaces.settleFloat(id) else {
-            floatSettleAttempts.removeValue(forKey: id)
+            settleAttempts.removeValue(forKey: id)
             return
         }
-        let attempts = floatSettleAttempts[id, default: 0]
+        let attempts = settleAttempts[id, default: 0]
         guard attempts < 3 else { return }   // the app will not comply; stop fighting it
-        floatSettleAttempts[id] = attempts + 1
+        settleAttempts[id] = attempts + 1
         // A window moving with nobody touching it is the kind of thing that wants an answer in
         // the log rather than a guess: this is the one place toe moves a float of its own accord.
         Log.info("brought floating window \(id) back inside gaps_out")
         apply(refocus: false)
+    }
+
+    /// The tile is written here rather than through `apply`, which would not do it: nothing about
+    /// the plan has changed — the tree never heard about the snap — so `desired[id]` still holds
+    /// the frame this window is supposed to have and `apply` skips every window it already
+    /// matches. This is the same write `windowFrameChangedExternally` makes, taken once more now
+    /// that the window has stopped moving.
+    private func settleTile(_ id: WindowID, _ window: ManagedWindow) {
+        // Read afresh: the deadline is long enough for the frame on the notification that
+        // scheduled this to be a frame of an animation that has since finished.
+        guard let want = desired[id], let have = window.element.frame, !Self.settled(have, want)
+        else {
+            settleAttempts.removeValue(forKey: id)
+            return
+        }
+        // Three, as everywhere else, and a snap spends two of them: macOS pushes the window
+        // back to the half it chose once, about a fifth of a second after the first write, and
+        // lets go of it after the second. The third is what is left for an app that will not
+        // comply — one whose minimum size exceeds its tile — which is where this stops.
+        let attempts = settleAttempts[id, default: 0]
+        guard attempts < 3 else { return }
+        settleAttempts[id] = attempts + 1
+        // Same reasoning as the float above: a window that moved with nobody touching it wants
+        // an answer in the log.
+        Log.info("put tiled window \(id) back in its tile")
+        WindowMover.setFrame(want, element: window.element, pid: window.pid)
+        if id == workspaces.focusedWindow { updateBorder() }
     }
 
     /// Apps round and clamp the frames they are given; two frames within 2pt of each other are
@@ -1613,11 +1669,12 @@ final class Coordinator: WindowTrackerDelegate {
         // WindowServer, so it is taken down deliberately rather than left to process death.
         dockSwipes.stop()
         hideBlocker.stop()
-        // The three that would otherwise outlive toe: the window server keeps a symbolic hotkey
-        // switched off until something switches it back on, and the reveal-desktop and Dock
-        // auto-hide preferences are written to the user's settings.
+        // The four that would otherwise outlive toe: the window server keeps a symbolic hotkey
+        // switched off until something switches it back on, and the reveal-desktop, edge-tiling
+        // and Dock auto-hide preferences are written to the user's settings.
         SymbolicHotkeys.restoreAll()
         WallpaperClick.restore()
+        EdgeTiling.restore()
         DockAutoHide.restore()
     }
 

--- a/Sources/toe/EdgeTiling.swift
+++ b/Sources/toe/EdgeTiling.swift
@@ -1,0 +1,165 @@
+import CoreFoundation
+import Foundation
+
+/// macOS's own drag-a-window-to-an-edge tiling, switched off for as long as toe runs.
+///
+/// Dragging a window to the side of the display tiles it to that half, and dragging it to the
+/// menu bar fills the screen. That is macOS placing a window toe is meant to be placing, and it
+/// lands *after* the mouse comes up — over the top of the frame the release settled, flush with
+/// the display edge where every tile around it keeps the margin clear, while the tree is still
+/// laid out around the tile the window left. It is the same problem `SymbolicHotkeys` and
+/// `WallpaperClick` exist for, arriving by a third route: a window ends up somewhere toe did not
+/// put it.
+///
+/// toe survives it either way — `Coordinator.settleTile` puts a tile back once the snap has
+/// stopped animating, and `settleFloat` insets a float macOS snapped to the margin — but
+/// surviving a thing is not the same as wanting it, and the recovery is visible: the window goes
+/// to macOS's half and comes back about three quarters of a second later.
+///
+/// Two preferences rather than one, because macOS counts the edges separately.
+/// `EnableTilingByEdgeDrag` is the setting System Settings › Desktop & Dock calls "Drag windows
+/// to screen edges to tile", and `EnableTopTilingByEdgeDrag` the "Drag windows to menu bar to
+/// fill screen" beneath it. Unset means on for both — tiling is the macOS default — so an absent
+/// key is a value to put back, not a value to ignore, and each is remembered separately because
+/// a user who has already turned one of them off by hand is owed exactly that back.
+///
+/// `EnableTilingOptionAccelerator` — hold `⌥` while dragging — is deliberately left alone. It is
+/// the same tiling asked for on purpose rather than triggered by where a drag happened to end,
+/// so what toe takes away is the accident, not the choice.
+///
+/// Like a symbolic hotkey, **this state outlives the process**, so it is handled the same way:
+/// journalled to disk *before* the change, and a journal found at startup is replayed, which is
+/// what repairs a crash, a force-quit or a logout.
+enum EdgeTiling {
+
+    private static let domain = "com.apple.WindowManager" as CFString
+
+    /// The sides first and the menu bar second, the order System Settings lists them in — which
+    /// is also the order the journal is written in, so a file left behind by a crash reads the
+    /// way the settings pane does.
+    private static let keys = ["EnableTilingByEdgeDrag", "EnableTopTilingByEdgeDrag"]
+
+    private static let journalURL = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".local/state/toe/edge-tiling")
+
+    /// What a preference was before toe touched it, and so what `restore` owes the user back.
+    /// `absent` is not the same as `on`: writing `true` where there was no key at all would leave
+    /// the user's settings holding a value they never set.
+    private enum Previous: String {
+        case on
+        case absent
+    }
+
+    /// The keys `disable` actually took, and what each of them was. Empty until it takes one — a
+    /// preference the user had already switched off themselves is not in here, and is never
+    /// given back.
+    private static var previous: [String: Previous] = [:]
+
+    // MARK: - Applying
+
+    /// Turns edge tiling off, remembering what was there. Idempotent, and a no-op when the user
+    /// has already turned both halves of it off themselves.
+    static func disable() {
+        guard previous.isEmpty else { return }
+        // Sequoia is where drag-to-edge tiling arrived. On anything older these keys mean nothing
+        // to WindowManager, and writing them would put a value in the user's settings that
+        // nothing will ever read and that only toe knows to take out again.
+        guard #available(macOS 15, *) else { return }
+
+        var taken: [String: Previous] = [:]
+        for key in keys {
+            let current = (CFPreferencesCopyAppValue(key as CFString, domain) as? NSNumber)?.boolValue
+            guard current ?? true else { continue }   // already off: nothing to take, nothing owed
+            taken[key] = current == nil ? .absent : .on
+        }
+        guard !taken.isEmpty else { return }
+
+        // Journalled before the change, not after: a crash between the two must leave a record
+        // that says too much, never one that says too little.
+        previous = taken
+        writeJournal(taken)
+        for key in taken.keys { write(false, to: key) }
+        synchronize()
+        Log.info("edge tiling: macOS's drag-to-edge tiling switched off")
+    }
+
+    /// Gives back exactly what `disable` took, and clears the journal. Safe to call twice.
+    static func restore() {
+        guard !previous.isEmpty else {
+            clearJournal()
+            return
+        }
+        put(back: previous)
+        previous = [:]
+        clearJournal()
+        Log.info("edge tiling: drag-to-edge tiling restored")
+    }
+
+    /// Replays a journal left behind by a toe that did not get to restore — a crash, a `kill -9`,
+    /// a logout. Call once at startup, before `disable`.
+    static func repairAfterUncleanExit() {
+        guard let text = try? String(contentsOf: journalURL, encoding: .utf8) else { return }
+        let was = readJournal(text)
+        if !was.isEmpty {
+            put(back: was)
+            Log.info("edge tiling: repaired drag-to-edge tiling after an unclean exit")
+        }
+        clearJournal()
+    }
+
+    // MARK: - The preferences
+
+    private static func put(back previous: [String: Previous]) {
+        for (key, was) in previous {
+            write(was == .on ? true : nil, to: key)
+        }
+        synchronize()
+    }
+
+    /// nil removes the key, which is how a setting the user never set is left the way it was.
+    private static func write(_ value: Bool?, to key: String) {
+        let property: CFPropertyList? = value.map { $0 ? kCFBooleanTrue : kCFBooleanFalse }
+        CFPreferencesSetAppValue(key as CFString, property, domain)
+    }
+
+    /// Once, after both keys rather than inside each write. WindowManager reads the preferences
+    /// rather than being told about them, so a write has to be out of toe's own cache and in
+    /// `cfprefsd` before the next drag asks — and it is read that late: with these written, the
+    /// very next drag to an edge lands in its tile with no snap at all, no restart of anything.
+    private static func synchronize() {
+        CFPreferencesAppSynchronize(domain)
+    }
+
+    // MARK: - The journal
+
+    /// One `key=state` per line. `WallpaperClick` has a single value and writes it bare; two
+    /// need naming, and naming them means a file that survives one of the pair being added or
+    /// dropped later — `readJournal` ignores a line it does not recognise.
+    private static func writeJournal(_ previous: [String: Previous]) {
+        try? FileManager.default.createDirectory(at: journalURL.deletingLastPathComponent(),
+                                                 withIntermediateDirectories: true)
+        let text = keys.compactMap { key in previous[key].map { "\(key)=\($0.rawValue)" } }
+            .joined(separator: "\n")
+        try? text.write(to: journalURL, atomically: true, encoding: .utf8)
+    }
+
+    /// A truncated or hand-edited line is dropped rather than read as a state to put back, which
+    /// is the rule `WallpaperClick` applies to its one value, line by line.
+    private static func readJournal(_ text: String) -> [String: Previous] {
+        var previous: [String: Previous] = [:]
+        for line in text.split(whereSeparator: \.isNewline) {
+            let parts = line.split(separator: "=", maxSplits: 1)
+            guard parts.count == 2 else { continue }
+            let key = String(parts[0]).trimmingCharacters(in: .whitespaces)
+            guard keys.contains(key),
+                  let was = Previous(rawValue: String(parts[1]).trimmingCharacters(in: .whitespaces))
+            else { continue }
+            previous[key] = was
+        }
+        return previous
+    }
+
+    private static func clearJournal() {
+        try? FileManager.default.removeItem(at: journalURL)
+    }
+}

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -134,6 +134,15 @@ disable_expose_shortcuts = true
 # "Click wallpaper to show desktop") and puts it back the way it found it when it quits.
 disable_wallpaper_click = true
 
+# Dragging a window to the side of the display tiles it to that half, and dragging it to the menu
+# bar fills the screen — macOS deciding where a window goes, which is toe's job, and deciding it
+# after the mouse has already come up. toe puts the window back either way, but you see it go
+# there and come back, so the two settings behind it are switched off while toe runs and put back
+# when it quits: the ones System Settings › Desktop & Dock calls "Drag windows to screen edges to
+# tile" and "Drag windows to menu bar to fill screen". Holding ⌥ while you drag still tiles, since
+# that is tiling you asked for rather than tiling that happened to you.
+disable_edge_tiling = true
+
 # The Dock takes a strip of screen off one edge that the tiles never get — around 70 points on a
 # default install, for something SUPER+SPACE reaches instead. toe turns on the setting System
 # Settings › Desktop & Dock calls "Automatically hide and show the Dock", which hands the strip


### PR DESCRIPTION
Dragging a **tiled** window to the side of the display tiled it to that half, and to the menu bar filled the screen — macOS placing a window toe is meant to be placing, landing *after* the mouse came up and over the top of the frame the release settled. The window stayed there. Measured on a 1728-point display, with a synthetic title-bar drag to the left edge:

| | frame |
|---|---|
| toe's tile | `15, 48, 842 × 1054` |
| after release | `0, 33, 864 × 1084` — exactly half the display, flush to the edge |
| three seconds later | unchanged |

…while the tree went on laying itself out around the tile the window had left. That is the "weird non-attached state".

### Why the snap-back did not catch it

`windowFrameChangedExternally` was already aimed at exactly this and could not land it. The snap **animates**, each step arrives as its own external move, and the three correction attempts were spent on frames that had not finished moving; by the time macOS stopped, toe had given up. It is the same reason #107 had to debounce the float case, so the settle that added is now general: the immediate correction stays — Chromium writes its remembered geometry once and wants an answer now, not a notification later — and the tile is asserted once more after the frame has held still, which is the one moment a write can hold. A snap spends two of the three attempts: macOS pushes the window back to its half once, ~200 ms after the first write, and lets go after the second.

### And then the behaviour itself

Surviving a thing is not the same as wanting it — you watch the window go to macOS's half and come back three quarters of a second later. So it is switched off while toe runs, the way the wallpaper click and the Exposé shortcuts already are. `EdgeTiling` writes `EnableTilingByEdgeDrag` and `EnableTopTilingByEdgeDrag` false, journalled to `~/.local/state/toe/edge-tiling` *before* the change and replayed at startup, each key remembering separately whether it was `on` or `absent` so a half already switched off by hand is never given back. `EnableTilingOptionAccelerator` is left alone: holding <kbd>⌥</kbd> while dragging still tiles, so what toe takes away is the accident, not the choice. Guarded on macOS 15, where the feature arrived.

`[misc] disable_edge_tiling`, true by default. Set it false and the preferences are handed back on the reload, and the settle above is what holds the layout together.

### Verified on a running agent

| | result |
|---|---|
| toe starts | both keys `0`, journal written |
| drag to left / right / top | lands straight in its tile — no snap, no excursion at all |
| with the setting `false` | macOS snaps, and the window is back in its tile in ~0.75 s |
| `SIGTERM` | keys removed (back to absent), journal cleared |
| `kill -9`, restart | `edge tiling: repaired drag-to-edge tiling after an unclean exit`, then off again |
| setting flipped in the config | preferences handed back on the live reload; put back, re-taken |

WindowManager re-reads the preferences per drag — no restart of anything is needed for them to take effect.

`make test`: 1257 assertions pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X483aXCBgNCMP13tKvJqNj
