### PR TITLE
Let a workspace change places with the one next door

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ leaves ⌘S, ⌘F, ⌘T, ⌘W, ⌘1-9 and ⌘Tab untouched.
 | `SUPER` + `1`…`9`, `0` | Switch to workspace 1…10 |
 | `SUPER` + `SHIFT` + `1`…`9`, `0` | Move window to workspace and follow it |
 | `SUPER` + `TAB` / `SHIFT`+`TAB` / `CTRL`+`TAB` | Next / previous workspace in use, former workspace |
+| `SUPER` + `CTRL` + `SHIFT` + `←` / `→` | Swap this workspace with the one next door, windows and all |
 | Sideways swipe on the trackpad | Next / previous workspace in use |
 | `SUPER` + `ENTER` | New terminal window |
 | `SUPER` + `SHIFT` + `ENTER` | New browser window |
@@ -141,11 +142,13 @@ app = "com.apple.ActivityMonitor"
 
 Binding specs accept the dash spelling and Omarchy's, so `"alt-shift-1"`, `"super+shift+1"` and
 `"SUPER SHIFT, 1"` all mean the same. The commands are `movefocus`, `swapwindow`, `movewindow`,
-`workspace`, `movetoworkspace`, `movetoworkspacesilent`, `killactive`, `togglefloating`,
-`togglesplit`, `swapsplit`, `growactive`, `resizeactive`, `exec`, `reload`, `menu`, `keybindings`,
-`theme`, `removetheme`, `background`, `nextbackground` and `quit`. `growactive <dx> <dy>` grows the
-focused window by that much; Hyprland's `resizeactive` moves the split by that much instead, which
-from a right-hand window is the other way round, and is accepted for configs copied from Omarchy.
+`workspace`, `movetoworkspace`, `movetoworkspacesilent`, `swapworkspace`, `killactive`,
+`togglefloating`, `togglesplit`, `swapsplit`, `growactive`, `resizeactive`, `exec`, `reload`,
+`menu`, `keybindings`, `theme`, `removetheme`, `background`, `nextbackground` and `quit`.
+`growactive <dx> <dy>` grows the focused window by that much; Hyprland's `resizeactive` moves the
+split by that much instead, which from a right-hand window is the other way round, and is accepted
+for configs copied from Omarchy. `swapworkspace left` / `right` is toe's own: it renumbers two
+workspaces rather than moving any window, so a workspace can be shuffled along the menu bar.
 
 Other sections worth knowing about:
 

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -262,6 +262,15 @@ font_size  = 18
 "super-shift-tab" = "workspace prev"
 "super-ctrl-tab"  = "workspace previous"
 
+# ── Reordering — SUPER CTRL SHIFT + arrows ────────────────────────────────────
+# Your workspace changes places with the one next door: on 3 with 2 to your left, this makes
+# yours 2 and theirs 3. Nothing on screen moves — the windows stay in their tiles and only the
+# numbers on the menu bar change — so it is how a workspace you started late gets to where it
+# belongs in the row, and how the number under SUPER+n becomes the one you expect. Off either
+# end the press does nothing: 1 has no left and 10 no right.
+"super-ctrl-shift-left"  = "swapworkspace left"
+"super-ctrl-shift-right" = "swapworkspace right"
+
 # ── Windows ───────────────────────────────────────────────────────────────────
 "super-w"       = "killactive"
 "super-j"       = "togglesplit"

