### PR TITLE
Cycle the workspaces the bar is showing, and pad it only when it is short

### DIFF
--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -182,8 +182,10 @@ prevent_hiding = true
 restore_session = true
 
 [bar]
-# waybar's persistent-workspaces: Omarchy keeps slots 1-5 on the bar even when they are
-# empty, dimmed. 0 shows only the workspaces in use; 10 always shows all ten.
+# waybar's persistent-workspaces: the fewest slots the bar ever has, so a fresh session still
+# shows 1-5, the empty ones dimmed. It is a floor and not a claim on the first five: once five
+# workspaces are in use the padding has nothing left to do, and an empty 4 between a busy 3 and
+# 5 is not drawn. 0 shows only the workspaces in use; 10 always shows all ten.
 persistent_workspaces = 5
 
 [menu]
@@ -253,8 +255,9 @@ font_size  = 18
 # Same, without following the window:  "movetoworkspacesilent 3"
 
 # ── Cycling ───────────────────────────────────────────────────────────────────
-# next/prev walk only the workspaces in use — the ones with windows on them, plus whatever the
-# other displays are showing — so a press never lands on a blank slot.
+# next/prev walk exactly the slots on the menu bar — the workspaces in use, plus the empty ones
+# bar.persistent_workspaces pads them out to — so a press never lands somewhere you cannot see
+# and never skips somewhere you can.
 "super-tab"       = "workspace next"
 "super-shift-tab" = "workspace prev"
 "super-ctrl-tab"  = "workspace previous"

