### PR TITLE
Give the development copy its own identity, and one toe at a time

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,8 @@ Recording — see `ScreenSnapshot`).
 
 ```sh
 make test      # layout suite — no permissions, no Xcode, ~1s
-make run       # build, bundle, sign, relaunch in place (replaces any running toe)
-make bundle    # build/Toe.app, runs `make test` first
+make run       # build/ToeDev.app, sign, relaunch in place (replaces any running toe)
+make bundle    # build/Toe.app — the installed identity; runs `make test` first
 make install   # same, into /Applications
 make dev-cert  # once per machine — see "Accessibility and code signing" below
 make reset-perms
@@ -140,6 +140,20 @@ macOS keys the Accessibility grant to the code signature, and an ad-hoc signatur
 build — so without `make dev-cert` (a stable self-signed `toe-dev` identity, one password prompt)
 you re-grant permission after every rebuild. `scripts/bundle.sh` picks it up automatically. When
 hotkeys or window moves stop working after a rebuild, `make reset-perms` and re-grant.
+
+**The grant is keyed to the bundle identifier as well**, which is why `make run` builds a second
+application rather than the same one: `build/ToeDev.app`, `com.clifmeister.toe.dev`, "Toe Dev" in
+the Accessibility list. The installed copy is signed with Developer ID and this one with `toe-dev`,
+so under one identifier each launch invalidated the other's grant and asked again. Two identifiers,
+two grants, each given once — and `make reset-perms` resets both.
+
+Two applications, one machine. Everything toe does is global — the hotkeys, the taps, the windows,
+the four settings journalled to `~/.local/state/toe` — so `AppIdentity.takeOver` asks any other
+running copy to quit and waits for it, first thing in `Coordinator.start`, before the journal
+repairs the outgoing copy is still writing. `SIGTERM` and not `NSRunningApplication.terminate()`:
+that sends a quit Apple Event, and AppKit answers it without going near `shutDown`, which would
+leave a hidden workspace's windows parked in the stash corner. Config and state are deliberately
+shared, since only one copy ever runs and a swap should keep your layout.
 
 ## Releasing
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
-APP      := build/Toe.app
-BUNDLEID := com.clifmeister.toe
-AGENT    := $(HOME)/Library/LaunchAgents/$(BUNDLEID).plist
+APP         := build/Toe.app
+DEV_APP     := build/ToeDev.app
+BUNDLEID    := com.clifmeister.toe
+DEVBUNDLEID := com.clifmeister.toe.dev
+AGENT       := $(HOME)/Library/LaunchAgents/$(BUNDLEID).plist
 
-.PHONY: all build test bundle run install uninstall dev-cert reset-perms start-at-login stop-at-login example-config icon clean
+.PHONY: all build test bundle dev-bundle run install uninstall dev-cert reset-perms start-at-login stop-at-login example-config icon clean
 
 all: bundle
 
@@ -17,8 +19,16 @@ test:
 bundle: test
 	@./scripts/bundle.sh release
 
-## Build and launch in place, replacing any running copy.
-run: bundle
+## The same app under its own identity — "Toe Dev", com.clifmeister.toe.dev — so that its
+## Accessibility grant is its own and swapping between this and the installed copy never costs
+## you the permission. See the comment at the top of scripts/bundle.sh.
+dev-bundle: test
+	@TOE_DEV=1 ./scripts/bundle.sh release
+
+## Build and launch the development copy in place. Whichever copy is running goes first:
+## `AppIdentity.takeOver` does the same from inside the app, so launching the installed one
+## afterwards is just as safe, but doing it here keeps the launch below from racing it.
+run: dev-bundle
 	@pkill -x toe 2>/dev/null || true
 	@# SIGTERM is asynchronous, and toe handles it rather than dying on the spot: it unstashes
 	@# every hidden workspace and takes down the event tap first. Opening the new copy while the
@@ -26,8 +36,8 @@ run: bundle
 	@# for the process to actually be gone. Bounded, so a wedged toe cannot hang the build.
 	@for _ in $$(seq 50); do pgrep -x toe >/dev/null || break; sleep 0.1; done
 	@pgrep -x toe >/dev/null && { echo "a previous toe will not exit — kill -9 it and retry"; exit 1; } || true
-	@open $(APP)
-	@echo "toe running — look for it in the menu bar"
+	@open $(DEV_APP)
+	@echo "Toe Dev running — look for it in the menu bar"
 
 install: bundle
 	@pkill -x toe 2>/dev/null || true
@@ -47,9 +57,13 @@ dev-cert:
 
 ## macOS keys Accessibility grants to the code signature, and an ad-hoc signature changes on
 ## every build. Run this after a rebuild if hotkeys or window moves stop working.
+## Both identities: the installed copy and the development one are separate applications to
+## macOS, so they hold — and lose — their permissions separately.
 reset-perms:
-	@tccutil reset Accessibility $(BUNDLEID) || true
-	@tccutil reset ScreenCapture $(BUNDLEID) || true
+	@for id in $(BUNDLEID) $(DEVBUNDLEID); do \
+	    tccutil reset Accessibility $$id || true; \
+	    tccutil reset ScreenCapture $$id || true; \
+	done
 	@echo "re-grant Accessibility for toe (and Screen Recording, if the slide is on), then relaunch"
 
 start-at-login:

--- a/README.md
+++ b/README.md
@@ -170,9 +170,14 @@ others. Symlinking it into a dotfiles repository works fine.
 ```sh
 make dev-cert   # once per machine: a stable signing identity so Accessibility survives rebuilds
 make test       # layout suite — no permissions, no Xcode needed