--- a/Sources/ToeCore/Dispatch/Command.swift
+++ b/Sources/ToeCore/Dispatch/Command.swift
@@ -14,6 +14,12 @@ public enum Command: Equatable {
     case moveWindow(Direction)
     case workspace(WorkspaceTarget)
     case moveToWorkspace(Int, follow: Bool)
+    /// `swapworkspace <left|right>`: the workspace you are on trades numbers with its
+    /// neighbour, so a workspace can be moved along the menu bar strip to where it belongs.
+    /// The argument is how far and which way, as a signed number of slots — toe's own verb;
+    /// Hyprland reorders nothing, and its `swapactiveworkspaces` is a different thing again
+    /// (two monitors trading what they show).
+    case swapWorkspace(Int)
     case killActive
     case toggleFloating
     case toggleSplit
@@ -95,11 +101,18 @@ public extension Command {
     /// fullscreen, closed unseen and unasked. Every other verb acts on the window's size, the
     /// theme, or a menu, and none of those is a window vanishing.
     ///
+    /// `swapworkspace` is here for the quieter version of the same thing. It moves no window at
+    /// all — it renumbers two workspaces — but the workspace it renumbers is the one *behind*
+    /// the fullscreen Space, and the strip that would report what happened is in a menu bar
+    /// that Space is covering. So the press would land on a workspace the user is not looking
+    /// at and say nothing about it.
+    ///
     /// The way out is the way in: leave fullscreen, or click a window on another display, and
     /// the keys work again with nothing to put back.
     var suspendedByFullscreen: Bool {
         switch self {
-        case .moveFocus, .swapWindow, .moveWindow, .workspace, .moveToWorkspace, .killActive:
+        case .moveFocus, .swapWindow, .moveWindow, .workspace, .moveToWorkspace, .killActive,
+             .swapWorkspace:
             return true
         default:
             return false
@@ -258,6 +271,24 @@ public enum CommandParser {
             case "e-1", "prev", "-1": return .workspace(.previous)
             case "previous", "former", "back": return .workspace(.former)
             default: return .workspace(.index(try workspaceIndex()))
+            }
+
+        // toe's own verb — see `Command.swapWorkspace`. `left`/`right` because that is what the
+        // strip does when you press it, with Hyprland's relative spellings accepted for the
+        // hands that already type them. No `moveworkspace` alias: one letter from
+        // `movetoworkspace`, and a number means something else entirely to each of them.
+        case "swapworkspace":
+            switch argument.lowercased() {
+            case "": throw CommandError.missingArgument(name)
+            case "l", "left", "-1", "e-1": return .swapWorkspace(-1)
+            case "r", "right", "+1", "e+1": return .swapWorkspace(1)
+            default:
+                // A signed count of slots, so `swapworkspace -2` is two places left. Zero is a
+                // bad argument rather than a no-op: a binding that does nothing is a typo.
+                guard let n = Int(argument), n != 0,
+                      abs(n) < WorkspaceManager.workspaceCount
+                else { throw CommandError.badArgument(name, argument) }
+                return .swapWorkspace(n)
             }
 
         case "movetoworkspace":

--- a/Sources/ToeCore/Dispatch/CommandLabel.swift
+++ b/Sources/ToeCore/Dispatch/CommandLabel.swift
@@ -3,10 +3,10 @@ import Foundation
 /// What a command is called, for a reader rather than for a parser.
 ///
 /// The keybindings page shows `SUPER + W  →  Close window`, and the right-hand half is this. It
-/// is the second exhaustive `switch` over `Command` in the tree — `Coordinator.dispatch` is the
-/// other — so a new command now needs three edits rather than two: the verb in `CommandParser`,
-/// the arm in `dispatch`, and a label here. The compiler catches a missing label; nothing but a
-/// reader catches a bad one.
+/// is one of three exhaustive `switch`es over `Command` in the tree — `Coordinator.dispatch` and
+/// `MenuModel.rank` are the others — so a new command needs four edits rather than two: the verb
+/// in `CommandParser`, the arm in `dispatch`, a label here, and a rank on the keybindings page.
+/// The compiler catches a missing label; nothing but a reader catches a bad one.
 public enum CommandLabel {
 
     public static func describe(_ command: Command) -> String {
@@ -18,6 +18,7 @@ public enum CommandLabel {
         case .moveToWorkspace(let n, let follow):
             return follow ? "Move window to workspace \(n)"
                           : "Move window to workspace \(n), staying here"
+        case .swapWorkspace(let delta): return swapWorkspace(delta)
         case .killActive:           return "Close window"
         case .toggleFloating:       return "Cycle floating"
         case .toggleSplit:          return "Toggle split orientation"
@@ -86,6 +87,16 @@ public enum CommandLabel {
                                     + " and " + change(dy, "taller", "shorter")
         case (false, false): return "Leave the window its size"
         }
+    }
+
+    /// "Swap this workspace with the one to its left" — the swap and not the renumbering, which
+    /// is only how it is done. What the user sees is their workspace changing places on the bar
+    /// with its neighbour, and both keeping their windows.
+    private static func swapWorkspace(_ delta: Int) -> String {
+        let side = delta < 0 ? "left" : "right"
+        let places = abs(delta)
+        return places == 1 ? "Swap this workspace with the one to its \(side)"
+                           : "Move this workspace \(places) places to the \(side)"
     }
 
     private static func workspace(_ target: WorkspaceTarget) -> String {

--- a/Sources/ToeCore/Layout/WorkspaceManager.swift
+++ b/Sources/ToeCore/Layout/WorkspaceManager.swift
@@ -17,7 +17,9 @@ public struct RenderPlan: Equatable {
 }
 
 public final class Workspace {
-    public let index: Int              // 1...10
+    /// 1...10. Not a constant: `swapWorkspace` renumbers two workspaces in place, which is the
+    /// whole of what reordering the strip does to them.
+    public internal(set) var index: Int
     public var monitorID: UInt32
     public var layout: DwindleLayout
     public var floating: Set<WindowID> = []
@@ -570,6 +572,53 @@ public final class WorkspaceManager {
         var next = (position + delta) % ring.count
         if next < 0 { next += ring.count }
         switchTo(workspace: ring[next])
+    }
+
+    /// `swapworkspace left` / `right`: this workspace trades places with the one next door,
+    /// windows and all.
+    ///
+    /// A renaming, and nothing more. Both workspaces keep their windows, their tree and the
+    /// monitor they live on; only the numbers change, and `activeWorkspace` follows them so the
+    /// display you are looking at goes on showing the same windows under its new number. Not one
+    /// window is written to, which is the whole appeal of doing it this way rather than carrying
+    /// windows from one workspace to the other: no stash, no re-tiling, no floating frame to put
+    /// back — and a workspace that was on the other display stays on the other display, since
+    /// its `monitorID` travels with it.
+    ///
+    /// The neighbour is `index ± 1` and deliberately not the next slot on the strip, which is
+    /// what `workspace next` walks. This is the verb that *reorders* the strip, so it has to be
+    /// able to move a workspace into an empty slot — and stepping over the empties, as the ring
+    /// does, is exactly the one thing that would make that impossible. Off either end nothing
+    /// happens: 1 has no left and 10 no right, and wrapping would fling a workspace the length
+    /// of the bar for a keypress that reads as one step.
+    @discardableResult
+    public func swapWorkspace(_ delta: Int) -> Bool {
+        let here = focusedWorkspaceIndex
+        let there = here + delta
+        guard delta != 0, (1...Self.workspaceCount).contains(there) else { return false }
+
+        let ours = workspaces[here]
+        let theirs = workspaces[there]
+        ours?.index = there
+        theirs?.index = here
+        // Assigning nil clears the key, which is right: a workspace is made on demand, and a
+        // slot nobody has been on should still have no entry after the swap.
+        workspaces[there] = ours
+        workspaces[here] = theirs
+
+        func renumbered(_ index: Int) -> Int {
+            switch index {
+            case here:  return there
+            case there: return here
+            default:    return index
+            }
+        }
+        // Every monitor's, not just the focused one's: the neighbour may be the workspace the
+        // second display is showing, and that display has to keep showing its own windows.
+        activeWorkspace = activeWorkspace.mapValues(renumbered)
+        // `workspace former` means the windows you were last on, not the slot they were in.
+        previousWorkspace = previousWorkspace.mapValues(renumbered)
+        return true
     }
 
     /// `movetoworkspace <n>` / `movetoworkspacesilent <n>`.

--- a/Sources/ToeCore/Menu/MenuModel.swift
+++ b/Sources/ToeCore/Menu/MenuModel.swift
@@ -543,11 +543,14 @@ public enum MenuModel {
         case .workspace(.index): return 3
         case .moveToWorkspace:  return 4
         case .workspace:        return 5
-        case .killActive, .toggleFloating, .toggleSplit, .swapSplit, .resizeActive, .growActive: return 6
-        case .theme, .removeTheme, .background, .nextBackground: return 7
-        case .menu:             return 8
-        case .reload, .quit:    return 9
-        case .exec:             return 10
+        // Last of the workspace verbs: it is the one that acts on a workspace as a whole rather
+        // than on where you are or what is on it.
+        case .swapWorkspace:    return 6
+        case .killActive, .toggleFloating, .toggleSplit, .swapSplit, .resizeActive, .growActive: return 7
+        case .theme, .removeTheme, .background, .nextBackground: return 8
+        case .menu:             return 9
+        case .reload, .quit:    return 10
+        case .exec:             return 11
         }
     }
 }

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -532,6 +532,84 @@ h.test("workspace next reaches a workspace another monitor is showing") { t in
     t.equal(wm.focusedWorkspaceIndex, rightWS, "the other display's workspace counts, empty or not")
 }
 
+h.test("swapworkspace trades places with the workspace next door") { t in
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
+
+    wm.switchTo(workspace: 2); wm.addWindow(1)
+    wm.switchTo(workspace: 3); wm.addWindow(2)
+
+    t.expect(wm.swapWorkspace(-1), "3 swaps with 2")
+    t.equal(wm.focusedWorkspaceIndex, 2, "your windows are on 2 now, and you are still on them")
+    t.equal(wm.workspaceIndex(of: 2), 2, "and they came with you")
+    t.equal(wm.workspaceIndex(of: 1), 3, "the neighbour's went the other way")
+    t.equal(wm.render().stashed, [1], "3 is hidden, as 2 was — nothing changed on screen")
+    t.equal(wm.workspaces[2]?.index, 2, "the workspace knows its new number")
+    t.equal(wm.workspaces[3]?.index, 3, "so does the one it swapped with")
+
+    t.expect(wm.swapWorkspace(1), "and back again")
+    t.equal(wm.focusedWorkspaceIndex, 3, "which undoes it exactly")
+    t.equal(wm.workspaceIndex(of: 2), 3, "windows and all")
+    t.equal(wm.workspaceIndex(of: 1), 2, "both ways")
+}
+
+h.test("swapworkspace moves into an empty slot, and stops at the ends") { t in
+    // The point of index ± 1 rather than the strip's ring: a workspace has to be able to move
+    // into a slot nothing is on, which is the one thing stepping over the empties cannot do.
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
+
+    wm.switchTo(workspace: 5); wm.addWindow(1)
+    t.expect(wm.swapWorkspace(-1), "4 is empty and is still somewhere to go")
+    t.equal(wm.focusedWorkspaceIndex, 4, "so the workspace is 4 now")
+    t.equal(wm.workspaceIndex(of: 1), 4, "with its window")
+    t.expect(wm.workspaces[5] == nil || wm.workspaces[5]!.isEmpty,
+             "and 5 is as empty as 4 was — an untouched slot stays untouched")
+
+    wm.switchTo(workspace: 1)
+    t.expect(!wm.swapWorkspace(-1), "1 has no left")
+    t.equal(wm.focusedWorkspaceIndex, 1, "so the press does nothing rather than wrapping to 10")
+    wm.switchTo(workspace: 10)
+    t.expect(!wm.swapWorkspace(1), "and 10 no right")
+    t.equal(wm.focusedWorkspaceIndex, 10, "same at the other end")
+    t.expect(!wm.swapWorkspace(0), "nought places is not a swap")
+}
+
+h.test("swapworkspace leaves the other display showing its own windows") { t in
+    // The neighbour may be the workspace the second display is on. Renumbering has to follow
+    // every monitor's active workspace, or that display would be showing somebody else's.
+    let left = box(0, 0, 1512, 982)
+    let right = box(1512, 0, 1920, 1080)
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: left, usable: left),
+                    Monitor(id: 2, frame: right, usable: right)])
+
+    wm.switchTo(workspace: 1); wm.addWindow(1)           // display 1
+    wm.switchTo(workspace: 2); wm.addWindow(2)           // display 2, since 2 re-homes to focus
+    t.equal(wm.workspaces[2]?.monitorID, 2, "the second display is on workspace 2")
+    wm.switchTo(workspace: 1)
+
+    t.expect(wm.swapWorkspace(1), "1 swaps with the workspace the other display is showing")
+    t.equal(wm.focusedWorkspaceIndex, 2, "your windows are 2 now")
+    t.equal(wm.activeWorkspace[2], 1, "and the other display's are 1, still on that display")
+    t.equal(wm.workspaces[1]?.monitorID, 2, "a workspace does not change display for a rename")
+    t.equal(wm.render().stashed, [], "and nothing is parked: both are still on screen")
+}
+
+h.test("swapworkspace carries the workspace `former` goes back to") { t in
+    // `workspace former` means the windows you were last on, not the number they were under.
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
+
+    wm.switchTo(workspace: 2); wm.addWindow(1)
+    wm.switchTo(workspace: 3); wm.addWindow(2)           // former is 2
+
+    t.expect(wm.swapWorkspace(-1), "swap, so the windows that were on 2 are on 3")
+    wm.switchToPreviousWorkspace()
+    t.equal(wm.focusedWorkspaceIndex, 3, "former follows them there")
+    t.equal(wm.workspaceIndex(of: 1), 3, "which is where they are")
+}
+
 h.test("a floating focus falls back to the window under the pointer") { t in
     let wm = WorkspaceManager()
     wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
@@ -3070,6 +3148,23 @@ h.test("a menu binding opens the level Omarchy's own key opens") { t in
             "slugified at the door, because the name is about to be joined onto a path")
     t.expect((try? CommandParser.parse("removetheme")) == nil,
              "and it needs an argument — there is no theme called nothing to delete")
+}
+
+h.test("swapworkspace parses the strip's own two directions") { t in
+    t.equal(try CommandParser.parse("swapworkspace left"), .swapWorkspace(-1), "the word")
+    t.equal(try CommandParser.parse("swapworkspace, r"), .swapWorkspace(1),
+            "Hyprland's comma and its single letter")
+    t.equal(try CommandParser.parse("swapworkspace e-1"), .swapWorkspace(-1),
+            "and its relative spelling, which `workspace` takes too")
+    t.equal(try CommandParser.parse("swapworkspace -2"), .swapWorkspace(-2), "a count of slots")
+    t.expect((try? CommandParser.parse("swapworkspace")) == nil, "it needs an argument")
+    t.expect((try? CommandParser.parse("swapworkspace 0")) == nil,
+             "and nought is a typo rather than a binding that does nothing")
+    t.expect((try? CommandParser.parse("swapworkspace 10")) == nil,
+             "ten places is further than the strip is long")
+    t.expect((try? CommandParser.parse("swapworkspace up")) == nil, "the strip has no up")
+    t.equal(CommandLabel.describe(.swapWorkspace(-1)),
+            "Swap this workspace with the one to its left", "and the keybindings page says so")
 }
 
 h.test("resizeactive takes Hyprland's two numbers and nothing else") { t in

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -1912,6 +1912,13 @@ final class Coordinator: WindowTrackerDelegate {
             workspaces.moveFocusedWindow(toWorkspace: n, follow: follow)
             apply(refocus: follow)
 
+        case .swapWorkspace(let delta):
+            // Nothing moves on screen — the swap is two workspaces trading numbers — so this
+            // render writes no frame and unparks nothing. It is here for the two things that do
+            // name a workspace by its number: the strip in the menu bar, and the session file
+            // `apply` schedules, which is what makes the new order survive a restart.
+            if workspaces.swapWorkspace(delta) { apply(refocus: false) }
+
         case .killActive:
             guard let id = workspaces.focusedWindow, let window = tracker.window(id) else { return }
             WindowMover.close(window)

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -253,6 +253,15 @@ font_size  = 18
 "super-shift-tab" = "workspace prev"
 "super-ctrl-tab"  = "workspace previous"
 
+# ── Reordering — SUPER CTRL SHIFT + arrows ────────────────────────────────────
+# Your workspace changes places with the one next door: on 3 with 2 to your left, this makes
+# yours 2 and theirs 3. Nothing on screen moves — the windows stay in their tiles and only the
+# numbers on the menu bar change — so it is how a workspace you started late gets to where it
+# belongs in the row, and how the number under SUPER+n becomes the one you expect. Off either
+# end the press does nothing: 1 has no left and 10 no right.
+"super-ctrl-shift-left"  = "swapworkspace left"
+"super-ctrl-shift-right" = "swapworkspace right"
+
 # ── Windows ───────────────────────────────────────────────────────────────────
 "super-w"       = "killactive"
 "super-j"       = "togglesplit"


### PR DESCRIPTION
`SUPER`+`CTRL`+`SHIFT`+`←`/`→` — `swapworkspace left` / `right`. On 3 with 2 to your left, the press makes yours 2 and theirs 3, so a workspace started late can be moved to where it belongs in the row and the number under `SUPER`+*n* becomes the one you expect. toe's own verb: Hyprland reorders nothing, and its `swapactiveworkspaces` is a different thing (two monitors trading what they show).

The whole of it is two workspaces trading numbers. Both keep their windows, their tree and the monitor they live on; `activeWorkspace` follows them so the display goes on showing the same windows under a new number, and **not one window is written to** — no stash, no re-tiling, no floating frame to put back, and a workspace on the second display stays on the second display. `workspace former` follows the windows rather than the slot. The render in `dispatch` is there for the two things that name a workspace by its number: the strip in the menu bar, and the session file, which carries the new order across a restart.

The neighbour is `index ± 1` and not the next slot on the strip `SUPER`+`TAB` walks: this is the verb that *reorders* the strip, so it has to be able to move a workspace into an empty slot, and stepping over the empties is exactly what would make that impossible. Off either end the press does nothing — 1 has no left and 10 no right — rather than flinging a workspace the length of the bar. Suspended by fullscreen along with the other workspace verbs: it would renumber the workspace behind the Space, and the strip that would report it is under a menu bar that Space is covering.

Also here: the parser (`left`/`right`/`l`/`r`/`±1`/`e±1`, or a signed slot count; no `moveworkspace` alias, one letter from `movetoworkspace` where a number means something else), the keybindings-page label and its rank, the default config, `toe.example.toml` and the README.

## Test plan

- `make test` — 1352 assertions pass, five of the tests new: swap and back, into an empty slot, the two-display case, `workspace former` following the windows, and the parser.
- `make run` and the two keys on a workspace with a neighbour: the strip's marker moves a slot, the windows stay in their tiles, and `SUPER`+*n* reaches them under the new number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)