--- a/Sources/ToeCore/Layout/WorkspaceManager.swift
+++ b/Sources/ToeCore/Layout/WorkspaceManager.swift
@@ -72,6 +72,11 @@ public final class WorkspaceManager {
     /// How big a window is when it leaves the tree. See `centredFloatingBox`.
     public var floatingSize = FloatingSize()
 
+    /// The floor on how many slots the menu bar strip has — `bar.persistent_workspaces`. It
+    /// lives here as well as in `StatusItem` because `workspace next` / `prev` cycle the
+    /// strip, so the layout has to know how long the strip is.
+    public var persistentWorkspaces = WorkspaceStrip.defaultPersistent
+
     public init(options: DwindleOptions = DwindleOptions(), gaps: Gaps = Gaps()) {
         self.options = options
         self.gaps = gaps
@@ -528,13 +533,14 @@ public final class WorkspaceManager {
         if let prev = previousWorkspace[focusedMonitorID] { switchTo(workspace: prev) }
     }
 
-    /// `workspace e+1` / `e-1`. Cycles through the workspaces in use — the ones with windows
-    /// on them, plus whatever the monitors are showing — rather than all ten, so a press never
-    /// lands on a blank slot you would have to press past. With nothing else in use it does
-    /// nothing, and the workspace you are on always counts as one of them.
+    /// `workspace e+1` / `e-1`. Cycles through exactly what the menu bar strip is showing —
+    /// the workspaces in use, plus whatever empty ones `persistentWorkspaces` pads the strip
+    /// out to — rather than all ten. So a press never lands on a slot you cannot see, and
+    /// never skips one you can: the strip is the map, and TAB walks it. With nothing else on
+    /// it the press does nothing, and the workspace you are on is always on it.
     public func switchToRelativeWorkspace(_ delta: Int) {
         let current = focusedWorkspaceIndex
-        let ring = (1...Self.workspaceCount).filter { $0 == current || inUse(workspace: $0) }
+        let ring = WorkspaceStrip.slots(for: stripStates(), persistent: persistentWorkspaces)
         guard ring.count > 1, let position = ring.firstIndex(of: current) else { return }
         var next = (position + delta) % ring.count
         if next < 0 { next += ring.count }
@@ -812,10 +818,20 @@ public extension WorkspaceManager {
         activeWorkspace.first { $0.value == index }?.key
     }
 
-    /// Whether a workspace is one of the ones you are actually using: it holds windows, or a
-    /// monitor is showing it right now. This is what the strip draws as anything but a dim
-    /// digit, and what `workspace e+1` cycles through.
-    func inUse(workspace index: Int) -> Bool {
-        !isEmpty(workspace: index) || monitorShowing(workspace: index) != nil
+    /// Every workspace as the strip sees it — what `Coordinator` hands the menu bar, and what
+    /// `workspace e+1` cycles.
+    ///
+    /// This replaced an `inUse(workspace:)` that answered the same question one workspace at a
+    /// time. "Is this one in use" now belongs to `WorkspaceStrip.slots`, which asks it of the
+    /// whole bar at once and only then works out how much padding the answers leave room for —
+    /// a per-workspace helper cannot see the count, and the count is the rule.
+    func stripStates() -> [WorkspaceStrip.State] {
+        let focused = focusedWorkspaceIndex
+        return (1...Self.workspaceCount).map { index in
+            WorkspaceStrip.State(index: index,
+                                 isFocused: index == focused,
+                                 isVisible: monitorShowing(workspace: index) != nil,
+                                 isEmpty: isEmpty(workspace: index))
+        }
     }
 }

--- a/Sources/ToeCore/WorkspaceStrip.swift
+++ b/Sources/ToeCore/WorkspaceStrip.swift
@@ -9,8 +9,8 @@ import Foundation
 /// lands on one. `StatusItem` draws the result.
 public enum WorkspaceStrip {
 
-    /// Omarchy's waybar declares `persistent-workspaces` 1-5, so those five keep a slot on
-    /// the bar whether or not anything is on them.
+    /// Omarchy's waybar declares `persistent-workspaces` 1-5, so the bar never has fewer
+    /// than five slots on it — see `slots` for what that does and does not mean.
     public static let defaultPersistent = 5
 
     /// What the strip needs to know about one workspace.
@@ -51,13 +51,34 @@ public enum WorkspaceStrip {
         public let dim: Bool
     }
 
-    /// A workspace earns a slot by being one of the first `persistent` — Omarchy's
-    /// `persistent-workspaces` — or by having windows on it, or by being on screen right
-    /// now. So the first five are always there, and past those the strip stays as short as
-    /// what you are actually using.
+    /// Which workspaces earn a slot, in the order they were given.
+    ///
+    /// A workspace earns one on merit by having windows on it or by being on screen right
+    /// now. `persistent` — Omarchy's `persistent-workspaces` — is then a *floor on how many
+    /// slots the strip has*, not a claim on the first five indices: only if fewer than
+    /// `persistent` workspaces earned a slot is the strip padded out to that many, with the
+    /// lowest empty ones. So a fresh session shows 1-5 and six workspaces in use show six,
+    /// where taking `index <= persistent` literally used to wedge an empty 4 in between a
+    /// busy 3 and 5 that had no need of the padding. Learned at v0.15.0.
+    public static func slots(for states: [State],
+                             persistent: Int = defaultPersistent) -> [Int] {
+        let earned = states.filter { !$0.isEmpty || $0.isVisible }
+        guard earned.count < persistent else { return earned.map(\.index) }
+
+        // Pad in the order given — callers hand over 1-10 ascending, so this is Omarchy's
+        // 1, 2, 3... and stops the moment the strip is `persistent` long.
+        let padding = states.lazy
+            .filter { $0.isEmpty && !$0.isVisible }
+            .prefix(persistent - earned.count)
+        let keep = Set(earned.map(\.index)).union(padding.map(\.index))
+        return states.map(\.index).filter(keep.contains)
+    }
+
+    /// The strip itself: `slots`, each labelled and marked the way waybar does it.
     public static func items(for states: [State],
                              persistent: Int = defaultPersistent) -> [Item] {
-        states.filter { $0.index <= persistent || !$0.isEmpty || $0.isVisible }.map { state in
+        let keep = Set(slots(for: states, persistent: persistent))
+        return states.filter { keep.contains($0.index) }.map { state in
             Item(index: state.index,
                  label: state.index == 10 ? "0" : "\(state.index)",
                  marker: state.isFocused ? .focused : (state.isVisible ? .visible : .digit),

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -438,7 +438,9 @@ h.test("movetoworkspace follows the window") { t in
 }
 
 h.test("workspace next skips the workspaces nothing is on") { t in
+    // persistent 0 is the strip with no padding, so the ring is the workspaces in use.
     let wm = WorkspaceManager()
+    wm.persistentWorkspaces = 0
     wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
 
     wm.addWindow(1)                                   // workspace 1
@@ -456,13 +458,62 @@ h.test("workspace next skips the workspaces nothing is on") { t in
     t.equal(wm.focusedWorkspaceIndex, 9, "prev walks the same ring backwards")
 }
 
+h.test("workspace next walks the padded slots the strip is showing") { t in
+    // The strip you can see is the ring TAB walks: with only 1, 4 and 9 in use the padding
+    // puts 2 and 3 on the bar, so a press has to be able to reach them. 5 is not on the bar —
+    // the padding stopped at five slots — so a press must not land there either.
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
+
+    wm.addWindow(1)
+    wm.switchTo(workspace: 4); wm.addWindow(2)
+    wm.switchTo(workspace: 9); wm.addWindow(3)
+    wm.switchTo(workspace: 1)
+
+    t.equal(WorkspaceStrip.slots(for: wm.stripStates(), persistent: 5), [1, 2, 3, 4, 9],
+            "two empties pad the strip to five")
+
+    var walked: [Int] = []
+    for _ in 1...5 { wm.switchToRelativeWorkspace(1); walked.append(wm.focusedWorkspaceIndex) }
+    t.equal(walked, [2, 3, 4, 9, 1], "TAB visits every slot on the bar and rounds")
+
+    wm.switchToRelativeWorkspace(-1)
+    t.equal(wm.focusedWorkspaceIndex, 9, "prev walks the same ring backwards")
+}
+
+h.test("workspace next stops padding once the strip is full") { t in
+    // 1, 2, 3, 5, 6 and 9 in use is already six slots, so no empty workspace joins the ring —
+    // and 4, sitting between two busy neighbours, is the one a naive `index <= persistent`
+    // used to hand you on the way past.
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
+
+    var next = WindowID(1)
+    for index in [1, 2, 3, 5, 6, 9] {
+        wm.switchTo(workspace: index); wm.addWindow(next); next += 1
+    }
+    wm.switchTo(workspace: 3)
+
+    t.equal(WorkspaceStrip.slots(for: wm.stripStates(), persistent: 5), [1, 2, 3, 5, 6, 9],
+            "six in use, so nothing is padded in — 4 included")
+
+    wm.switchToRelativeWorkspace(1)
+    t.equal(wm.focusedWorkspaceIndex, 5, "next steps over the empty 4")
+}
+
 h.test("workspace next stays put when nothing else is in use") { t in
     let wm = WorkspaceManager()
+    wm.persistentWorkspaces = 0
     wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
     wm.addWindow(1)
 
     wm.switchToRelativeWorkspace(1)
     t.equal(wm.focusedWorkspaceIndex, 1, "one workspace in use, so the press does nothing")
+
+    // With Omarchy's five persistent slots there is somewhere to go, even on a fresh session.
+    wm.persistentWorkspaces = 5
+    wm.switchToRelativeWorkspace(1)
+    t.equal(wm.focusedWorkspaceIndex, 2, "the padded slots are reachable from the first press")
 }
 
 h.test("workspace next reaches a workspace another monitor is showing") { t in
@@ -2114,8 +2165,24 @@ h.test("the strip keeps Omarchy's persistent workspaces") { t in
     t.equal(fresh.map(\.dim), [false, true, true, true, true], "the empty four are dimmed")
 
     let beyond = WorkspaceStrip.items(for: states(occupied: [1, 8], focused: 1))
-    t.equal(beyond.map(\.index), [1, 2, 3, 4, 5, 8],
-            "a workspace past the persistent five appears once it has windows")
+    t.equal(beyond.map(\.index), [1, 2, 3, 4, 8],
+            "a workspace past the persistent five appears once it has windows, and the "
+            + "padding gives up a slot for it rather than adding a sixth")
+
+    // The bug: persistent is a floor on how many slots there are, not a claim on 1-5. Six
+    // workspaces in use is already past the floor, so the empty 4 between them stays off.
+    let full = WorkspaceStrip.items(for: states(occupied: [1, 2, 3, 5, 6, 9], focused: 1))
+    t.equal(full.map(\.index), [1, 2, 3, 5, 6, 9], "no empty 4 once five slots are earned")
+    t.equal(full.map(\.dim), [false, false, false, false, false, false], "and none is dimmed")
+
+    // Exactly at the floor: five in use, nothing padded, and again no empty 4.
+    let atFloor = WorkspaceStrip.items(for: states(occupied: [1, 2, 3, 5, 6], focused: 1))
+    t.equal(atFloor.map(\.index), [1, 2, 3, 5, 6], "five in use is already five slots")
+
+    // One short of it: the lowest empty workspace is padded in to make the fifth slot.
+    let oneShort = WorkspaceStrip.items(for: states(occupied: [2, 3, 5, 6], focused: 2))
+    t.equal(oneShort.map(\.index), [1, 2, 3, 5, 6], "four in use, so the lowest empty joins")
+    t.equal(oneShort.map(\.dim), [true, false, false, false, false], "the padded one is dimmed")
 
     t.equal(WorkspaceStrip.items(for: states(occupied: [1], focused: 1), persistent: 10)
                 .map(\.index), Array(1...10), "persistent 10 shows all ten")

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -441,6 +441,8 @@ final class Coordinator: WindowTrackerDelegate {
         workspaces.options = config.dwindle
         workspaces.gaps = config.gaps
         workspaces.floatingSize = config.floating
+        // Both the strip and `workspace next` read this: the bar draws the slots, TAB walks them.
+        workspaces.persistentWorkspaces = config.bar.persistentWorkspaces
         tracker.floatRules = config.floatRules
         border.apply(config.border)
         status.persistentWorkspaces = config.bar.persistentWorkspaces
@@ -931,16 +933,10 @@ final class Coordinator: WindowTrackerDelegate {
 
     /// What the strip in the menu bar title draws. This runs on every focus change and every
     /// adopted window, so it stays to what the strip actually reads — no window lists, no app
-    /// names, and above all no icons.
+    /// names, and above all no icons. It is the layout's own answer rather than a second one
+    /// built here, because `workspace next` cycles the same list.
     private func workspaceStates() -> [WorkspaceStrip.State] {
-        let focusedIndex = workspaces.focusedWorkspaceIndex
-
-        return (1...WorkspaceManager.workspaceCount).map { index in
-            WorkspaceStrip.State(index: index,
-                                 isFocused: index == focusedIndex,
-                                 isVisible: workspaces.monitorShowing(workspace: index) != nil,
-                                 isEmpty: workspaces.isEmpty(workspace: index))
-        }
+        workspaces.stripStates()
     }
 
     // MARK: - Monitors

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -173,8 +173,10 @@ prevent_hiding = true
 restore_session = true
 
 [bar]
-# waybar's persistent-workspaces: Omarchy keeps slots 1-5 on the bar even when they are
-# empty, dimmed. 0 shows only the workspaces in use; 10 always shows all ten.
+# waybar's persistent-workspaces: the fewest slots the bar ever has, so a fresh session still
+# shows 1-5, the empty ones dimmed. It is a floor and not a claim on the first five: once five
+# workspaces are in use the padding has nothing left to do, and an empty 4 between a busy 3 and
+# 5 is not drawn. 0 shows only the workspaces in use; 10 always shows all ten.
 persistent_workspaces = 5
 
 [menu]
@@ -244,8 +246,9 @@ font_size  = 18
 # Same, without following the window:  "movetoworkspacesilent 3"
 
 # ── Cycling ───────────────────────────────────────────────────────────────────
-# next/prev walk only the workspaces in use — the ones with windows on them, plus whatever the
-# other displays are showing — so a press never lands on a blank slot.
+# next/prev walk exactly the slots on the menu bar — the workspaces in use, plus the empty ones
+# bar.persistent_workspaces pads them out to — so a press never lands somewhere you cannot see
+# and never skips somewhere you can.
 "super-tab"       = "workspace next"
 "super-shift-tab" = "workspace prev"
 "super-ctrl-tab"  = "workspace previous"


### PR DESCRIPTION
Two halves of one rule that had drifted apart.

### The strip drew an empty workspace it had no need of

`bar.persistent_workspaces` was read as a claim on indices 1-5 — `items` kept a slot for any `index <= persistent`. With 1, 2, 3, 5, 6 and 9 in use, an empty 4 was still drawn between two busy neighbours, even though six slots were already earned and the minimum had nothing left to do.

It is now a floor on how many slots there are. A workspace earns one by holding windows or being on screen; only a strip shorter than `persistent` is padded out, with the lowest empty ones. `WorkspaceStrip.slots` is that rule and `items` draws it.

| in use | before | after |
| --- | --- | --- |
| 1 | `1 2 3 4 5` | `1 2 3 4 5` |
| 1, 8 | `1 2 3 4 5 8` | `1 2 3 4 8` |
| 1, 2, 3, 5, 6, 9 | `1 2 3 4 5 6 9` | `1 2 3 5 6 9` |

The middle row is a deliberate consequence: padding gives up a slot rather than adding a sixth, which is what a minimum of five says.

### TAB and the swipe skipped the slots you could see

`workspace next` / `prev` built their own ring from an `inUse(workspace:)` that knew nothing about padding, so they walked only the occupied workspaces and stepped straight past the dimmed slots sitting right there on the bar. They now cycle `WorkspaceStrip.slots` over the same states the menu bar draws — the strip is the map, and a press never lands somewhere you cannot see or skips somewhere you can. The dock swipe comes through the same `switchWorkspace(.next)` and inherited it.

That is why `persistent_workspaces` is plumbed into `WorkspaceManager` as well as `StatusItem`.

### Along the way

- `inUse(workspace:)` had no callers left and is gone. It answered per workspace, and the count is the rule.
- `Coordinator.workspaceStates()` returns the layout's `stripStates()` instead of building a second copy of the same list.
- `toe.example.toml` regenerated; both config comments say what the setting now means.

### Testing

`make test` — 1278 assertions pass, including new coverage for the six-in-use case, the exactly-at-the-floor case, one short of it, and TAB walking the padded ring both ways. Verified in the running app with `make run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X483aXCBgNCMP13tKvJqNj