-make run        # build, sign and relaunch in place
+make run        # build, sign and relaunch in place, as "Toe Dev"
 make install    # same, into /Applications
 ```
+
+`make run` builds a separate application — `build/ToeDev.app`, "Toe Dev" — so that the copy you are
+working on and the one in `/Applications` hold their Accessibility grants separately and neither
+launch costs you the other's permission. Grant each once. Only one copy runs at a time: whichever
+starts asks the other to quit and waits for it to unstash its windows before taking over.
 
 Diagnostics go to the unified log:
 

--- a/Sources/toe/AppIdentity.swift
+++ b/Sources/toe/AppIdentity.swift
@@ -1,0 +1,82 @@
+import AppKit
+
+/// Which copy of toe this is, and how it takes the machine from the other one.
+///
+/// There are two: the installed application, signed with the Developer ID certificate, and the
+/// one `make run` builds, signed with toe-dev. macOS keys an Accessibility grant to a bundle
+/// identifier and the signature stored against it, so a shared identifier means every swap
+/// between them invalidates the other's grant and asks for the permission again. They carry
+/// separate identifiers instead — `scripts/bundle.sh` stamps the development one — which makes
+/// them two applications as far as macOS is concerned, each with a grant of its own, given once.
+///
+/// Two applications, but still one machine. Everything toe does is global: the Carbon hotkeys,
+/// the event taps, the windows themselves, and the four system settings journalled to
+/// `~/.local/state/toe`. Two copies running at once would fight over all of it, and the journals
+/// are the part that does not simply sort itself out — both would write, and whichever exited
+/// last would hand back a "before" state the other had already changed. So a starting copy takes
+/// the machine from whichever one holds it.
+enum AppIdentity {
+
+    static let installed = "com.clifmeister.toe"
+    static let development = "com.clifmeister.toe.dev"
+
+    /// Whether this is the copy `make run` built. The one place it reaches the screen is the
+    /// quick menu's `About` row: two copies that cannot be told apart are two copies you will
+    /// eventually debug the wrong one of.
+    static var isDevelopment: Bool { Bundle.main.bundleIdentifier == development }
+
+    /// Asks every other copy of toe to quit, and waits for it to be gone.
+    ///
+    /// `SIGTERM`, not `NSRunningApplication.terminate()`: that sends a quit Apple Event, which
+    /// AppKit answers by terminating without going near `Coordinator.shutDown` — so the outgoing
+    /// copy would leave every hidden workspace's windows parked in the stash corner and the four
+    /// journalled settings unrestored. The signal handler is toe's one teardown path and is
+    /// exactly what `make run`'s `pkill` has always used.
+    ///
+    /// Called before anything in `start` touches those journals, because the copy on its way out
+    /// is still writing them.
+    static func takeOver() {
+        let others = otherCopies()
+        guard !others.isEmpty else { return }
+
+        for app in others {
+            Log.info("another toe is running (pid \(app.processIdentifier), "
+                     + "\(app.bundleIdentifier ?? "no bundle id")) — asking it to quit")
+            kill(app.processIdentifier, SIGTERM)
+        }
+
+        // Bounded like `make run`'s wait, and generous for the same reason: the outgoing copy
+        // unstashes every window it had parked before it goes, and that is a synchronous
+        // Accessibility write per window. Spinning the run loop rather than sleeping — this runs
+        // before `NSApp.run`, and the `isTerminated` this polls is only updated by AppKit
+        // servicing its notifications.
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline, others.contains(where: { !$0.isTerminated }) {
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.05))
+        }
+
+        // A copy that will not answer is worse than one killed outright: it still holds the
+        // hotkeys and the event taps, and this one is about to start writing frames it disagrees
+        // with. What is lost is its session snapshot and whatever it had stashed, which is why
+        // this is the second thing tried and not the first — and why it says so.
+        for app in others where !app.isTerminated {
+            Log.error("toe (pid \(app.processIdentifier)) did not quit within 5s — killing it. "
+                      + "Windows on its hidden workspaces may be left parked off-screen.")
+            kill(app.processIdentifier, SIGKILL)
+        }
+    }
+
+    /// Every running toe but this one.
+    ///
+    /// By bundle identifier, and by executable name for anything running outside a bundle —
+    /// `swift run toe` has no `Info.plist` and so no identifier to match, and it manages windows
+    /// just the same.
+    private static func otherCopies() -> [NSRunningApplication] {
+        let mine = ProcessInfo.processInfo.processIdentifier
+        return NSWorkspace.shared.runningApplications.filter { app in
+            guard app.processIdentifier != mine else { return false }
+            if let id = app.bundleIdentifier { return id == installed || id == development }
+            return app.executableURL?.lastPathComponent == "toe"
+        }
+    }
+}

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -191,6 +191,9 @@ final class Coordinator: WindowTrackerDelegate {
         status.onOpenMenu = { [weak self] in self?.dispatch(.menu(.root)) }
 
         installSignalHandlers()
+        // Before the four repairs below, because the copy this replaces writes those journals on
+        // its way out — and before anything grabs a hotkey or a tap it is still holding.
+        AppIdentity.takeOver()
         // Symbolic hotkey state outlives the process, so a previous toe that was killed rather
         // than quit may have left Mission Control's shortcut switched off. Give it back before
         // anything else, so the config below decides from a known-good baseline.

--- a/Sources/toe/UI/QuickMenu.swift
+++ b/Sources/toe/UI/QuickMenu.swift
@@ -36,8 +36,15 @@ final class QuickMenu {
     /// What the bundle was stamped with, for the `About` row. nil for a binary run straight out
     /// of `.build`, which has no Info.plist to have been stamped — and the row is then left out
     /// rather than reporting a version toe does not know.
-    private static let version =
-        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    ///
+    /// The development copy says so. It is the same application under its own identifier — see
+    /// `AppIdentity` — and the one row toe has to report a fact about itself is where the
+    /// question "which of the two am I looking at?" belongs.
+    private static let version: String? = {
+        guard let stamped = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+        else { return nil }
+        return AppIdentity.isDevelopment ? "\(stamped) dev" : stamped
+    }()
 
     private let panel: MenuPanel
     private let view = MenuView()

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -1,14 +1,35 @@
 #!/usr/bin/env bash
 # Assembles Toe.app from the release binary and signs it.
 #
-# Two environment variables let CI drive this without changing local behaviour:
+# Three environment variables let CI and `make run` drive this without changing what the
+# default build does:
 #   TOE_SIGN_IDENTITY  signing identity to use, skipping the toe-dev/ad-hoc search
 #   TOE_VERSION        version to stamp into the bundled Info.plist
+#   TOE_DEV            build the development flavour — see below
 set -euo pipefail
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-app="$root/build/Toe.app"
 config="${1:-release}"
+
+# macOS keys an Accessibility grant to a bundle identifier *and* the code signature stored
+# against it. The installed copy is signed with the Developer ID certificate and the local one
+# with toe-dev, so sharing an identifier means each launch invalidates the other's grant and
+# the permission has to be given again every time you swap between them. The development
+# flavour is a separate application as far as macOS is concerned — its own identifier, its own
+# grant, granted once — so the two can be swapped freely. They still cannot run at the same
+# time, and do not: see `AppIdentity.takeOver`.
+#
+# No space in the bundle's file name, only in what it calls itself: `build/Toe Dev.app` would
+# have to be quoted through every Makefile rule that touches it.
+if [ -n "${TOE_DEV:-}" ]; then
+    app="$root/build/ToeDev.app"
+    bundle_id="com.clifmeister.toe.dev"
+    bundle_name="Toe Dev"
+else
+    app="$root/build/Toe.app"
+    bundle_id="com.clifmeister.toe"
+    bundle_name="Toe"
+fi
 
 swift build -c "$config" --package-path "$root"
 binary="$(swift build -c "$config" --package-path "$root" --show-bin-path)/toe"
@@ -27,10 +48,20 @@ cp "$root/Resources/JetBrainsMonoNerdFont-Regular.ttf" "$app/Contents/Resources/
 cp "$root/Resources/JetBrainsMonoNerdFont-OFL.txt" "$app/Contents/Resources/"
 printf 'APPL????' > "$app/Contents/PkgInfo"
 
+plist="$app/Contents/Info.plist"
+
+# The committed Info.plist is the installed application's, so only the development flavour has
+# anything to rewrite. `CFBundleName` is what the Accessibility list in System Settings shows,
+# which is the one place the two copies have to be told apart by eye.
+if [ -n "${TOE_DEV:-}" ]; then
+    /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier $bundle_id" "$plist"
+    /usr/libexec/PlistBuddy -c "Set :CFBundleName $bundle_name" "$plist"
+    /usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName $bundle_name" "$plist"
+fi
+
 # Releases stamp the tag's version into the bundle. Left alone, the committed Info.plist
 # version stands, so a local `make run` builds exactly what it always did.
 if [ -n "${TOE_VERSION:-}" ]; then
-    plist="$app/Contents/Info.plist"
     /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $TOE_VERSION" "$plist"
     /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $TOE_VERSION" "$plist"
     echo "stamped version $TOE_VERSION"
@@ -51,7 +82,9 @@ fi
 # the network and Apple's timestamp server — it is what keeps already-shipped builds valid
 # after the certificate expires. Both are limited to the release path, so a local `make run`
 # against toe-dev, and CI's ad-hoc fallback, sign exactly as they always did.
-flags=(--force --sign "$identity" --identifier com.clifmeister.toe)
+# The signing identifier and not just the plist: TCC keys the grant to the identifier in the
+# signature, so a dev bundle signed as the installed one would land back in its entry.
+flags=(--force --sign "$identity" --identifier "$bundle_id")
 if [ -n "${TOE_SIGN_IDENTITY:-}" ]; then
     flags+=(--options runtime --timestamp --entitlements "$root/Resources/toe.entitlements")
 fi


### PR DESCRIPTION
macOS keys an Accessibility grant to the bundle identifier *and* the signature stored against it. The installed copy is signed with Developer ID and the local one with `toe-dev`, so under a shared identifier each launch invalidated the other's grant and asked for the permission again on every swap.

`make run` now builds `build/ToeDev.app` — `com.clifmeister.toe.dev`, "Toe Dev" in the Accessibility list — and `codesign --identifier` matches, so the two are separate applications to macOS with separate grants, each given once. `make reset-perms` resets both. The `About` row says "dev" so you can tell which one you are looking at.

Two applications, one machine. Everything toe does is global — the Carbon hotkeys, the event taps, the windows, the four settings journalled to `~/.local/state/toe` — so `AppIdentity.takeOver` asks any other running copy to quit and waits for it, first thing in `Coordinator.start` and before the journal repairs the outgoing copy is still writing. `SIGTERM` rather than `NSRunningApplication.terminate()`: that sends a quit Apple Event, which AppKit answers without going near `shutDown`, leaving a hidden workspace's windows parked in the stash corner. A copy that will not answer inside 5s is killed, and says so in the log.

Config and state stay shared — only one copy ever runs, and a swap should keep your layout.

## Test plan

- `make test` — the layout suite is untouched by this and passes.
- `make run`, grant "Toe Dev" Accessibility once; `make install`, grant "Toe" once; swap back and forth and neither asks again.
- With the installed copy running, `make run`: the log shows it asking the other to quit, and the hidden workspace's windows come back rather than staying in the stash corner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)