### PR TITLE
Put toe's own switches on the Setup level and take the Trigger menu out

### DIFF
--- a/Sources/ToeCore/Config/ConfigWriter.swift
+++ b/Sources/ToeCore/Config/ConfigWriter.swift
@@ -17,7 +17,7 @@ import Foundation
 /// config is broken* into *toe declined to edit your config, and said so in the log*.
 ///
 /// Written for the theme (`ThemeWriter`), generalised the day the menu grew a second thing to
-/// write: the slide's `on`/`off` under Trigger › Toggle.
+/// write: the slide's `on`/`off` under Setup.
 public enum ConfigWriter {
 
     /// `literal` is written after the `=` exactly as given — `"gruvbox"` with its quotes, `true`

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -81,7 +81,8 @@ name = ""
 
 [border]
 # Highlights the focused window. Omarchy's col.active_border gradient — and what you see when no
-# theme is set above, since a theme replaces both stops with one flat accent.
+# theme is set above, since a theme replaces both stops with one flat accent. SUPER+SPACE > Setup
+# has this switch as well, and rewrites this line.
 enabled      = true
 width        = 2
 active_start = "#33ccffee"
@@ -125,6 +126,10 @@ swallow_dock_swipes = true
 # the swipe switches instantly, as it does now. macOS 15 reminds you now and then that toe can
 # record the screen — it captures for the moment of a swipe and keeps nothing. The swipe only:
 # it is the gesture the Spaces slide belongs to. SUPER+1…0 and SUPER+TAB stay instant.
+#
+# SUPER+SPACE > Setup has this switch, and throwing it there rewrites this line — the menu and
+# this file are the same setting, so there is nothing to keep in step. It is also where the
+# permission prompt comes from, with the row you pressed still on screen to explain it.
 slide_on_swipe = false
 # Seconds. Spaces takes about a third of one.
 slide_duration = 0.3
@@ -156,7 +161,10 @@ disable_edge_tiling = true
 # default install, for something SUPER+SPACE reaches instead. toe turns on the setting System
 # Settings › Desktop & Dock calls "Automatically hide and show the Dock", which hands the strip
 # back and leaves the Dock one mouse-to-the-edge away, and turns it off again when it quits. A
-# Dock you already auto-hide yourself is left alone.
+# Dock you already auto-hide yourself is left alone: this line is toe making sure the strip is
+# there, not toe taking your Dock over. SUPER+SPACE > Setup has this switch too, and that one is
+# you asking rather than toe maintaining — throwing it there moves the Dock either way, including
+# back into view on a machine that was hiding it before toe ever started.
 autohide_dock = true
 
 # ⌘H and ⌘⌥H take an application's windows out of the layout without closing them — the tree

--- a/Sources/ToeCore/Dispatch/Command.swift
+++ b/Sources/ToeCore/Dispatch/Command.swift
@@ -205,12 +205,13 @@ public enum CommandParser {
             case "", "root", "go":                    return .menu(.root)
             case "keybindings", "keys":               return .menu(.keybindings)
             case "learn":                             return .menu(.learn)
-            case "trigger":                           return .menu(.trigger)
-            case "toggle", "toggles":                 return .menu(.toggle)
             case "style":                             return .menu(.style)
             case "theme", "themes":                   return .menu(.theme)
             case "background", "backgrounds", "wallpaper": return .menu(.background)
-            case "setup", "settings":                 return .menu(.setup)
+            // `trigger` and `toggles` opened the borrowed `Trigger › Toggle` level, which held
+            // one switch and is gone; the switch is a Setup row now, so the aliases follow it
+            // there rather than becoming an error in a config that was right when it was written.
+            case "setup", "settings", "trigger", "toggle", "toggles": return .menu(.setup)
             case "install":                           return .menu(.install)
             case "remove", "uninstall":               return .menu(.remove)
             default:                    throw CommandError.badArgument(name, argument)

--- a/Sources/ToeCore/Menu/MenuModel.swift
+++ b/Sources/ToeCore/Menu/MenuModel.swift
@@ -34,8 +34,6 @@ public struct MenuRoute: Equatable, Sendable {
     public static let style = MenuRoute(path: ["Style"])
     public static let theme = MenuRoute(path: ["Style", "Theme"])
     public static let background = MenuRoute(path: ["Style", "Background"])
-    public static let trigger = MenuRoute(path: ["Trigger"])
-    public static let toggle = MenuRoute(path: ["Trigger", "Toggle"])
     public static let setup = MenuRoute(path: ["Setup"])
     public static let install = MenuRoute(path: ["Install"])
     public static let remove = MenuRoute(path: ["Remove"])
@@ -49,7 +47,6 @@ public struct MenuItem: Equatable {
     /// moves rather than every test that mentions a row.
     public enum Icon: Equatable, Sendable {
         case gear, book, keyboard, pencil, power, toggleOn, toggleOff
-        case rocket, sliders
         case paintbrush, droplet, image
         case download, trash, info, globe
     }
@@ -59,10 +56,10 @@ public struct MenuItem: Equatable {
         case page(MenuPage)
         case run(Command)
         case toggleLoginItem
-        /// The Trigger › Toggle row for `animations.slide_on_swipe`. Its own case rather than a
+        /// One of the Setup switches — which one is the payload. Its own case rather than a
         /// `.run`, for the reason the login toggle has one: the row's value flips under the
         /// cursor and the menu stays open, which no `Command` does.
-        case toggleSlide
+        case toggleSetting(ConfigSwitch)
         /// A row that says something and does nothing when you press it — "Fetching Omarchy's
         /// themes…". The alternative was leaving the level looking like a short list rather than
         /// an unfinished one, which is the sort of thing you stare at wondering if it is broken.
@@ -182,6 +179,71 @@ public struct StyleMenu: Equatable {
     }
 }
 
+/// A Setup row that flips one boolean in `toe.toml`.
+///
+/// The case names the line it writes — which table, which key, and how to read it back — because
+/// everything between the row and the file is otherwise the same code once per switch: the menu
+/// builds a row from `value(in:)`, `MenuState` hands the case straight back, and
+/// `Coordinator.toggle` writes `key` into `table` and reloads. A fourth switch is a case here and
+/// nothing anywhere else.
+///
+/// Only settings that are *worth* a row belong here — a switch in the menu is a switch somebody
+/// will throw while looking at what it does, so it wants an effect they can see. These three
+/// change the screen the moment they are written. `restore_session` does not, and is not here.
+public enum ConfigSwitch: String, Equatable, Sendable, CaseIterable {
+    /// `[animations] slide_on_swipe`. The one that can ask for a permission — see
+    /// `Coordinator.toggle` on why the flip goes through the file.
+    case slide
+    /// `[border] enabled`. The gradient around the focused window.
+    case border
+    /// `[misc] autohide_dock`. Hands the Dock's strip of screen back to the tiles.
+    case dock
+
+    /// The row's title. Says what the setting does rather than what the key is called, because
+    /// the key is one grep away and the row is not.
+    public var title: String {
+        switch self {
+        case .slide:  return "Workspace slide"
+        case .border: return "Focus border"
+        case .dock:   return "Auto-hide Dock"
+        }
+    }
+
+    public var table: String {
+        switch self {
+        case .slide:  return "animations"
+        case .border: return "border"
+        case .dock:   return "misc"
+        }
+    }
+
+    public var key: String {
+        switch self {
+        case .slide:  return "slide_on_swipe"
+        case .border: return "enabled"
+        case .dock:   return "autohide_dock"
+        }
+    }
+
+    public func value(in config: Config) -> Bool {
+        switch self {
+        case .slide:  return config.animations.slideOnSwipe
+        case .border: return config.border.enabled
+        case .dock:   return config.misc.autohideDock
+        }
+    }
+
+    /// The value written into a config in memory, for the one caller that has to show a row
+    /// before the file has been read back — `QuickMenu`, redrawing the level under the cursor.
+    public func set(_ on: Bool, in config: inout Config) {
+        switch self {
+        case .slide:  config.animations.slideOnSwipe = on
+        case .border: config.border.enabled = on
+        case .dock:   config.misc.autohideDock = on
+        }
+    }
+}
+
 /// The menu's contents.
 ///
 /// Deliberately a function of the state it displays rather than a constant: a "Run on startup"
@@ -202,24 +264,23 @@ public enum MenuModel {
     /// theme, a background and an already-installed row.
     public static let checkmark = "✓"
 
-    public static func root(loginItem: LoginItemState, bindings: [Binding],
+    public static func root(loginItem: LoginItemState, config: Config,
                             style: StyleMenu = StyleMenu(),
-                            version: String? = nil,
-                            slideOnSwipe: Bool = false) -> [MenuItem] {
+                            version: String? = nil) -> [MenuItem] {
         // Omarchy's root order, with the rows toe has no analogue for left out: Apps, **Learn**,
-        // **Trigger**, **Style**, **Setup**, **Install**, **Remove**, Update, **About**, System.
+        // Trigger, **Style**, **Setup**, **Install**, **Remove**, Update, **About**, System.
         // Quit is toe's own and goes last, after everything ported.
         var items: [MenuItem] = [
             MenuItem(title: "Learn", icon: .book, action: .submenu(learn())),
-            MenuItem(title: "Trigger", icon: .rocket,
-                     action: .submenu(trigger(slideOnSwipe: slideOnSwipe))),
             MenuItem(title: "Style", icon: .paintbrush, action: .submenu(MenuModel.style(style))),
         ]
-        // Setup can come out empty — neither of its rows is guaranteed — and a row that leads
-        // into an empty level is worse than no row, so the parent goes with it. That is Omarchy's
-        // rule for a submenu whose children have all failed their `when`, applied here by hand
-        // because toe's levels are built rather than filtered.
-        let setupRows = setup(loginItem: loginItem, bindings: bindings)
+        // A row that leads into an empty level is worse than no row, so the parent goes with an
+        // empty Setup. That is Omarchy's rule for a submenu whose children have all failed their
+        // `when`, applied here by hand because toe's levels are built rather than filtered. The
+        // slide switch is unconditional, so as things stand the level cannot come out empty — but
+        // which of these rows survives is a function of the machine, and the guard is what keeps
+        // the day one of them goes conditional again from putting a dead row at the root.
+        let setupRows = setup(loginItem: loginItem, config: config)
         if !setupRows.isEmpty {
             items.append(MenuItem(title: "Setup", icon: .gear, action: .submenu(setupRows)))
         }
@@ -259,31 +320,6 @@ public enum MenuModel {
             MenuItem(title: "Hyprland", icon: .globe,
                      action: .run(.exec("open https://wiki.hypr.land/"))),
         ]
-    }
-
-    /// Omarchy's `Trigger` level: Emoji, Reminder, Capture, Transcode, Share, **Toggle**,
-    /// Hardware, Speed Test. One survives. The rest are Linux tools — an emoji picker, ffmpeg,
-    /// a share sheet, a touchpad switch — that a Mac either has of its own or has no need of, so
-    /// they fail their `when` here the way an upstream row does on a machine without the
-    /// hardware. Toggle stays because it holds a row toe can honour, and a level with one live
-    /// descendant is listed: that is the Setup rule read the other way round.
-    public static func trigger(slideOnSwipe: Bool) -> [MenuItem] {
-        [MenuItem(title: "Toggle", icon: .sliders, action: .submenu(toggles(slideOnSwipe: slideOnSwipe)))]
-    }
-
-    /// Omarchy's `Trigger › Toggle` level — where upstream keeps every switch that is on or off
-    /// *right now*: Stay Awake, Notifications, Screensaver, Nightlight, Menu Bar, and the
-    /// Hyprland ones, Workspace Layout and Window Gaps. None of those ten has a Mac analogue
-    /// toe can throw from here yet, so the level opens with toe's own row, where an Omarchy
-    /// user would go looking for a switch. (Run on startup is under Setup, not here, on
-    /// purpose: it is how toe *starts*, like upstream's Direct Boot, not what is on at the
-    /// moment.) Also built on its own, by the menu, when throwing the switch rebuilds the level
-    /// under the cursor.
-    public static func toggles(slideOnSwipe: Bool) -> [MenuItem] {
-        [MenuItem(title: "Workspace slide",
-                  icon: slideOnSwipe ? .toggleOn : .toggleOff,
-                  value: slideOnSwipe ? "on" : "off",
-                  action: .toggleSlide)]
     }
 
     /// Omarchy's `Style` level, minus the parts toe has no analogue for.
@@ -410,15 +446,33 @@ public enum MenuModel {
     ///
     /// `Config` is `setup.config`, which upstream is a submenu of the files Omarchy will open for
     /// you. toe has one file, so it is one row.
-    public static func setup(loginItem: LoginItemState, bindings: [Binding]) -> [MenuItem] {
+    public static func setup(loginItem: LoginItemState, config: Config) -> [MenuItem] {
         var rows: [MenuItem] = []
-        if let opener = configOpener(in: bindings) {
+        if let opener = configOpener(in: config.bindings) {
             rows.append(MenuItem(title: "Config", icon: .pencil, action: .run(opener.command)))
         }
         // After the ported row rather than before it: this one has no Omarchy counterpart — an
         // Omarchy session does not start its window manager at login, it *is* the login — and
         // toe's own rows go under the ones an Omarchy user came looking for.
         if let startup = startup(loginItem) { rows.append(startup) }
+        // Upstream keeps its live switches under `Trigger › Toggle`, and the slide sat there for
+        // exactly as long as it was the only one: a root row leading to a level leading to a
+        // level holding one switch is three keys to reach a thing toe had one of. None of these
+        // is one of upstream's ten toggles — they are toe's own settings — so with the borrowed
+        // level gone they go where toe's other settings are, under the config and the startup
+        // switch, in the order `ConfigSwitch` declares them.
+        //
+        // Every one of them is also a line in `toe.toml`, and the row and the file say the same
+        // thing because the row *is* the file: the value is read from the config the menu was
+        // opened with, and throwing the switch edits that line rather than remembering something
+        // beside it.
+        for setting in ConfigSwitch.allCases {
+            let on = setting.value(in: config)
+            rows.append(MenuItem(title: setting.title,
+                                 icon: on ? .toggleOn : .toggleOff,
+                                 value: on ? "on" : "off",
+                                 action: .toggleSetting(setting)))
+        }
         return rows
     }
 

--- a/Sources/ToeCore/Menu/MenuState.swift
+++ b/Sources/ToeCore/Menu/MenuState.swift
@@ -7,7 +7,7 @@ public enum MenuOutcome: Equatable {
     case closed
     case run(Command)
     case toggleLoginItem
-    case toggleSlide
+    case toggleSetting(ConfigSwitch)
     case page(MenuPage)
     /// Nothing under the cursor — an empty list, filtered down to no rows at all.
     case none
@@ -144,8 +144,8 @@ public struct MenuState: Equatable {
             return .run(command)
         case .toggleLoginItem:
             return .toggleLoginItem
-        case .toggleSlide:
-            return .toggleSlide
+        case .toggleSetting(let setting):
+            return .toggleSetting(setting)
         case .note:
             // Pressing it does nothing, and `.none` is what the menu already does when there is
             // nothing to do — the panel stays open on the row you are looking at.

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -2198,7 +2198,7 @@ h.test("the filter matches a subsequence rather than a substring") { t in
 }
 
 h.test("typing puts the selection back at the top") { t in
-    var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 10)
+    var m = MenuState(root: MenuModel.root(loginItem: .off, config: Config()), visibleRows: 10)
     m.move(by: 2)
     t.equal(m.selection, 2, "moved down two")
     m.type("q")
@@ -2207,7 +2207,7 @@ h.test("typing puts the selection back at the top") { t in
 }
 
 h.test("a submenu is entered, backed out of, and clears the query on the way in") { t in
-    var m = MenuState(root: MenuModel.root(loginItem: .on, bindings: []), visibleRows: 10)
+    var m = MenuState(root: MenuModel.root(loginItem: .on, config: Config()), visibleRows: 10)
     t.equal(m.prompt, "Go…", "walker's placeholder at the root")
     m.type("setup")
     t.equal(m.visible.count, 1, "one row matches 'setup'")
@@ -2215,13 +2215,15 @@ h.test("a submenu is entered, backed out of, and clears the query on the way in"
     t.equal(m.query, "", "the query does not follow you into the submenu")
     t.equal(m.breadcrumb, ["Setup"], "the level is named")
     t.equal(m.prompt, "Setup…", "and the placeholder says where you are")
-    t.equal(m.visible.map(\.title), ["Run on startup"], "what toe can actually change for you")
+    t.equal(m.visible.map(\.title),
+            ["Run on startup", "Workspace slide", "Focus border", "Auto-hide Dock"],
+            "what toe can actually change for you")
     t.equal(m.pop(), .popped, "Escape climbs one level")
     t.equal(m.pop(), .closed, "and closes at the root")
 }
 
 h.test("backspace eats the query, then leaves the submenu") { t in
-    var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 10)
+    var m = MenuState(root: MenuModel.root(loginItem: .off, config: Config()), visibleRows: 10)
     m.type("learn")
     t.equal(m.activate(), .pushed, "into Learn")
     m.type("ke")
@@ -2259,14 +2261,14 @@ h.test("an empty field is not a match") { t in
 }
 
 h.test("typing searches the whole tree, not the level in front of you") { t in
-    var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 10)
+    var m = MenuState(root: MenuModel.root(loginItem: .off, config: Config()), visibleRows: 10)
     m.type("startup")
     t.equal(m.visible.map(\.title), ["Run on startup"],
             "found two levels down without anyone having to go there")
     t.equal(m.visible.first?.subtitle, "Setup", "and the row says where it lives")
     t.equal(m.activate(), .toggleLoginItem, "acting on it needs no descent either")
 
-    var deep = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 10)
+    var deep = MenuState(root: MenuModel.root(loginItem: .off, config: Config()), visibleRows: 10)
     deep.type("keyb")
     t.equal(deep.visible.map(\.title), ["Keybindings"], "the same for the other branch")
     t.equal(deep.visible.first?.subtitle, "Learn", "named by its path")
@@ -2274,7 +2276,7 @@ h.test("typing searches the whole tree, not the level in front of you") { t in
 }
 
 h.test("a branch found by searching is still a branch") { t in
-    var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 10)
+    var m = MenuState(root: MenuModel.root(loginItem: .off, config: Config()), visibleRows: 10)
     m.type("learn")
     t.equal(m.visible.map(\.title), ["Learn"], "the branch itself matches, not only its children")
     t.equal(m.visible.first?.subtitle, nil, "a row at the level you are on has no path to show")
@@ -2282,7 +2284,7 @@ h.test("a branch found by searching is still a branch") { t in
 }
 
 h.test("a searched list carries no icons") { t in
-    var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 20)
+    var m = MenuState(root: MenuModel.root(loginItem: .off, config: Config()), visibleRows: 20)
     t.expect(m.visible.contains { $0.icon != nil }, "a level draws its glyphs")
     m.type("e")
     t.expect(m.visible.count > 1, "the search turns up rows from several levels")
@@ -2293,23 +2295,23 @@ h.test("a searched list carries no icons") { t in
 }
 
 h.test("an empty query is one level at a time, with no paths") { t in
-    var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 10)
+    var m = MenuState(root: MenuModel.root(loginItem: .off, config: Config()), visibleRows: 10)
     m.type("z")
     t.equal(m.visible.count, 0, "nothing matches")
     m.backspace()
-    t.equal(m.visible.map(\.title), ["Learn", "Trigger", "Style", "Setup", "Quit"], "the level comes back")
+    t.equal(m.visible.map(\.title), ["Learn", "Style", "Setup", "Quit"], "the level comes back")
     t.expect(m.visible.allSatisfy { $0.subtitle == nil },
              "and the paths go away with the search that needed them")
 }
 
 h.test("the rows lead where the menu says they do") { t in
-    var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 10)
-    t.equal(m.visible.map(\.title), ["Learn", "Trigger", "Style", "Setup", "Quit"], "the whole menu, bare minimum")
-    t.equal(m.visible.map(\.leadsOn), [true, true, true, true, false], "four lead on, Quit acts")
+    var m = MenuState(root: MenuModel.root(loginItem: .off, config: Config()), visibleRows: 10)
+    t.equal(m.visible.map(\.title), ["Learn", "Style", "Setup", "Quit"], "the whole menu, bare minimum")
+    t.equal(m.visible.map(\.leadsOn), [true, true, true, false], "three lead on, Quit acts")
     m.type("quit")
     t.equal(m.activate(), .run(.quit), "and Quit dispatches rather than descending")
 
-    var learn = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 10)
+    var learn = MenuState(root: MenuModel.root(loginItem: .off, config: Config()), visibleRows: 10)
     learn.type("learn")
     _ = learn.activate()
     t.equal(learn.activate(), .page(.keybindings), "Learn holds the keybindings page")
@@ -2317,12 +2319,13 @@ h.test("the rows lead where the menu says they do") { t in
 
 h.test("the startup row reads the state it is handed") { t in
     func startup(_ state: LoginItemState) -> MenuItem? {
-        let root = MenuModel.root(loginItem: state, bindings: [])
+        let root = MenuModel.root(loginItem: state, config: Config())
         // By title rather than by position: Setup moves as Install and Remove come and go with
-        // the catalogue, and in the case below it is not there at all.
+        // the catalogue. The row is looked up by title too — Setup holds the slide switch as
+        // well, and in the case below the startup row is the one of the two that is missing.
         guard case .submenu(let setup)? = root.first(where: { $0.title == "Setup" })?.action
         else { return nil }
-        return setup.first
+        return setup.first { $0.title == "Run on startup" }
     }
     t.equal(startup(.on)?.value, "on", "the row shows launchd's answer, not a preference")
     t.equal(startup(.on)?.action, .toggleLoginItem, "and pressing it flips it")
@@ -2332,38 +2335,66 @@ h.test("the startup row reads the state it is handed") { t in
             + "throw is worse than one you were never offered")
 }
 
-h.test("the slide switch lives under Trigger › Toggle and reads the config") { t in
-    func row(_ on: Bool) -> MenuItem? {
-        let root = MenuModel.root(loginItem: .off, bindings: [], slideOnSwipe: on)
-        guard case .submenu(let trigger)? = root.first(where: { $0.title == "Trigger" })?.action,
-              case .submenu(let toggles)? = trigger.first(where: { $0.title == "Toggle" })?.action
-        else { return nil }
-        return toggles.first
+h.test("the switches live under Setup, and each row is the line it writes") { t in
+    func setup(_ config: Config) -> [MenuItem] {
+        let root = MenuModel.root(loginItem: .off, config: config)
+        guard case .submenu(let rows)? = root.first(where: { $0.title == "Setup" })?.action
+        else { return [] }
+        return rows
     }
-    t.equal(row(true)?.title, "Workspace slide", "toe's own row, where upstream keeps its switches")
-    t.equal(row(true)?.value, "on", "the row shows the config")
-    t.equal(row(true)?.icon, .toggleOn, "and draws it")
-    t.equal(row(false)?.value, "off", "the other way round")
-    t.equal(row(false)?.icon, .toggleOff, "likewise")
-    t.equal(row(false)?.action, .toggleSlide, "and pressing it flips it")
+    let shipped = try Config.parse(Config.defaultTOML)
+    t.equal(setup(shipped).map(\.title).suffix(3),
+            ["Workspace slide", "Focus border", "Auto-hide Dock"],
+            "toe's own switches, under the config and the startup row")
 
-    var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 10,
-                      path: MenuRoute.toggle.path)
-    t.equal(m.breadcrumb, ["Trigger", "Toggle"], "`menu toggle` opens on the level")
-    t.equal(m.activate(), .toggleSlide, "and Return asks the app layer to throw the switch")
-    t.equal(try CommandParser.parse("menu toggle"), .menu(.toggle), "Omarchy's alias for the level")
-    t.equal(try CommandParser.parse("menu trigger"), .menu(.trigger), "and its parent")
+    // Each switch is checked through the writer the menu throws it with, against the parser the
+    // config is read with: a `table` or a `key` that named nothing would leave a row that looks
+    // like it works and a file that never changes, which is the one failure the runtime guard
+    // (`Coordinator.rewriteConfig`'s verify) can only turn into a log line after the fact.
+    for setting in ConfigSwitch.allCases {
+        let was = setting.value(in: shipped)
+        let edited = ConfigWriter.setting(setting.key, to: was ? "false" : "true",
+                                          inTable: setting.table, of: Config.defaultTOML)
+        t.equal(setting.value(in: try Config.parse(edited)), !was,
+                "\(setting.rawValue): the table and the key are the ones the parser reads")
+
+        let row = setup(try Config.parse(edited)).first { $0.title == setting.title }
+        t.equal(row?.value, was ? "off" : "on", "\(setting.rawValue): the row shows the config")
+        t.equal(row?.icon, was ? .toggleOff : .toggleOn, "\(setting.rawValue): and draws it")
+        t.equal(row?.action, .toggleSetting(setting),
+                "\(setting.rawValue): and pressing it flips that switch, not another")
+    }
+
+    // What `QuickMenu` redraws the level with while the file is being read back.
+    var shown = shipped
+    ConfigSwitch.dock.set(false, in: &shown)
+    t.equal(setup(shown).first { $0.title == "Auto-hide Dock" }?.value, "off",
+            "a switch set in memory shows in the row, for the moment before the reload lands")
+    t.equal(setup(shown).first { $0.title == "Focus border" }?.value, "on", "and moves nothing else")
+
+    var m = MenuState(root: MenuModel.root(loginItem: .off, config: Config()), visibleRows: 10,
+                      path: MenuRoute.setup.path)
+    t.equal(m.breadcrumb, ["Setup"], "`menu setup` opens on the level")
+    m.type("slide")
+    t.equal(m.activate(), .toggleSetting(.slide),
+            "and Return asks the app layer to throw the switch under the cursor")
+    // The level the switches used to live on is gone, and the two routes that opened it now open
+    // the one they moved to, so a config written when the slide was three levels down still works.
+    t.equal(try CommandParser.parse("menu toggle"), .menu(.setup), "Omarchy's alias follows the rows")
+    t.equal(try CommandParser.parse("menu trigger"), .menu(.setup), "and so does its parent")
 }
 
 h.test("the Config row is your binding, not toe's idea of an editor") { t in
     func rows(_ toml: String, loginItem: LoginItemState = .off) throws -> [MenuItem] {
-        MenuModel.setup(loginItem: loginItem, bindings: try Config.parse(toml).bindings)
+        MenuModel.setup(loginItem: loginItem, config: try Config.parse(toml))
     }
 
     // The shipped config: the row runs exactly the line the file bound, character for character.
     // Omarchy's `setup.config` first, then toe's own row — the ported rows lead.
     let shipped = try rows(Config.defaultTOML)
-    t.equal(shipped.map(\.title), ["Config", "Run on startup"], "both rows, Omarchy's leading")
+    t.equal(shipped.map(\.title),
+            ["Config", "Run on startup", "Workspace slide", "Focus border", "Auto-hide Dock"],
+            "every row, Omarchy's leading")
     t.equal(shipped.first?.action,
             .run(.exec("open -a \"Visual Studio Code\" ~/.config/toe/toe.toml")),
             "and it opens the config the way your config says to")
@@ -2380,29 +2411,34 @@ h.test("the Config row is your binding, not toe's idea of an editor") { t in
 
     // An exec that opens something else is not an editor for this file.
     let unrelated = try rows("[binds]\n\"super-enter\" = \"exec open -a Ghostty\"\n")
-    t.equal(unrelated.map(\.title), ["Run on startup"],
+    t.equal(unrelated.map(\.title),
+            ["Run on startup", "Workspace slide", "Focus border", "Auto-hide Dock"],
             "no binding that opens the config, no row offering to")
     t.equal(MenuModel.root(loginItem: .unavailable("needs /Applications"),
-                           bindings: try Config.parse("[binds]\n\"super-enter\" = \"exec open -a Ghostty\"\n").bindings)
+                           config: try Config.parse("[binds]\n\"super-enter\" = \"exec open -a Ghostty\"\n"))
                 .map(\.title),
-            ["Learn", "Trigger", "Style", "Quit"],
-            "and with the startup row gone as well, Setup has nothing left to hold")
+            ["Learn", "Style", "Setup", "Quit"],
+            "and with the startup row gone as well, Setup is down to the switch that always works")
 
     // The row is there even when the startup toggle cannot be.
     let buildDir = try rows(Config.defaultTOML, loginItem: .unavailable("needs /Applications"))
-    t.equal(buildDir.map(\.title), ["Config"], "the one row that works is still offered")
+    t.equal(buildDir.map(\.title),
+            ["Config", "Workspace slide", "Focus border", "Auto-hide Dock"],
+            "the rows that work are still offered")
 }
 
-h.test("Setup goes with the startup row, being all that was left in it") { t in
-    let m = MenuState(root: MenuModel.root(loginItem: .unavailable("needs /Applications"), bindings: []),
+h.test("Setup holds the rows that work, and the startup one is not always among them") { t in
+    var m = MenuState(root: MenuModel.root(loginItem: .unavailable("needs /Applications"), config: Config()),
                       visibleRows: 10)
-    t.equal(m.visible.map(\.title), ["Learn", "Trigger", "Style", "Quit"],
-            "a row that leads into an empty level is worse than no row")
+    t.equal(m.visible.map(\.title), ["Learn", "Style", "Setup", "Quit"],
+            "Setup stays, on the strength of the one row that cannot be unavailable")
+    m.type("startup")
+    t.equal(m.visible.count, 0, "and the search cannot turn up the row that is not there")
 
-    var searching = MenuState(root: MenuModel.root(loginItem: .unavailable("needs /Applications"), bindings: []),
-                              visibleRows: 10)
-    searching.type("startup")
-    t.equal(searching.visible.count, 0, "and the search cannot turn it up either")
+    var slide = MenuState(root: MenuModel.root(loginItem: .unavailable("needs /Applications"),
+                                               config: Config()), visibleRows: 10)
+    slide.type("slide")
+    t.equal(slide.visible.map(\.subtitle), ["Setup"], "while the switch is found under Setup")
 }
 
 h.test("the second column never runs into the title") { t in
@@ -2573,7 +2609,7 @@ h.test("a filling row is the row cut off at the fraction") { t in
 }
 
 h.test("rebuilding under an open menu leaves you where you were standing") { t in
-    var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: [],
+    var m = MenuState(root: MenuModel.root(loginItem: .off, config: Config(),
                                            style: downloadingStyle(fetching: 1, bytesDone: 0)), visibleRows: 10)
     // Down into Install › Style › Theme, the way a user gets to a theme they have not got.
     while m.selectedItem?.title != "Install" { m.move(by: 1) }
@@ -2588,7 +2624,7 @@ h.test("rebuilding under an open menu leaves you where you were standing") { t i
 
     // A picture lands. The whole tree is rebuilt, because the level in front of the user is two
     // rungs down and the menu cannot know which of MenuModel's builders made it.
-    m.rebuild(root: MenuModel.root(loginItem: .off, bindings: [],
+    m.rebuild(root: MenuModel.root(loginItem: .off, config: Config(),
                                    style: downloadingStyle(fetching: 5, bytesDone: 2_400_000)))
     t.equal(m.breadcrumb, ["Install", "Style", "Theme"], "still on the level it was on")
     t.equal(m.selection, standingOn, "still on the row it was on")
@@ -2602,7 +2638,7 @@ h.test("a rebuild that cannot re-enter a level surfaces one rung up") { t in
     // none takes the level the user is standing in out from under them. Real, not defensive.
     let withPictures = StyleMenu(themes: [ThemeRef(slug: "gruvbox", name: "Gruvbox")],
                                  current: "gruvbox", backgrounds: ["1-a.jpg", "2-b.jpg"])
-    var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: [], style: withPictures),
+    var m = MenuState(root: MenuModel.root(loginItem: .off, config: Config(), style: withPictures),
                       visibleRows: 10)
     while m.selectedItem?.title != "Style" { m.move(by: 1) }
     _ = m.activate()
@@ -2613,7 +2649,7 @@ h.test("a rebuild that cannot re-enter a level surfaces one rung up") { t in
 
     let withNone = StyleMenu(themes: [ThemeRef(slug: "vantablack", name: "Vantablack")],
                              current: "vantablack")
-    m.rebuild(root: MenuModel.root(loginItem: .off, bindings: [], style: withNone))
+    m.rebuild(root: MenuModel.root(loginItem: .off, config: Config(), style: withNone))
     // Not an error and not an empty level: the deepest level that still exists.
     t.equal(m.breadcrumb, ["Style"], "the level went away, so the user comes up to Style")
     t.equal(m.visible.map(\.title), ["Theme"], "which no longer offers Background at all")
@@ -2621,21 +2657,21 @@ h.test("a rebuild that cannot re-enter a level surfaces one rung up") { t in
 }
 
 h.test("the fetching note appears and goes away without the menu being reopened") { t in
-    var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: [],
+    var m = MenuState(root: MenuModel.root(loginItem: .off, config: Config(),
                                            style: StyleMenu(fetching: true)),
                       visibleRows: 10, path: ["Install", "Style", "Theme"])
     t.equal(m.visible.map(\.title), ["Fetching Omarchy's themes…"],
             "a machine with nothing yet, mid-fetch")
 
     // The catalogue arrives. This is what `ThemeCatalogue.onChange` now reaches.
-    m.rebuild(root: MenuModel.root(loginItem: .off, bindings: [], style: StyleMenu(
+    m.rebuild(root: MenuModel.root(loginItem: .off, config: Config(), style: StyleMenu(
         available: [RemoteTheme(slug: "nord", name: "Nord", backgrounds: [])], fetching: false)))
     t.equal(m.visible.map(\.title), ["Nord"],
             "the note gives way to the themes it was waiting for")
 }
 
 h.test("the selection clamps at both ends") { t in
-    var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: []), visibleRows: 10)
+    var m = MenuState(root: MenuModel.root(loginItem: .off, config: Config()), visibleRows: 10)
     m.move(by: -1)
     t.equal(m.selection, 0, "up from the top stays at the top — a list is not a carousel")
     m.move(by: 99)
@@ -3574,11 +3610,11 @@ h.test("a backgrounds folder is filtered and sorted the same way twice") { t in
 
 h.test("Style is always at the root, because it is how you get a theme at all") { t in
     let m = MenuState(root: MenuModel.root(loginItem: .unavailable("needs /Applications"),
-                                           bindings: []), visibleRows: 10)
+                                           config: Config()), visibleRows: 10)
     // Unlike Setup, which goes when both its rows are unavailable, Style stays even on a
     // machine with no themes and no network: it is the level you go to *to* get one, so leaving
     // it out exactly when it is most needed would be the wrong way round.
-    t.equal(m.visible.map(\.title), ["Learn", "Trigger", "Style", "Quit"], "still there with nothing behind it")
+    t.equal(m.visible.map(\.title), ["Learn", "Style", "Setup", "Quit"], "still there with nothing behind it")
     t.equal(MenuModel.style(StyleMenu()).map(\.title), ["Theme"],
             "holding the theme list, and no Background row until there are pictures")
 }
@@ -3690,7 +3726,7 @@ h.test("the Background level is shaped like the Theme level above it") { t in
 
 h.test("a theme can be found by typing its name from the root") { t in
     let style = StyleMenu(themes: [ThemeRef(slug: "gruvbox", name: "Gruvbox")])
-    var m = MenuState(root: MenuModel.root(loginItem: .off, bindings: [], style: style),
+    var m = MenuState(root: MenuModel.root(loginItem: .off, config: Config(), style: style),
                       visibleRows: 10)
     m.type("gruv")
     // Twice, because a theme on the disk is two rows now: the one that wears it and the one that
@@ -3701,7 +3737,7 @@ h.test("a theme can be found by typing its name from the root") { t in
             "and each says where it was found")
     t.equal(m.activate(), .run(.theme("gruvbox")), "the first is the one that wears it")
 
-    var picture = MenuState(root: MenuModel.root(loginItem: .off, bindings: [],
+    var picture = MenuState(root: MenuModel.root(loginItem: .off, config: Config(),
                                                  style: StyleMenu(current: "gruvbox",
                                                                   backgrounds: ["city.jpg"])),
                             visibleRows: 10)
@@ -3714,19 +3750,21 @@ h.test("a theme can be found by typing its name from the root") { t in
 h.test("the root is Omarchy's root, with what a Mac cannot do left out") { t in
     // Upstream's order is Apps, Learn, Trigger, Style, Setup, Install, Remove, Update, About,
     // System. Every row toe has an analogue for, in that order, and Quit — which has no
-    // counterpart, Omarchy's System being a power menu for the machine — last.
+    // counterpart, Omarchy's System being a power menu for the machine — last. Trigger is not
+    // among them: the eight rows upstream hangs off it are Linux tools bar one, and that one
+    // switch is a Setup row here rather than two levels of scaffolding holding it up.
     let full = StyleMenu(themes: [ThemeRef(slug: "gruvbox", name: "Gruvbox")],
                          available: [RemoteTheme(slug: "nord", name: "Nord", backgrounds: [])],
                          current: "gruvbox", backgrounds: ["a.jpg"])
     let c = try Config.parse(Config.defaultTOML)
-    let rows = MenuModel.root(loginItem: .off, bindings: c.bindings, style: full, version: "0.9.7")
+    let rows = MenuModel.root(loginItem: .off, config: c, style: full, version: "0.9.7")
     t.equal(rows.map(\.title),
-            ["Learn", "Trigger", "Style", "Setup", "Install", "Remove", "About", "Quit"],
+            ["Learn", "Style", "Setup", "Install", "Remove", "About", "Quit"],
             "the same names at the same depth, in the same order")
     t.equal(rows.first { $0.title == "About" }?.value, "0.9.7",
             "About is the one fact toe can report about itself, in the second column")
     t.equal(rows.first { $0.title == "About" }?.action, .note, "and nothing to press")
-    t.expect(MenuModel.root(loginItem: .off, bindings: c.bindings, style: full)
+    t.expect(MenuModel.root(loginItem: .off, config: c, style: full)
                 .allSatisfy { $0.title != "About" },
              "a build with no stamped version leaves the row out rather than saying `unknown`")
 }
@@ -3745,7 +3783,7 @@ h.test("Learn is the keybindings and the three manuals that are about this machi
 h.test("a binding can open the menu at a level, the way omarchy-menu toggle does") { t in
     let style = StyleMenu(themes: [ThemeRef(slug: "gruvbox", name: "Gruvbox")],
                           current: "gruvbox", backgrounds: ["city.jpg", "coast.jpg"])
-    let root = MenuModel.root(loginItem: .off, bindings: [], style: style)
+    let root = MenuModel.root(loginItem: .off, config: Config(), style: style)
 
     var m = MenuState(root: root, visibleRows: 10, path: MenuRoute.background.path)
     t.equal(m.breadcrumb, ["Style", "Background"], "opened three rows in")
@@ -3756,7 +3794,7 @@ h.test("a binding can open the menu at a level, the way omarchy-menu toggle does
 
     // A route that does not resolve stops where it can rather than failing: Background exists
     // only while the current theme has pictures, and the key is bound whether it does or not.
-    let bare = MenuState(root: MenuModel.root(loginItem: .off, bindings: [], style: StyleMenu()),
+    let bare = MenuState(root: MenuModel.root(loginItem: .off, config: Config(), style: StyleMenu()),
                          visibleRows: 10, path: MenuRoute.background.path)
     t.equal(bare.breadcrumb, ["Style"], "as deep as the tree goes, and no error")
     t.equal(MenuState(root: root, visibleRows: 10).breadcrumb, [],

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -224,7 +224,7 @@ final class Coordinator: WindowTrackerDelegate {
             self.dispatch(binding.command)
         }
         quickMenu.onCommand = { [weak self] command in self?.dispatch(command) }
-        quickMenu.onToggleSlide = { [weak self] in self?.toggleSlide() ?? false }
+        quickMenu.onToggleSetting = { [weak self] setting in self?.toggle(setting) ?? false }
         // Dragging a tiled window over another one trades their places, live, the way
         // Hyprland's `IHyprLayout::onMouseMove` does.
         drag.onMove = { [weak self] id, point in
@@ -672,21 +672,34 @@ final class Coordinator: WindowTrackerDelegate {
                       verify: { Slug.make($0.theme.name) == slug })
     }
 
-    /// Flips `animations.slide_on_swipe` in the config file, for the menu's Toggle row, and
-    /// answers the value now in effect.
+    /// Flips one of the menu's Setup switches in the config file and answers the value now in
+    /// effect. Which line to write is the switch's own business — see `ConfigSwitch`.
     ///
     /// Through the file rather than flipped in memory, because the file is where the setting
-    /// lives: a flip the next reload put back would be a switch that throws itself. Going through
-    /// the file also means the first `on` arrives by `applyAnimationSetting` and asks for Screen
-    /// Recording with the menu open on the row that asked — the one moment the prompt has a
-    /// context, and better than a config save nobody was watching.
-    private func toggleSlide() -> Bool {
-        let wanted = !config.animations.slideOnSwipe
-        rewriteConfig("slide", edit: {
-            ConfigWriter.setting("slide_on_swipe", to: wanted ? "true" : "false",
-                                 inTable: "animations", of: $0)
-        }, verify: { $0.animations.slideOnSwipe == wanted })
-        return config.animations.slideOnSwipe
+    /// lives: a flip the next reload put back would be a switch that throws itself. It also means
+    /// the reload does the work — `border.apply` for the border, `applyMiscSettings` for the
+    /// Dock — so the switch and the config file that says the same thing take the same path, and
+    /// there is nothing here that only happens when a menu row was the one to ask.
+    ///
+    /// For the slide that path matters twice over: the first `on` arrives by
+    /// `applyAnimationSetting` and asks for Screen Recording with the menu open on the row that
+    /// asked — the one moment the prompt has a context, and better than a config save nobody was
+    /// watching.
+    private func toggle(_ setting: ConfigSwitch) -> Bool {
+        let wanted = !setting.value(in: config)
+        rewriteConfig(setting.key, edit: {
+            ConfigWriter.setting(setting.key, to: wanted ? "true" : "false",
+                                 inTable: setting.table, of: $0)
+        }, verify: { setting.value(in: $0) == wanted })
+        let now = setting.value(in: config)
+        // The Dock is the one switch the reload above does not always act on: `autohide_dock` is
+        // toe making sure the strip is there, and it leaves a Dock you hide yourself alone, so on
+        // that machine the row would sit there saying `off` beside a Dock that never moved. The
+        // switch says what it does instead — see `DockAutoHide.command`. Only when the file
+        // actually changed: a write that was declined leaves the row, the file and the Dock
+        // agreeing on the old value rather than the Dock alone on the new one.
+        if setting == .dock, now == wanted { DockAutoHide.command(now) }
+        return now
     }
 
     /// Edits `toe.toml` in place and reloads. `what` names the caller in the log.

--- a/Sources/toe/DockAutoHide.swift
+++ b/Sources/toe/DockAutoHide.swift
@@ -26,6 +26,11 @@ import Foundation
 /// Like a symbolic hotkey, **this state outlives the process**, so it is handled the same way:
 /// journalled to disk *before* the change, and a journal found at startup is replayed, which is
 /// what repairs a crash, a force-quit or a logout.
+///
+/// **Two ways in, meaning two different things.** `enable`/`restore` are the config key being
+/// *maintained*: toe hands the strip back if you were not already hiding the Dock yourself, and
+/// gives back exactly what it took. `command` is the menu's switch being *thrown*: you are asking
+/// for the Dock to be a way, now, so it is told either way and toe stops owing you anything back.
 enum DockAutoHide {
 
     /// `Boolean` in C is an `unsigned char`, not a `_Bool`. The two are passed and returned
@@ -74,10 +79,12 @@ enum DockAutoHide {
     /// The read below is only safe because of *when* this is called. `CoreDockSetAutoHideEnabled`
     /// messages the Dock rather than writing a value, and `CoreDockGetAutoHideEnabled` lags that
     /// round trip by a few hundred milliseconds — so a read taken straight after a write reports
-    /// the old state. `applyMiscSettings` calls this at startup and on a config reload, where
-    /// nothing has just written, and `previous` short-circuits every call after the first. Anything
-    /// that wants to flip auto-hiding on demand — a binding, a menu row — must not re-read to find
-    /// out what it did; `previous` is the answer.
+    /// the old state. `applyMiscSettings` calls this at startup and on a config reload, and
+    /// `previous` short-circuits every call after the first. The one reload that *does* follow a
+    /// write is the menu's own switch, and the write there is `command`'s, which happens after
+    /// this has run: the next reload is another keystroke away, which is a long time beside a few
+    /// hundred milliseconds. Nothing here may re-read to find out what it just did — `previous` is
+    /// the answer.
     static func enable() {
         guard previous == nil, let getAutoHide, let setAutoHide else { return }
         guard getAutoHide() == 0 else { return }
@@ -102,6 +109,30 @@ enum DockAutoHide {
         previous = nil
         clearJournal()
         Log.info("dock: auto-hide restored")
+    }
+
+    /// The menu's switch, thrown: makes the Dock match, whatever the two above decided.
+    ///
+    /// Called after the config file has been written and reloaded, so `enable` or `restore` has
+    /// already run and has already done the right thing in every case where toe is the one
+    /// holding the setting. What is left is the case they deliberately leave alone — a Dock you
+    /// auto-hide yourself, which `restore` will not switch off because `enable` never switched it
+    /// on. Maintaining the config key, that silence is correct; it is not toe's preference to
+    /// take. A row you just pressed is not that: it is you asking, about your own Dock, so the
+    /// Dock is told.
+    ///
+    /// Nothing is journalled, and a journal that was there is dropped: throwing the switch by
+    /// hand hands the setting *to you*, so from here toe owes nothing back. Without that, a Dock
+    /// you asked to hide from the menu would be given back to you showing at quit — `enable`
+    /// having journalled `off` a moment earlier, on the strength of a state you had already
+    /// changed your mind about — and a switch that undoes itself when toe exits is the thing the
+    /// journal exists to prevent, pointed the wrong way.
+    static func command(_ on: Bool) {
+        guard let setAutoHide else { return }
+        setAutoHide(on ? 1 : 0)
+        previous = nil
+        clearJournal()
+        Log.info("dock: auto-hide \(on ? "on" : "off"), from the menu")
     }
 
     /// Replays a journal left behind by a toe that did not get to restore — a crash, a `kill -9`,

--- a/Sources/toe/UI/MenuFont.swift
+++ b/Sources/toe/UI/MenuFont.swift
@@ -103,8 +103,6 @@ enum MenuFont {
         case .power:     return "\u{F011}"   // nf-fa-power_off
         case .toggleOn:  return "\u{F205}"   // nf-fa-toggle_on
         case .toggleOff: return "\u{F204}"   // nf-fa-toggle_off
-        case .rocket:    return "\u{F135}"   // nf-fa-rocket — upstream draws Trigger as one too
-        case .sliders:   return "\u{F1DE}"   // nf-fa-sliders
         case .paintbrush: return "\u{F1FC}"  // nf-fa-paint_brush
         case .droplet:   return "\u{F043}"   // nf-fa-tint
         case .image:     return "\u{F03E}"   // nf-fa-picture_o
@@ -126,8 +124,6 @@ enum MenuFont {
         case .power:     return "power"
         case .toggleOn:  return "switch.2"
         case .toggleOff: return "switch.2"
-        case .rocket:    return "bolt"
-        case .sliders:   return "slider.horizontal.3"
         case .paintbrush: return "paintbrush"
         case .droplet:   return "drop"
         case .image:     return "photo"

--- a/Sources/toe/UI/QuickMenu.swift
+++ b/Sources/toe/UI/QuickMenu.swift
@@ -29,9 +29,9 @@ final class QuickMenu {
 
     /// Where a chosen row goes. `Coordinator` hands these straight to `dispatch`.
     var onCommand: ((Command) -> Void)?
-    /// The Trigger › Toggle row for the slide: flips the setting and answers the value now in
-    /// effect, which is what the level is rebuilt with. The Coordinator owns the config file.
-    var onToggleSlide: (() -> Bool)?
+    /// A Setup switch: flips the setting and answers the value now in effect, which is what the
+    /// level is rebuilt with. The Coordinator owns the config file.
+    var onToggleSetting: ((ConfigSwitch) -> Bool)?
 
     /// What the bundle was stamped with, for the `About` row. nil for a binary run straight out
     /// of `.build`, which has no Info.plist to have been stamped — and the row is then left out
@@ -68,6 +68,16 @@ final class QuickMenu {
     /// Who was in front when the menu opened, so a stray activation can be put back.
     private var frontmostAtOpen: pid_t?
     private var observers: [any NSObjectProtocol] = []
+    /// The display layout the menu was opened on — one frame per screen, in order.
+    ///
+    /// `didChangeScreenParameters` says rather less than its name suggests: auto-hiding the Dock
+    /// is a screen-parameters change too, because `visibleFrame` moves, and so the menu's own
+    /// Auto-hide Dock row closed the menu on the row you had just pressed while every other
+    /// switch left it up. A display coming, going or changing resolution moves a `frame`, and
+    /// that is the thing the menu cannot stay open across, so that is what is compared.
+    private var screenLayout: [CGRect] = []
+
+    private static var currentScreenLayout: [CGRect] { NSScreen.screens.map(\.frame) }
 
     var isVisible: Bool { panel.isVisible }
 
@@ -126,12 +136,12 @@ final class QuickMenu {
         loginItem = LoginItem.state()
         let items = route.page == .keybindings
             ? MenuModel.keybindings(config.bindings, superKey: config.superKey)
-            : MenuModel.root(loginItem: loginItem, bindings: config.bindings, style: style,
-                             version: QuickMenu.version,
-                             slideOnSwipe: config.animations.slideOnSwipe)
+            : MenuModel.root(loginItem: loginItem, config: config, style: style,
+                             version: QuickMenu.version)
         state = MenuState(root: items, visibleRows: 10, path: route.path)
 
         frontmostAtOpen = NSWorkspace.shared.frontmostApplication?.processIdentifier
+        screenLayout = Self.currentScreenLayout
         observe()
         layoutAndRender()
         panel.makeKeyAndOrderFront(nil)
@@ -179,9 +189,8 @@ final class QuickMenu {
         guard panel.isVisible, state != nil else { return }
         if fontChanged { measure() }
         if route.page == .root {
-            state?.rebuild(root: MenuModel.root(loginItem: loginItem, bindings: config.bindings,
-                                                style: style, version: QuickMenu.version,
-                                                slideOnSwipe: config.animations.slideOnSwipe))
+            state?.rebuild(root: MenuModel.root(loginItem: loginItem, config: config,
+                                                style: style, version: QuickMenu.version))
         }
         // Through the full path rather than straight to `render()`: a level that gained or lost
         // rows — the fetching note going away, a downloaded theme moving up into the installed
@@ -263,21 +272,22 @@ final class QuickMenu {
         case .toggleLoginItem:
             // Deliberately does not close: the value flips under the cursor, as omarchy-menu's
             // toggles do, so you can see what you just did.
-            let setup = MenuModel.setup(loginItem: LoginItem.toggle(),
-                                        bindings: config.bindings)
+            let setup = MenuModel.setup(loginItem: LoginItem.toggle(), config: config)
             // The level itself rather than a row of the root: Setup is not always in the same
             // place — Install and Remove come and go with the catalogue — and on the day the
             // toggle answers `unavailable` it is not there at all.
             if !setup.isEmpty { state?.replaceLevel(with: setup) }
             layoutAndRender()
-        case .toggleSlide:
+        case .toggleSetting(let setting):
             // Same shape as the login toggle: the value flips under the cursor and the menu
             // stays. The flip goes through the config file and a reload, and that reload has
             // already handed the new config to `update` by the time the callback returns; the
-            // level is replaced from the answer all the same, so the row is right even if the
-            // reload found nothing to do.
-            let on = onToggleSlide?() ?? config.animations.slideOnSwipe
-            state?.replaceLevel(with: MenuModel.toggles(slideOnSwipe: on))
+            // level is rebuilt from the answer all the same — written into a copy of the config
+            // first — so the row is right even if the reload found nothing to do.
+            let on = onToggleSetting?(setting) ?? setting.value(in: config)
+            var shown = config
+            setting.set(on, in: &shown)
+            state?.replaceLevel(with: MenuModel.setup(loginItem: loginItem, config: shown))
             layoutAndRender()
         case .run(let command):
             // Theme rows stay — `Command.keepsMenuOpen` says why at length. Everything else
@@ -349,9 +359,12 @@ final class QuickMenu {
         guard observers.isEmpty else { return }
         add(NSWindow.didResignKeyNotification, object: panel) { [weak self] _ in self?.close() }
         // A display coming or going moves the area the menu was centred on. Closing is honest;
-        // re-centring mid-keystroke is a menu that jumps out from under the pointer.
+        // re-centring mid-keystroke is a menu that jumps out from under the pointer. A Dock that
+        // just hid itself is not that — the screens are where they were, one of them has a strip
+        // back — and the menu stays where it is, which is where you are looking.
         add(NSApplication.didChangeScreenParametersNotification, object: nil) { [weak self] _ in
-            self?.close()
+            guard let self, Self.currentScreenLayout != self.screenLayout else { return }
+            self.close()
         }
     }
 

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -72,7 +72,8 @@ name = ""
 
 [border]
 # Highlights the focused window. Omarchy's col.active_border gradient — and what you see when no
-# theme is set above, since a theme replaces both stops with one flat accent.
+# theme is set above, since a theme replaces both stops with one flat accent. SUPER+SPACE > Setup
+# has this switch as well, and rewrites this line.
 enabled      = true
 width        = 2
 active_start = "#33ccffee"
@@ -116,6 +117,10 @@ swallow_dock_swipes = true
 # the swipe switches instantly, as it does now. macOS 15 reminds you now and then that toe can
 # record the screen — it captures for the moment of a swipe and keeps nothing. The swipe only:
 # it is the gesture the Spaces slide belongs to. SUPER+1…0 and SUPER+TAB stay instant.
+#
+# SUPER+SPACE > Setup has this switch, and throwing it there rewrites this line — the menu and
+# this file are the same setting, so there is nothing to keep in step. It is also where the
+# permission prompt comes from, with the row you pressed still on screen to explain it.
 slide_on_swipe = false
 # Seconds. Spaces takes about a third of one.
 slide_duration = 0.3
@@ -147,7 +152,10 @@ disable_edge_tiling = true
 # default install, for something SUPER+SPACE reaches instead. toe turns on the setting System
 # Settings › Desktop & Dock calls "Automatically hide and show the Dock", which hands the strip
 # back and leaves the Dock one mouse-to-the-edge away, and turns it off again when it quits. A
-# Dock you already auto-hide yourself is left alone.
+# Dock you already auto-hide yourself is left alone: this line is toe making sure the strip is
+# there, not toe taking your Dock over. SUPER+SPACE > Setup has this switch too, and that one is
+# you asking rather than toe maintaining — throwing it there moves the Dock either way, including
+# back into view on a machine that was hiding it before toe ever started.
 autohide_dock = true
 
 # ⌘H and ⌘⌥H take an application's windows out of the layout without closing them — the tree


### PR DESCRIPTION
`Trigger` was a root row leading to a level leading to a level holding one switch. Upstream hangs eight rows off it and seven are Linux tools — an emoji picker, ffmpeg, a share sheet, a touchpad switch — so toe listed the whole branch for the eighth. The switch moves to `Setup`, beside the config and the startup toggle, and `Trigger` goes.

`menu trigger` and `menu toggle` now resolve to `.setup` rather than erroring, so a binding written when the slide was three levels down still opens the level holding it.

## Two more switches, and a name for the plumbing

`border.enabled` and `misc.autohide_dock` join it. The second switch would have been the third copy of the same four-place plumbing, so it got a type instead: `ConfigSwitch` carries the table, the key, `value(in:)` and `set(_:in:)`, and everything between the row and the file reads it — the menu builds a row from it, `MenuState` hands the case straight back, `Coordinator.toggle` writes that key into that table and reloads. A fourth switch is a case there and nothing anywhere else.

With three values to pass, `MenuModel.root` and `setup` take a `Config` rather than `bindings: [Binding]` plus a loose `slideOnSwipe: Bool`. The bindings were coming out of the same config anyway.

Setup now reads: Config, Run on startup, Workspace slide, Focus border, Auto-hide Dock.

## The Dock needed more than a row

`autohide_dock` is toe *making sure* the strip is there, and it leaves a Dock you already auto-hide yourself alone — `enable` takes its early exit and journals nothing, so `restore` has nothing to give back. On that machine the row sat there saying `off` beside a Dock that never moved.

A row you just pressed is not the key being maintained; it is you asking, about your own Dock. `DockAutoHide.command` tells the Dock either way and drops the journal: after a switch thrown by hand the setting is yours. Without that last part, a Dock you had just asked to hide would be handed back showing at quit, on the strength of an `off` that `enable` journalled a moment earlier and you had already changed your mind about.

## …and then it closed the menu it was on

Hiding the Dock moves `visibleFrame`, which fires `didChangeScreenParametersNotification` exactly as a display coming or going does, and `QuickMenu` closes on that. It now snapshots `NSScreen.screens.map(\.frame)` at open and closes only when one of those actually moved — so a strip of screen coming back leaves the menu where you are looking, and so does toggling the Dock in System Settings with the menu up.

## Tests

`make test` — 1267 assertions. The switch test walks `ConfigSwitch.allCases` and round-trips each one's `table`/`key` through `ConfigWriter` into `Config.parse`: a key naming nothing would otherwise look like a working row over a file that never changes, which the runtime guard can only turn into a log line after the fact. The two AX-side changes (`DockAutoHide.command`, the screen-frame comparison) are in `Sources/toe` and have no selftest coverage; both were checked by hand in `make run`.

`Icon.rocket` and `.sliders` had no rows left and are out of the enum and both `MenuFont` tables. The three keys say in `toe.toml` that Setup flips them, and `toe.example.toml` is regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X483aXCBgNCMP13tKvJqNj