### PR TITLE
Warm the slide's capture path, and give swapworkspace a fallback key

### DIFF
--- a/Sources/ToeCore/Config/Config.swift
+++ b/Sources/ToeCore/Config/Config.swift
@@ -222,6 +222,13 @@ public struct Config: Equatable {
     /// them — and the answer is usually still no, because a key taken from someone who did not
     /// ask for it is a worse failure than a feature they have to go and bind.
     ///
+    /// So the question that actually separates the list from everything else is not whether a
+    /// binding is new. It is whether the command has *any other route*. A verb the quick menu
+    /// carries is a verb an old config can still reach, and it can wait for the day its owner
+    /// goes looking; a verb that exists only on a key nobody has is a feature that shipped to
+    /// nobody. That is the narrower bar, it is the one the entries below actually clear, and
+    /// stating it that way is what keeps the list from growing to hold every new binding.
+    ///
     /// Editing the config is not one of them, though it used to be. It is an `exec` binding now,
     /// like the ones that open a terminal or a browser, and a fallback would have to name an
     /// editor toe has no business choosing — and would put itself back on `SUPER`+`,` every time
@@ -255,6 +262,19 @@ public struct Config: Equatable {
         ("super-equal", .growActive(dx: 100, dy: 0)),
         ("super-shift-minus", .growActive(dx: 0, dy: -100)),
         ("super-shift-equal", .growActive(dx: 0, dy: 100)),
+        // `swapworkspace`, on the reachability bar above rather than on any resemblance to
+        // Omarchy — it has none, and neither has Hyprland: the verb is toe's own, so there is no
+        // upstream habit to satisfy and that argument is not available here. What is available
+        // is that the quick menu does not carry it either, which left it the one command in toe
+        // reachable by no route at all from a config written before it. A feature that shipped
+        // to nobody is the failure this list is for.
+        //
+        // Both directions, because left without right is half a feature — the same reason the
+        // four resize keys go together — and ⌥⌃⇧ with an arrow is deep enough that taking it is
+        // close to taking nothing. Standing aside is the usual two rules plus `swapsWorkspaces`:
+        // any swap on any key, in any direction, and both of these stay away.
+        ("super-ctrl-shift-left", .swapWorkspace(-1)),
+        ("super-ctrl-shift-right", .swapWorkspace(1)),
     ]
 
     /// Whether a binding already answers for a fallback's command. Equality, except that any
@@ -265,6 +285,9 @@ public struct Config: Equatable {
     static func bound(_ command: Command, in bindings: [Binding]) -> Bool {
         bindings.contains { existing in
             if existing.command.resizes && command.resizes { return true }
+            // Same rule, same reason: a config with `swapworkspace 3` on a key of its own knows
+            // the feature exists, which is the whole thing the fallback was for.
+            if existing.command.swapsWorkspaces && command.swapsWorkspaces { return true }
             return existing.command == command
         }
     }

--- a/Sources/ToeCore/Dispatch/Command.swift
+++ b/Sources/ToeCore/Dispatch/Command.swift
@@ -83,6 +83,15 @@ public extension Command {
         }
     }
 
+    /// True for the verb that renumbers workspaces. Every direction and distance answers for
+    /// every other where the question is "has this config got workspace swapping on a key" —
+    /// see `Config.bound(_:in:)`. `swapWindow` and `swapSplit` are not this: they move a window
+    /// inside a workspace and are a different feature with different keys.
+    var swapsWorkspaces: Bool {
+        if case .swapWorkspace = self { return true }
+        return false
+    }
+
     /// The verbs a native-fullscreen window suspends: everything that moves the focus or a
     /// window, and the one that closes one.
     ///

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -1662,7 +1662,8 @@ h.test("the escape hatches are bound even when the config forgets them") { t in
     // The shipped config binds them itself, so nothing should be duplicated.
     let shipped = try Config.parse(Config.defaultTOML)
     for command in [Command.quit, .reload, .menu(.background), .menu(.theme),
-                    .growActive(dx: 100, dy: 0), .growActive(dx: 0, dy: 100)] {
+                    .growActive(dx: 100, dy: 0), .growActive(dx: 0, dy: 100),
+                    .swapWorkspace(-1), .swapWorkspace(1)] {
         t.equal(shipped.bindings.filter { $0.command == command }.count, 1,
                 "the shipped config binds \(command) exactly once")
     }
@@ -1706,6 +1707,29 @@ h.test("the escape hatches are bound even when the config forgets them") { t in
     t.equal(binding(equal, .growActive(dx: 100, dy: 0)), nil, "and is not given the resize on top")
     t.equal(binding(equal, .growActive(dx: -100, dy: 0))?.source, "super-minus", "while SUPER+- still lands")
     t.equal(binding(taken, .killActive)?.source, "super-ctrl-space", "still doing what you asked")
+
+    // `swapworkspace`, on the list for the reachability reason rather than the Omarchy one: the
+    // quick menu does not carry the verb, so a config written before it had no route to the
+    // feature at all. The case that prompted this was a real config that predated it and a user
+    // pressing the key from the README to no effect.
+    t.equal(binding(old, .swapWorkspace(-1))?.source, "super-ctrl-shift-left",
+            "a config written before workspaces could trade places still gets the key")
+    t.equal(binding(old, .swapWorkspace(1))?.source, "super-ctrl-shift-right",
+            "and its pair, because one direction is half a feature")
+    // Any swap on any key is an answer, whatever its direction or distance — the resize rule,
+    // for the same reason: a config with the verb already knows the feature is there.
+    let swapper = try Config.parse("[binds]\n\"super-y\" = \"swapworkspace 3\"\n")
+    t.equal(swapper.bindings.filter { $0.command.swapsWorkspaces }.count, 1,
+            "your own swap binding stands alone")
+    t.equal(binding(swapper, .swapWorkspace(3))?.source, "super-y", "on your key")
+    // Moving one direction elsewhere takes both keys back, since either answers for the verb.
+    let leftOnly = try Config.parse("[binds]\n\"super-z\" = \"swapworkspace left\"\n")
+    t.equal(leftOnly.bindings.filter { $0.command.swapsWorkspaces }.count, 1,
+            "binding one direction yourself stands the pair aside")
+    // And swapping a *window* is a different feature that answers for none of it.
+    let window = try Config.parse("[binds]\n\"super-shift-left\" = \"swapwindow l\"\n")
+    t.equal(binding(window, .swapWorkspace(-1))?.source, "super-ctrl-shift-left",
+            "swapwindow is not swapworkspace and does not stand it aside")
 }
 
 h.test("nan and infinity are refused rather than reaching the layout") { t in

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -160,9 +160,20 @@ final class Coordinator: WindowTrackerDelegate {
     /// Bumped whenever a slide is started or cancelled, so that a callback from an earlier one
     /// — a picture, a timer, an animation ending — finds it is no longer wanted and does nothing.
     private var slideGeneration = 0
-    /// How long the switch waits for the first picture before going ahead without one. A
-    /// capture is a few milliseconds once the capture session is warm, and the user's fingers
-    /// have just left the trackpad, so this is the most a swipe may be held up for a picture.
+    /// How long the switch waits for the first picture before going ahead without one. The
+    /// user's fingers have just left the trackpad, so this is the most a swipe may be held up
+    /// for a picture — past it the switch is made the plain way and the slide is dropped.
+    ///
+    /// This assumes a warm capture path, and until v0.20.0 that assumption was simply false:
+    /// nothing warmed it, so ScreenCaptureKit's first `captureImage` of the run — hundreds of
+    /// milliseconds of spinning up capture infrastructure — blew the budget every time, and the
+    /// swipes after it raced two full-resolution captures against this. That is what made the
+    /// slide a coin flip. `ScreenSnapshot.warm` and the wallpaper cache are the two halves of
+    /// making the sentence true, and with both of them in this number is left alone on measured
+    /// grounds rather than kept out of caution: over 63 swipes on a 5120×1440 display the one
+    /// capture still on the critical path ran 27 ms median, 53 ms p95, 60 ms worst, and not one
+    /// swipe missed the deadline. It was never the constant that was wrong. Re-measure before
+    /// touching it — `slide: outgoing picture after N ms (screen …, wallpaper …)` is the line.
     private static let slidePictureDeadline: TimeInterval = 0.1
     /// How long after the switch the second picture is taken. The Accessibility writes have
     /// returned by then, but that means the app has *received* its frame, not painted it —
@@ -857,7 +868,18 @@ final class Coordinator: WindowTrackerDelegate {
             snapshot.requestOnce()
             return
         }
-        snapshot.refresh()
+        snapshot.refresh { [weak self] in self?.warmSlide() }
+    }
+
+    /// The capture path, warmed for the displays as they are now.
+    ///
+    /// Always on the back of a `refresh` rather than beside it: `warm` can only point at a
+    /// display `SCShareableContent` has already named, so calling the two in a row would warm
+    /// nothing on the first run. `workspaces.monitors` is asked for the rects rather than
+    /// `NSScreen`, because these have to be the *same* rects a swipe will ask for or the
+    /// wallpaper cache misses on the very swipe it was taken for.
+    private func warmSlide() {
+        snapshot.warm(workspaces.monitors.map { (id: $0.id, area: $0.usable, frame: $0.frame) })
     }
 
     /// The macOS behaviours toe takes over, applied at startup and on every reload. None of them
@@ -1081,17 +1103,50 @@ final class Coordinator: WindowTrackerDelegate {
         switchWorkspace(target)
         let after = workspaces.activeWorkspace[monitorID]
 
-        guard config.animations.slideOnSwipe, before != after,
-              let direction = WorkspaceSlide.direction(for: target),
-              let monitor = workspaces.monitor(id: monitorID)
-        else { apply(refocus: true); return }
+        // Every skip from here on says so, and says which one it was. They were all silent until
+        // v0.20.0, and a slide that does not happen looks identical whichever guard stopped it —
+        // so "sometimes it slides" was undiagnosable from the log, which is the only instrument
+        // there is for a gesture. One guard per reason for that reason: a compound `guard` would
+        // be shorter and could only report the first arm's story for all of them.
+        guard config.animations.slideOnSwipe else { apply(refocus: true); return }
+
+        // `.next` can land on a workspace that lives on the other display, in which case the
+        // focus moved and this display's content did not. Nothing to slide, and this is the
+        // common one — not a fault.
+        guard before != after else {
+            Log.info("slide: skipped — display \(monitorID) is still showing"
+                     + " workspace \(before.map(String.init) ?? "none")")
+            apply(refocus: true)
+            return
+        }
+        guard let direction = WorkspaceSlide.direction(for: target) else {
+            // `.index` and `.former`, which no swipe produces — so this is a new caller, not a
+            // user's swipe, and worth saying out loud rather than silently not animating.
+            Log.info("slide: skipped — \(target) has no direction to slide in")
+            apply(refocus: true)
+            return
+        }
+        guard let monitor = workspaces.monitor(id: monitorID) else {
+            Log.info("slide: skipped — display \(monitorID) is not in the layout")
+            apply(refocus: true)
+            return
+        }
 
         // The grant may have landed since the config was applied — read it now, and if the
         // displays have not been listed since, list them for the next swipe. This one switches
         // the plain way rather than wait on an enumeration of every window on the system.
-        guard ScreenSnapshot.isGranted else { apply(refocus: true); return }
+        guard ScreenSnapshot.isGranted else {
+            Log.info("slide: skipped — Screen Recording is not granted")
+            apply(refocus: true)
+            return
+        }
+        // Also the recovery for a grant given in System Settings while toe ran: `refresh` refused
+        // to list anything at the time (see `applyAnimationSetting`), so `displays` was empty for
+        // the life of the process and every swipe landed here. It now costs the one swipe.
         guard snapshot.knows(display: monitor.id) else {
-            snapshot.refresh()
+            Log.info("slide: skipped — display \(monitor.id) is not listed yet;"
+                     + " listing and warming it for the next swipe")
+            snapshot.refresh { [weak self] in self?.warmSlide() }
             apply(refocus: true)
             return
         }
@@ -1147,6 +1202,8 @@ final class Coordinator: WindowTrackerDelegate {
         // slides, wallpaper and all, which is how the first version looked.
         var screen: CGImage??
         var wallpaper: CGImage??
+        var screenMs = 0
+        var wallpaperMs = 0
         let proceed = { [weak self] in
             guard let self, self.slideIs(.awaitingPicture, mine),
                   let screen, let wallpaper else { return }
@@ -1156,6 +1213,7 @@ final class Coordinator: WindowTrackerDelegate {
                 return
             }
             Log.info("slide: outgoing picture after \(ms()) ms"
+                     + " (screen \(screenMs) ms, wallpaper \(wallpaperMs) ms)"
                      + (wallpaper == nil ? " — no wallpaper picture, sliding the whole screen" : ""))
             self.slidePhase = .switching
             self.slide.begin(showing: image, over: monitor.usable, wallpaper: wallpaper,
@@ -1189,13 +1247,19 @@ final class Coordinator: WindowTrackerDelegate {
                 }
             }
         }
+        // Each capture's own time, reported together on the one line below rather than one line
+        // each: they race, and "no picture after 100 ms" cannot say which of the two was late —
+        // which is exactly the question the budget turns on, and was unanswerable from the log
+        // until v0.20.0.
         snapshot.capture(display: monitor.id, area: monitor.usable, frame: monitor.frame,
                          of: .everything) { image in
+            screenMs = ms()
             screen = .some(image)
             proceed()
         }
         snapshot.capture(display: monitor.id, area: monitor.usable, frame: monitor.frame,
                          of: .wallpaper) { image in
+            wallpaperMs = ms()
             wallpaper = .some(image)
             proceed()
         }
@@ -1438,7 +1502,12 @@ final class Coordinator: WindowTrackerDelegate {
         // A slide in flight is a picture of a screen that no longer exists in that shape.
         cancelSlide()
         refreshMonitors()
-        snapshot.refresh()
+        // Both cached pictures are of a screen that no longer has that shape — and the rects the
+        // wallpapers were keyed on have just changed, so they would miss anyway. Warmed again on
+        // the back of the new list, since `refreshMonitors` has already run and the rects are
+        // current.
+        snapshot.forgetWallpapers()
+        snapshot.refresh { [weak self] in self?.warmSlide() }
         desired.removeAll()
         corrections.removeAll()
         apply(refocus: false)

--- a/Sources/toe/UI/ScreenSnapshot.swift
+++ b/Sources/toe/UI/ScreenSnapshot.swift
@@ -26,6 +26,72 @@ final class ScreenSnapshot {
     /// alone.
     private var dock: SCRunningApplication?
     private var requested = false
+    /// The picture of the desktop behind each display, kept between swipes.
+    ///
+    /// The wallpaper is the one subject that does not change while a swipe happens — that is the
+    /// whole reason it is a picture of its own — so taking it again per swipe bought nothing and
+    /// cost the slide its budget: `beginSlide` waits for *both* pictures before the panel can go
+    /// up, and two concurrent captures compete for the same encoder. Learned at v0.20.0, where
+    /// the slide was a coin flip because of it — measured at 2-4 ms for a hit against 27-60 ms
+    /// for the capture it replaces, which is the difference between racing the deadline with one
+    /// picture and racing it with two. Keyed on the rect it was taken for *and* on the
+    /// desktop picture it was taken of, so a resolution change or a new wallpaper misses rather
+    /// than showing the wrong thing — see `CachedWallpaper`.
+    ///
+    /// The cost is memory, and it is worth naming: one picture per attached display, held for as
+    /// long as that display is attached. `SlideOverlay.hide` drops its three pictures precisely
+    /// so that they are not held, so the reasoning has to be met head on — **peak** memory is
+    /// unchanged, because during a slide this is one of those three anyway; what grows is the
+    /// steady state, between swipes. `wallpaperScale` is what keeps that number small enough to
+    /// be worth it: 7.4 MB per display on a 5120×1440 screen rather than 29.5. Bounded by the
+    /// number of displays and by nothing the user does — but it is still why nothing else here
+    /// is cached, and why a fourth picture should not be.
+    private var wallpapers: [CGDirectDisplayID: CachedWallpaper] = [:]
+
+    /// A cached desktop picture, with everything a swipe has to agree with before it may use it.
+    private struct CachedWallpaper {
+        var area: Box
+        var frame: Box
+        /// What `NSWorkspace` said the desktop picture was when this was taken.
+        ///
+        /// The wallpaper is written by toe on a theme change (`Wallpaper.set`) *and* by the user
+        /// in System Settings, and a cache with no answer for the second would slide the previous
+        /// picture under the windows until the next display change. One rule covers both: the hit
+        /// is checked against the live URL, which is the same cheap read-back `Wallpaper.apply`
+        /// already leans on. Deliberately not a notification from `Wallpaper` as well — that
+        /// would catch the subset this already catches, and be the copy that drifts. Not
+        /// airtight, though: a dynamic or shuffling desktop
+        /// picture changes what is on screen without changing its URL, and that one slide is
+        /// wrong. It is a picture of the desktop behind moving windows for a third of a second,
+        /// and worth less than a capture per swipe.
+        var picture: URL?
+        var image: CGImage
+    }
+
+    /// How much of the wallpaper's resolution is worth taking, as a fraction of the display's.
+    ///
+    /// The only picture here that may be shrunk, and the reason is what each one has to survive
+    /// being looked at *while standing still*:
+    ///
+    /// - The outgoing picture is shown static over the live screen for `slidePanelLatency`
+    ///   before anything moves, and it is a photograph of exactly what is already there. At full
+    ///   resolution it is invisible; at anything less the whole screen would go soft for a frame
+    ///   and then slide, which is the "flash before the slide" that `SlideOverlay.begin`'s
+    ///   `CATransaction.flush` exists to prevent. Full resolution, always.
+    /// - The incoming picture comes to rest showing the new workspace, and the live screen only
+    ///   replaces it when the panel goes down. A soft one would snap sharp at the end. Same.
+    /// - The wallpaper never stands in for anything sharp. It is a backdrop, behind window
+    ///   pictures that are moving over it, for one `slide_duration`, and half of it is under a
+    ///   window at any moment. `CALayer.contentsGravity = .resize` stretches it back up for
+    ///   free (see `SlideOverlay`), and bilinear upscaling of a desktop picture at this size is
+    ///   not something the eye has time to find.
+    ///
+    /// A half in each direction is a quarter of the pixels: on a 5120×1440 display that is 29.5
+    /// MB down to 7.4 MB, and it is the one of the three that is *kept* between swipes, so this
+    /// is the number that decides toe's steady-state footprint. It also makes the capture itself
+    /// cheaper, which the deadline gets the benefit of. Lower it further if the footprint matters
+    /// more than the backdrop does; the wallpaper is the only thing that gets worse.
+    private static let wallpaperScale = 0.5
 
     /// Whether Screen Recording is granted. Read on every swipe rather than once: a grant given
     /// in System Settings while toe runs is worth noticing without a relaunch, where it lands.
@@ -49,7 +115,12 @@ final class ScreenSnapshot {
 
     /// Learns what is on screen. Asynchronous, and a failure keeps whatever was known before:
     /// a display list that is stale by one screen is still right about the others.
-    func refresh() {
+    ///
+    /// `then` runs on the main queue once the list is in, and only then — it is where the caller
+    /// warms the capture path (`warm`), which cannot be done before there is a display to point
+    /// it at. It does not run if the grant is missing or the enumeration failed, because in
+    /// neither case is there anything to warm.
+    func refresh(then: (() -> Void)? = nil) {
         guard Self.isGranted else { return }
         SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: false) { [weak self] content, error in
             DispatchQueue.main.async {
@@ -62,8 +133,52 @@ final class ScreenSnapshot {
                 self.toe = content.applications.first { $0.processID == getpid() }
                 self.dock = content.applications.first { $0.bundleIdentifier == "com.apple.dock" }
                 Log.info("slide: \(self.displays.count) display(s) can be pictured")
+                then?()
             }
         }
+    }
+
+    /// Builds the capture pipeline before a swipe needs it, and fills the wallpaper cache doing so.
+    ///
+    /// ScreenCaptureKit's first `captureImage` in a process is hundreds of milliseconds — it is
+    /// spinning up capture infrastructure, not photographing a screen — which is more than the
+    /// whole slide budget and is why the first swipe of every run never slid. `refresh` warmed
+    /// the display *list* and nothing else; the comment on `slidePictureDeadline` has always
+    /// claimed a warm session, and this is what finally makes that true.
+    ///
+    /// The warm-up is a real wallpaper capture rather than a throwaway, so the cost buys the
+    /// cache as well. Areas are `Monitor.usable` / `Monitor.frame`, exactly as a swipe will ask
+    /// for them, or the cache would miss on the very first swipe it was taken for.
+    func warm(_ areas: [(id: CGDirectDisplayID, area: Box, frame: Box)]) {
+        guard Self.isGranted else { return }
+        let started = Date()
+        for a in areas where displays[a.id] != nil {
+            capture(display: a.id, area: a.area, frame: a.frame, of: .wallpaper) { image in
+                // The size is here rather than left to arithmetic: it is the one place to see
+                // that `wallpaperScale` is being applied, and what it is costing in memory.
+                Log.info("slide: display \(a.id) warm after"
+                         + " \(Int(Date().timeIntervalSince(started) * 1000)) ms"
+                         + (image.map { " — wallpaper \($0.width)×\($0.height),"
+                                        + " \($0.width * $0.height * 4 / 1_048_576) MB" }
+                            ?? " — no wallpaper picture"))
+            }
+        }
+    }
+
+    /// The desktop picture `NSWorkspace` currently has on `id`, or nil if that display is not
+    /// one AppKit is listing — which is not a failure worth logging, only a cache that misses.
+    private static func desktopPicture(of id: CGDirectDisplayID) -> URL? {
+        NSScreen.screens.first { $0.displayID == id }
+            .flatMap { NSWorkspace.shared.desktopImageURL(for: $0) }
+    }
+
+    /// Drops the cached desktop pictures, for a display change: the rects they were keyed on
+    /// have just stopped meaning anything, so this is freeing memory rather than correcting an
+    /// answer — `CachedWallpaper` would have missed on its own. A *new wallpaper* needs nothing
+    /// called; that is the URL check's job, and calling something here as well is the second
+    /// place the rule could drift from.
+    func forgetWallpapers() {
+        wallpapers.removeAll()
     }
 
     /// What a picture is of.
@@ -87,6 +202,16 @@ final class ScreenSnapshot {
     func capture(display id: CGDirectDisplayID, area: Box, frame: Box, of subject: Subject,
                  completion: @escaping (CGImage?) -> Void) {
         guard let display = displays[id] else { completion(nil); return }
+
+        // A cache hit answers on the spot rather than on the next turn of the main queue. That is
+        // the point of it — the slide is racing a deadline measured in a few frames — and it is
+        // safe because every caller is already on the main queue and treats this as a callback
+        // that may have run by the time `capture` returns; see `beginSlide`'s `proceed`.
+        if case .wallpaper = subject, let have = wallpapers[id], have.area == area, have.frame == frame,
+           have.picture == Self.desktopPicture(of: id) {
+            completion(have.image)
+            return
+        }
 
         // Two shapes of filter, and they differ in more than the list: a filter that *excludes*
         // applications starts from the whole display, wallpaper included, and a filter that
@@ -112,16 +237,27 @@ final class ScreenSnapshot {
         // and default to 1920 × 1080 whatever the rect, so they are set from the rect and the
         // display's own scale, or a Retina picture comes back at half its resolution.
         let scale = CGFloat(filter.pointPixelScale)
+        // `sourceRect` still names the whole region — it is what is photographed, not how big
+        // the photograph is. Only the pixel count asked for shrinks, and only for the wallpaper.
+        var wanted = 1.0
+        if case .wallpaper = subject { wanted = Self.wallpaperScale }
         config.sourceRect = CGRect(x: area.x - frame.x, y: area.y - frame.y, width: area.w, height: area.h)
-        config.width = Int((area.w * scale).rounded())
-        config.height = Int((area.h * scale).rounded())
+        config.width = max(1, Int((area.w * scale * wanted).rounded()))
+        config.height = max(1, Int((area.h * scale * wanted).rounded()))
         config.showsCursor = false
         config.captureResolution = .best
 
-        SCScreenshotManager.captureImage(contentFilter: filter, configuration: config) { image, error in
+        SCScreenshotManager.captureImage(contentFilter: filter, configuration: config) { [weak self] image, error in
             DispatchQueue.main.async {
                 if image == nil {
                     Log.error("slide: capture failed: \(error?.localizedDescription ?? "no image")")
+                }
+                if case .wallpaper = subject, let self, let image {
+                    // Read *after* the capture, not before: a wallpaper written in between would
+                    // otherwise be cached under the old URL and never noticed.
+                    self.wallpapers[id] = CachedWallpaper(area: area, frame: frame,
+                                                          picture: Self.desktopPicture(of: id),
+                                                          image: image)
                 }
                 completion(image)
             }


### PR DESCRIPTION
Two unrelated fixes, both of which were a feature reaching the user only some of the time. One commit, as asked.

## The workspace slide was a coin flip

`beginSlide` issued **two** captures — the screen and the wallpaper — and put its panel up only when both had landed, racing a 100 ms deadline. The comment on `slidePictureDeadline` claimed *"a capture is a few milliseconds once the capture session is warm"*, and nothing in toe ever warmed one: `ScreenSnapshot.capture` calls `SCScreenshotManager.captureImage`, a one-shot that builds its filter, spins up capture and tears down again, and `refresh()` cached only the `SCDisplay` list.

So the first capture of every run paid ScreenCaptureKit's cold start — measured at 78 ms for the *cheaper* of the two filters — which is why the first swipe after a launch or reload never slid; and the swipes after it raced two full-resolution captures against the same 100 ms, which is why the rest were a coin flip. Both reported symptoms, one cause.

`ScreenSnapshot.warm` now builds the pipeline on the back of `refresh`'s completion, so the cold start is paid at startup rather than on a gesture, and it takes a real wallpaper picture doing it, which fills a cache. The wallpaper is the one subject that cannot change while a swipe happens, so a swipe now issues one capture instead of waiting on a pair. The cache is keyed on the rect *and* on the live `NSWorkspace.desktopImageURL`, so a resolution change or a new desktop picture misses rather than showing the wrong thing — one rule in one place, deliberately not a notification from `Wallpaper` as well, which would catch the subset this already catches and be the copy that drifts.

### Measured, 63 swipes on a 5120×1440 display

| | before | after |
|---|---|---|
| wallpaper picture | full capture, racing the deadline | **2–4 ms** (cache hit) |
| screen picture | one of two concurrent captures | 27 ms median, 53 p95, 60 max |
| deadline misses | the coin flip | **0 / 63** |
| skips / capture failures | — | **0 / 0** |

`slidePictureDeadline` is therefore left at 100 ms, on measured grounds rather than out of caution — it was never the constant that was wrong. `wallpaperScale` takes the cached picture at half resolution per axis, 7.4 MB rather than 29.5 on that display. It is the only one of the three pictures that can be shrunk: the other two are each shown *standing still* at some point (outgoing over the live screen before anything moves, incoming at rest before the panel drops) and a soft one would visibly snap sharp.

### The silent guards

All five skips in `swipeToWorkspace` now say which one fired. A slide that does not happen looks identical whichever guard stopped it, and a gesture has no instrument but the log, so "sometimes it slides" was not diagnosable at all. One guard per reason — a compound one can only report the first arm's story for all of them.

Fixed with them: a grant given in System Settings mid-run. `applyAnimationSetting` returned without calling `refresh`, and `refresh` refuses when the grant is missing, so `displays` stayed empty for the life of the process and *every* swipe took the `knows(display:)` miss. It now costs one swipe and warms on the way.

## `swapworkspace` gets a fallback key

A config's `[binds]` replaces the defaults rather than merging, and is never rewritten, so the binding shipped in v0.20.0 reached nobody who already had a config. Diagnosed from a real config: 41 bind lines + 6 fallbacks = the 47 the log reported, with `swapworkspace` among the eight missing and the only one not covered.

Unlike the resize keys and the menu rows, it has no Omarchy or Hyprland counterpart, so the "upstream habit to satisfy" argument that carried those is not available. What carried this one is that the quick menu does not carry the verb either, which left it **the one command in toe reachable by no route at all** from an older config. The list's comment is amended to say that outright: the question is not whether a binding is new — true of every one from here on — but whether the command has any other route. That is the narrower bar, and stating it is what keeps the list from growing to hold everything.

Standing aside gains `Command.swapsWorkspaces` alongside `resizes`: any swap on any key, in any direction or distance, keeps both fallbacks away, because a config that has the verb already knows the feature is there. `swapwindow` is a different feature and answers for none of it.

## Tests

`make test`: **1360 assertions pass** (+8). Debug and release both build clean. No AppKit reached ToeCore.