### PR TITLE
Bring a window's workspace up when something else focuses it

### DIFF
--- a/Sources/ToeCore/Layout/WorkspaceManager.swift
+++ b/Sources/ToeCore/Layout/WorkspaceManager.swift
@@ -529,6 +529,31 @@ public final class WorkspaceManager {
         refocusVisible()
     }
 
+    /// A window has taken the focus without toe asking for it — an application's Dock icon,
+    /// Cmd-Tab, Spotlight, a link opening in a browser that is not on screen — and the window
+    /// the system just focused may be sitting on a workspace that is not showing.
+    ///
+    /// The window is not pushed away: its workspace is brought to it, the same answer
+    /// `settleFullscreenReturns` gives a window coming back from a fullscreen Space. Anything
+    /// else means the click did nothing at all — the window stays parked at `stashPoint` with
+    /// the focus on it, which is exactly the bug this fixes.
+    ///
+    /// Returns whether a workspace switch was needed, because the two cases cost the caller
+    /// very different amounts of work: the focus landing where it could already be seen wants
+    /// the border moved, while this wants the whole workspace written out.
+    @discardableResult
+    public func revealWindow(_ id: WindowID) -> Bool {
+        guard let index = workspaceIndex(of: id) else { return false }
+        let hidden = !visibleWorkspaceIndices.contains(index)
+        if hidden { switchTo(workspace: index) }
+        // After the switch and not before: `switchTo` ends in `refocusVisible`, which hands the
+        // focus to the arriving workspace's own most recently used window — and that is not the
+        // window the user has just asked for. On a workspace that was already showing this is
+        // the plain `noteFocus` this call replaces.
+        noteFocus(id)
+        return hidden
+    }
+
     public func switchToPreviousWorkspace() {
         if let prev = previousWorkspace[focusedMonitorID] { switchTo(workspace: prev) }
     }

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -762,6 +762,55 @@ h.test("a workspace of nothing but detached windows still walks") { t in
     t.equal(wm.windowInDirection(.right, from: 2), nil, "at either end of it")
 }
 
+// Clicking an application's Dock icon focuses its window wherever that window is. Before
+// `revealWindow` the focus went into the model and nothing else moved, so the click looked like
+// it had done nothing at all: the window stayed parked off-screen with the focus on it.
+h.test("focusing a window on a hidden workspace brings its workspace up") { t in
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
+    wm.addWindow(1); wm.addWindow(2)
+    wm.switchTo(workspace: 2)
+    wm.addWindow(3)
+
+    t.equal(wm.render().stashed, [1, 2], "workspace 1 is parked off-screen")
+    t.equal(wm.revealWindow(1), true, "w1 was not on screen, so its workspace had to come up")
+    t.equal(wm.focusedWorkspaceIndex, 1, "which is workspace 1")
+    t.equal(wm.focusedWindow, 1, "and the window the focus landed on is the focused one")
+    t.equal(wm.render().stashed, [3], "workspace 2 is parked in its place")
+
+    // Not `focusHistory`'s most recent window on the arriving workspace — w2 was focused there
+    // more recently than w1 — but the window that was actually clicked.
+    wm.switchTo(workspace: 2)
+    t.equal(wm.revealWindow(2), true, "w2 is off-screen again")
+    t.equal(wm.focusedWindow, 2, "and it is what the focus follows, not w1")
+
+    // A window that is already on screen asks for no switch: the caller only has a border to move.
+    t.equal(wm.revealWindow(1), false, "w1 is on the workspace that is showing")
+    t.equal(wm.focusedWindow, 1, "and takes the focus where it stands")
+    t.equal(wm.focusedWorkspaceIndex, 1, "nothing switched")
+
+    t.equal(wm.revealWindow(99), false, "a window toe does not manage reveals nothing")
+}
+
+h.test("revealing a window on another monitor's workspace follows it there") { t in
+    let left = box(0, 0, 1512, 982)
+    let right = box(1512, 0, 1920, 1080)
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: left, usable: left),
+                    Monitor(id: 2, frame: right, usable: right)])
+
+    let leftWS = wm.activeWorkspace[1]!
+    let rightWS = wm.activeWorkspace[2]!
+    wm.switchTo(workspace: leftWS); wm.addWindow(1)
+    wm.switchTo(workspace: rightWS); wm.addWindow(2)
+
+    // Both workspaces are showing — one per monitor — so nothing is stashed and nothing switches.
+    // The focus still has to cross to the other display, which is `noteFocus`'s job.
+    t.equal(wm.revealWindow(1), false, "w1's workspace is on screen, on the other monitor")
+    t.equal(wm.focusedWorkspaceIndex, leftWS, "the focused monitor followed it")
+    t.equal(wm.focusedWindow, 1, "and w1 has the focus")
+}
+
 h.test("a floating window keeps its frame across a workspace round trip") { t in
     let wm = WorkspaceManager()
     wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -1245,14 +1245,42 @@ final class Coordinator: WindowTrackerDelegate {
 
     func windowFocused(_ id: WindowID) {
         guard workspaces.workspaceIndex(of: id) != nil, !isEchoOfOwnRaise(id) else { return }
-        workspaces.noteFocus(id)
+        // Following the focus onto a workspace that is not showing is right only when the user
+        // asked for it. Clicking an application's Dock icon, Cmd-Tab and Spotlight all activate
+        // the application as they focus its window; an application raising a window of its own
+        // accord does not, and yanking the screen away from the user for that is the behaviour
+        // Hyprland keeps behind `focus_on_activate` and leaves off. The same test `isEchoOfOwnRaise`
+        // makes, for the same reason: a focus that comes with an activation is a person's doing.
+        let activated = tracker.window(id).map {
+            NSWorkspace.shared.frontmostApplication?.processIdentifier == $0.pid
+        } ?? false
+        let revealed: Bool
+        if activated {
+            revealed = workspaces.revealWindow(id)
+        } else {
+            workspaces.noteFocus(id)
+            revealed = false
+        }
+        // The system has already given this window the focus — that is what brought us here — so
+        // toe has nothing to assert, and saying so keeps `apply` from raising it a second time.
         focusApplied = id
-        // Clicking a window raises it, so the focused one is already in front and stays there;
-        // this is only about the float it has just taken the focus from.
-        sinkUnfocusedFloats(workspaces.render())
-        updateBorder()
-        refreshStatus()
-        scheduleSessionSave()
+
+        guard revealed else {
+            // Clicking a window raises it, so the focused one is already in front and stays there;
+            // this is only about the float it has just taken the focus from.
+            sinkUnfocusedFloats(workspaces.render())
+            updateBorder()
+            refreshStatus()
+            scheduleSessionSave()
+            return
+        }
+
+        // The focus arrived from off-screen: the Dock, Cmd-Tab, Spotlight. `revealWindow` has
+        // switched to the window's workspace, and the whole switch now has to reach the screen —
+        // this workspace's windows are parked at `stashPoint` and the one the user clicked is
+        // among them, focused and nowhere to be seen. `apply` ends in the border, the status and
+        // the session save, so nothing more is owed here.
+        apply(refocus: false)
     }
 
     /// Chromium, Electron and the JetBrains IDEs restore their own remembered geometry a beat


### PR DESCRIPTION
Clicking an application's Dock icon focuses its window wherever that window is — and if the window was parked on a hidden workspace, the focus went into the model and nothing else moved. The window stayed at `stashPoint` with the focus on it, so the click looked like it had done nothing at all. Cmd-Tab and Spotlight arrive by the same door.

- **`WorkspaceManager.revealWindow(_:)`** brings the window's workspace to it rather than pushing the window away — the answer `settleFullscreenReturns` already gives a window coming back from a fullscreen Space. It notes the focus *after* the switch, because `switchTo` ends in `refocusVisible`, which would otherwise hand the focus to the arriving workspace's own most recently used window rather than the one that was clicked. It returns whether a switch was needed, since the two cases cost the caller very different amounts of work.
- **`Coordinator.windowFocused`** takes that in place of `noteFocus`. Focus that lands somewhere already visible does what it always did; focus that arrived from off-screen goes through `apply`, which unparks the workspace and writes every frame. `focusApplied = id` either way — the system has already given the window the focus, so there is nothing to assert and no second raise.
- **Only when the application is frontmost.** A Dock click, Cmd-Tab and Spotlight all activate as they focus; an application raising a window of its own accord does not, and pulling the screen out from under the user for that is what Hyprland keeps behind `focus_on_activate` and leaves off. The same frontmost test `isEchoOfOwnRaise` makes, for the same reason.

No slide. This lands where `dispatch`'s `workspace <n>` does, and an arbitrary jump to an index has no left or right to slide toward — `WorkspaceSlide.direction` answers nil for one, and a reveal can cross displays, where nothing on the current one moves at all.

Two new selftest cases: revealing a window on a hidden workspace (including that it takes the focus over that workspace's own more recent window), and revealing one on a second monitor's visible workspace, where nothing switches but the focused monitor still has to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdXsaPh1RpiryrDQ3qcXoL