### PR TITLE
Give toe a command line, and a skill so an agent can use it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,12 +30,17 @@ executable rather than XCTest (XCTest ships with Xcode, not the Command Line Too
 `make test` working on a bare CLT machine). The whole suite is ~600 assertions and runs in about a
 second, so run all of it. Failures print as `test name:line — what: got X, want Y`.
 
+`toe query state` and the rest of the command line are the same binary talking to the running
+agent — see "The control socket" below.
+
 **Diagnostics without launching the agent:**
 
 ```sh
 toe --version                # what the bundle was stamped with
 toe --print-default-config   # the shipped default TOML
 toe --print-corner-radius    # what macOS rounds each on-screen window to
+toe help                     # the command line's own usage (also what a bare `toe` prints)
+toe skill print              # the generated Claude Code skill, without writing it anywhere
 log stream --predicate 'subsystem == "com.clifmeister.toe"' --level info
 ```
 
@@ -133,6 +138,56 @@ rather than expired by age.
 **AX calls are synchronous and on the main thread**, capped at 250 ms (`axMessagingTimeout`). They
 are not rare — `isManageable` alone is six round trips per candidate window. Adding one to a path
 that runs on every focus change or stack change is a real cost; put it after the cheap conditions.
+
+## The control socket
+
+`toe <verb>` is the same binary, deciding by argv before `NSApplication` exists — the shape
+`--version` and `--print-default-config` already had. It connects to a Unix socket at
+`~/.local/state/toe/toe.sock` and the running agent answers. A Mach service would be the more
+macOS answer and is not available: it needs a `MachServices` key in a launchd plist, and toe is as
+often started by `open Toe.app`, which never goes through launchd.
+
+The split follows the two-target rule. `ToeCore/Control` holds the wire types, the argv parsing,
+the selectors, the verb catalogue, the layout profiles and the generated skill document — all of
+it pure, all of it in the selftest. `toe/Control` holds the socket, the client, and the assembly
+of live state into `StateReport`.
+
+Three things here are easy to break:
+
+- **The socket runs on the main thread**, because a request ends in Accessibility writes and those
+  are main-thread-only. So nothing in `ControlSocket` may block: non-blocking descriptors, a
+  64 KiB cap, a two-second deadline on a connection that has not produced a whole request, a
+  write source for partial writes, and `SO_NOSIGPIPE` on every accepted descriptor.
+- **A batch renders once.** `Coordinator.batch` holds `apply` while a run of commands executes,
+  because every arm of `dispatch` ends in its own `apply` and ten of those is an arrangement
+  assembling itself on screen. Only synchronous runs are ever wrapped.
+- **`exec` and `quit` are gated** by `[cli] allow_exec` / `allow_quit`, and `CommandCatalogue.gate`
+  is where that is decided. The socket is not a privilege boundary — it is mode 600 in your own
+  home directory — but a window manager with one verb that runs shell lines should not hand a
+  shell to everything that learns to talk to it as a side effect. A new verb that runs anything
+  belongs on that list.
+
+**A bare `toe` from a shell is not the agent.** `make install-cli` and the cask's `binary` stanza
+both put `toe` on the PATH, at which point somebody types it to see what it does — and started from
+a shell the agent inherits that shell's process group, so closing the tab signals it and
+`installSignalHandlers` shuts it down, after `takeOver` has already stopped the copy that was
+running properly. `isatty` on **either** standard input or standard output separates that from
+launchd and `open Toe.app`, which have neither; one alone leaves a hole that `toe | head` or
+`toe > log` walks through, which is how this was found. `toe agent` is the deliberate way in from a
+shell.
+
+`Command.acceptsTarget` is the other rule worth knowing: `--window` may only be pointed at the
+verbs whose meaning survives being aimed away from the focus. The directional ones do not — they
+mean "from where the focus is" — and the catalogue's `--window` column is computed from that
+property rather than written down beside it, so the table cannot claim a target the dispatcher
+would refuse.
+
+The skill document (`SkillDocument`) is generated rather than committed, and its verb table comes
+from `CommandCatalogue`, so a verb added to the table reaches the file without anybody remembering
+to. The prose around it is the part that cannot be derived, and it is the reason the file exists:
+workspaces are not Spaces, fullscreen suspends half the verbs, a float is the user's. Installing
+it is `Install › Claude Code skill` in the quick menu, `toe skill install` on the command line, or
+the `installskill` verb.
 
 ## Accessibility and code signing
 

--- a/Casks/toe.rb
+++ b/Casks/toe.rb
@@ -20,6 +20,15 @@ cask "toe" do
 
   app "Toe.app"
 
+  # `toe` on the PATH, pointing into the bundle rather than at a copy of it — the same binary is
+  # the window manager and the command line that steers it, told apart by its first argument, so
+  # there is nothing else to install and nothing that can fall out of step with the app.
+  #
+  # Homebrew symlinks this into its own bin, which is already on the PATH of anyone who installed
+  # toe this way, and removes it on uninstall. See `toe help`, and `toe skill install` for the
+  # Claude Code skill.
+  binary "#{appdir}/Toe.app/Contents/MacOS/toe"
+
   uninstall launchctl: "com.clifmeister.toe",
             quit:      "com.clifmeister.toe"
 
@@ -40,6 +49,10 @@ cask "toe" do
       notarized, where it used to carry a self-signed certificate. macOS keys Accessibility
       to the signature, so it sees this as a different app: remove the old toe entry from the
       Accessibility list, then add the new one. One time only — later upgrades keep the grant.
+
+      `toe` is now on your PATH as well: `toe query state` says what is open and where,
+      `toe dispatch "workspace 3"` drives it, and `toe help` lists the rest. `toe skill install`
+      writes a Claude Code skill so an agent can do the same.
 
       To start toe at login, see "Start at login" at #{cask.homepage}
     EOS

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,11 @@ BUNDLEID    := com.clifmeister.toe
 DEVBUNDLEID := com.clifmeister.toe.dev
 AGENT       := $(HOME)/Library/LaunchAgents/$(BUNDLEID).plist
 
-.PHONY: all build test bundle dev-bundle run install uninstall dev-cert reset-perms start-at-login stop-at-login example-config icon clean
+# Where `make install-cli` puts the symlink. Homebrew's bin if there is one — it is already on
+# the PATH of anyone who has brew — and /usr/local/bin otherwise, which may want sudo.
+BINDIR      ?= $(shell brew --prefix 2>/dev/null || echo /usr/local)/bin
+
+.PHONY: all build test bundle dev-bundle run install uninstall install-cli uninstall-cli dev-cert reset-perms start-at-login stop-at-login example-config icon clean
 
 all: bundle
 
@@ -45,7 +49,23 @@ install: bundle
 	@cp -R $(APP) /Applications/Toe.app
 	@echo "installed /Applications/Toe.app — run 'make start-at-login' to launch it at login"
 
-uninstall: stop-at-login
+## `toe` on the PATH, for an install from source. The Homebrew cask does this itself with its
+## `binary` stanza, so this is only for `make install`. The symlink points into the bundle rather
+## than at a copy: the same binary is the agent and the command line, told apart by argv, and a
+## copy would go stale the next time you built.
+install-cli:
+	@test -x /Applications/Toe.app/Contents/MacOS/toe \
+	    || { echo "install /Applications/Toe.app first — run 'make install'"; exit 1; }
+	@mkdir -p $(BINDIR) 2>/dev/null || true
+	@ln -sf /Applications/Toe.app/Contents/MacOS/toe $(BINDIR)/toe 2>/dev/null \
+	    || { echo "could not write $(BINDIR)/toe — try 'sudo make install-cli', or BINDIR=~/bin"; exit 1; }
+	@echo "linked $(BINDIR)/toe — try 'toe help'"
+
+uninstall-cli:
+	@rm -f $(BINDIR)/toe
+	@echo "removed $(BINDIR)/toe"
+
+uninstall: stop-at-login uninstall-cli
 	@pkill -x toe 2>/dev/null || true
 	@rm -rf /Applications/Toe.app
 	@echo "removed /Applications/Toe.app"

--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ Binding specs accept the dash spelling and Omarchy's, so `"alt-shift-1"`, `"supe
 `"SUPER SHIFT, 1"` all mean the same. The commands are `movefocus`, `swapwindow`, `movewindow`,
 `workspace`, `movetoworkspace`, `movetoworkspacesilent`, `swapworkspace`, `killactive`,
 `togglefloating`, `togglesplit`, `swapsplit`, `growactive`, `resizeactive`, `exec`, `reload`,
-`menu`, `keybindings`, `theme`, `removetheme`, `background`, `nextbackground` and `quit`.
+`menu`, `keybindings`, `theme`, `removetheme`, `background`, `nextbackground`, `installskill`,
+`removeskill` and `quit`.
 `growactive <dx> <dy>` grows the focused window by that much; Hyprland's `resizeactive` moves the
 split by that much instead, which from a right-hand window is the other way round, and is accepted
 for configs copied from Omarchy. `swapworkspace left` / `right` is toe's own: it renumbers two
@@ -162,11 +163,66 @@ Other sections worth knowing about:
   default because it needs Screen Recording, a second permission; Trigger › Toggle in the quick
   menu flips it.
 - `[bar] persistent_workspaces` — how many workspaces always keep a slot on the menu bar.
+- `[cli]` — the command line below: whether its socket is opened at all, and whether `exec` and
+  `quit` may travel over it. Both are refused by default.
 
 **Treat the config as code.** An `exec` binding runs whatever the file says through `/bin/sh`,
 and toe reloads the file within a moment of it changing — so anything that can write it can run
 commands as you. toe creates it `0600` and warns in the menu bar if it is later found writable by
 others. Symlinking it into a dotfiles repository works fine.
+
+## The command line
+
+`toe` is a command as well as a window manager. Run with a verb, it talks to the copy already
+running over a socket at `~/.local/state/toe/toe.sock` — mode `0600`, in a `0700` directory, and
+refused to any user but you.
+
+```sh
+toe query state                          # what is open, where, and on which workspace
+toe query commands                       # every verb dispatch accepts
+toe dispatch "workspace 3"
+toe dispatch "movetoworkspace 2" "workspace 2"       # several, drawn once at the end
+toe dispatch --window app:Safari "movetoworkspace 3"
+toe focus app:Ghostty
+toe layout save work                     # remember an arrangement
+toe layout apply work                    # and put it back, by application rather than window id
+toe help
+```
+
+Replies are JSON on stdout — `{"ok":true,"result":…}`. A refusal exits 1 with a sentence on
+stderr; a mistyped command exits 2 without reaching toe at all. Selectors are `id:`, `app:`,
+`bundle:`, `title:` and `workspace:`, and a bare word tries the application first, then the title;
+a selector matching more than one window is refused with the candidates listed.
+
+**Getting `toe` onto your `PATH`.** Installed with Homebrew you already have it — the cask
+symlinks the binary into Homebrew's `bin`. From source, `make install-cli` does the same into
+`$(brew --prefix)/bin`, or wherever `BINDIR` points:
+
+```sh
+make install && make install-cli      # or: BINDIR=~/bin make install-cli
+```
+
+Either way the link points *into* the bundle rather than at a copy of it: the same binary is the
+window manager and the command line, told apart by its first argument. Without a link it is
+`/Applications/Toe.app/Contents/MacOS/toe`.
+
+Which means a bare `toe` typed at a prompt would otherwise start a window manager as a child of
+your shell — one that takes over from the copy running properly and then dies when you close the
+tab. So from a shell, `toe` with no arguments prints the usage; with no terminal at either end,
+which is how launchd and `open Toe.app` start it, it is the window manager. `toe agent` runs it in
+your shell deliberately.
+
+**Driving toe from an agent.** `toe skill install` writes a Claude Code skill into
+`~/.claude/skills/toe/SKILL.md` — the verb table, the selector syntax, and the handful of things
+about this window manager that nothing else would tell you: that a workspace is not a macOS Space,
+that a fullscreen window suspends half the verbs, that a floating window is the user's. The verb
+half is generated from toe's own table, so it cannot drift out of step with the program. The quick
+menu has the same row under Install › Claude Code skill, ticked once the file is there, and Remove
+takes it away again. `toe skill print` shows the document without writing it anywhere.
+
+`exec` and `quit` do not travel over the socket unless `[cli] allow_exec` / `allow_quit` say so.
+`exec` runs a shell line, and a control socket that carried it would hand a shell to everything
+that learned to talk to toe.
 
 ## From source
 
@@ -190,8 +246,9 @@ log stream --predicate 'subsystem == "com.clifmeister.toe"' --level info
 
 ## Not included
 
-By design: no scratchpads, no binding modes, no scripting API, no window groups. It is a
-layout engine and the bindings that drive it.
+By design: no scratchpads, no binding modes, no window groups, and no scripting language. The
+command line above is not one — it is the same verbs the keys send, spelled out loud so something
+else can send them. It is a layout engine, the bindings that drive it, and one socket.
 
 ## License
 

--- a/Sources/ToeCore/Config/Config.swift
+++ b/Sources/ToeCore/Config/Config.swift
@@ -142,6 +142,38 @@ public struct MiscConfig: Equatable {
 }
 
 /// A window that should float instead of joining the dwindle tree.
+/// `[cli]` — what the `toe` command line, and whatever is driving it, is allowed to do.
+///
+/// The socket is not a privilege boundary: it lives in your home directory, mode 600, and
+/// anything running as you could equally well press the keys. What it is is a *blast radius*.
+/// `Command.exec` runs a shell line, so a control socket that carried it would hand a shell to
+/// every script and every language model that learned to talk to toe — not by anyone's decision,
+/// but as a side effect of window management having one verb that runs programs. `quit` is the
+/// same shape of mistake pointing the other way: a caller that stops toe cannot start it again,
+/// and the user is left with a machine that has stopped tiling for reasons nothing on screen
+/// explains.
+///
+/// Both stay bound to keys, where a person pressed them. Neither travels over the socket unless
+/// this section says so, and the refusal names the key to set — a setting nobody can find is a
+/// setting that reads as a bug.
+public struct CLIConfig: Equatable {
+    /// Whether the socket is opened at all. Off is a complete answer for anyone who wants toe
+    /// and does not want anything else able to drive it.
+    public var enabled: Bool = true
+    public var allowExec: Bool = false
+    public var allowQuit: Bool = false
+
+    /// Why this command may not come in over the socket, or nil when it may.
+    public func refusal(for command: Command) -> String? {
+        guard let gate = CommandCatalogue.gate(command) else { return nil }
+        switch gate.key {
+        case "cli.allow_exec": return allowExec ? nil : gate.reason
+        case "cli.allow_quit": return allowQuit ? nil : gate.reason
+        default:               return gate.reason
+        }
+    }
+}
+
 public struct FloatRule: Equatable {
     /// Bundle identifier. `*` matches any run of characters.
     public var app: String?
@@ -195,6 +227,7 @@ public struct Config: Equatable {
     public var menu: MenuConfig = MenuConfig()
     public var theme: ThemeConfig = ThemeConfig()
     public var misc: MiscConfig = MiscConfig()
+    public var cli: CLIConfig = CLIConfig()
     public var bindings: [Binding] = []
     public var floatRules: [FloatRule] = Config.defaultFloatRules
     /// Non-fatal problems (a binding that would not parse, an unknown key). Surfaced in the
@@ -613,6 +646,25 @@ public struct Config: Equatable {
                     config.misc.restoreSession = v
                 } else {
                     config.warnings.append("misc.restore_session: must be true or false, using \(config.misc.restoreSession)")
+                }
+            }
+        }
+
+        if let c = root["cli"]?.tableValue {
+            // Told apart from absent rather than coerced, the way `[misc]` and `[gestures]` do
+            // it: a mistyped boolean here is the difference between a socket and no socket, and
+            // silence about that is indistinguishable from toe ignoring the file.
+            for (key, path) in [("enabled", "cli.enabled"), ("allow_exec", "cli.allow_exec"),
+                                ("allow_quit", "cli.allow_quit")] {
+                guard let raw = c[key] else { continue }
+                guard let value = raw.boolValue else {
+                    config.warnings.append("\(path): must be true or false, leaving it alone")
+                    continue
+                }
+                switch key {
+                case "enabled":    config.cli.enabled = value
+                case "allow_exec": config.cli.allowExec = value
+                default:           config.cli.allowQuit = value
                 }
             }
         }

--- a/Sources/ToeCore/Config/DefaultConfig.swift
+++ b/Sources/ToeCore/Config/DefaultConfig.swift
@@ -181,6 +181,40 @@ prevent_hiding = true
 # choice you made rather than a window arrangement toe worked out for you.
 restore_session = true
 
+[cli]
+# `toe` is a command line as well as a window manager. Run with a verb it talks to the copy already
+# running, over a socket at ~/.local/state/toe/toe.sock — 0600, in a 0700 directory, and refused to
+# any user but you:
+#
+#   toe query state                          what is open, where, and on which workspace
+#   toe query commands                       every verb dispatch accepts
+#   toe dispatch "workspace 3"               run one
+#   toe dispatch "movetoworkspace 2" "workspace 2"    run several, drawn once at the end
+#   toe dispatch --window app:Safari "movetoworkspace 3"
+#   toe layout save work / toe layout apply work      remember an arrangement, and put it back
+#   toe help                                 all of it
+#
+# The binary is inside the app bundle, so it is /Applications/Toe.app/Contents/MacOS/toe unless you
+# have put a symlink to it on your PATH.
+#
+# This exists so that something else can drive toe — a script, or a language model with a terminal.
+# `toe skill install` writes a page for Claude Code into ~/.claude/skills/toe describing all of the
+# above, generated from toe's own verb table so it cannot go stale; SUPER+SPACE > Install has the
+# same row, and Remove takes it away again.
+enabled = true
+
+# Two verbs are refused over that socket regardless, unless these say otherwise. They stay bound to
+# keys either way, where a person pressed them.
+#
+# `exec` runs a shell line, so a socket that carried it would hand a shell to every script and every
+# agent that learned to talk to toe — not by anyone's decision, but because window management
+# happens to have one verb that runs programs. Turn it on if you want that; know that it is what you
+# are turning on.
+allow_exec = false
+# `quit` stops toe, and a caller that stops toe cannot start it again — leaving a machine that has
+# stopped tiling for reasons nothing on screen explains.
+allow_quit = false
+
 [bar]
 # waybar's persistent-workspaces: the fewest slots the bar ever has, so a fresh session still
 # shows 1-5, the empty ones dimmed. It is a floor and not a claim on the first five: once five

--- a/Sources/ToeCore/Control/CommandCatalogue.swift
+++ b/Sources/ToeCore/Control/CommandCatalogue.swift
@@ -1,0 +1,179 @@
+import Foundation
+
+/// One verb, described for somebody who has never seen toe's config.
+///
+/// `sample` is not decoration. It is a line that must parse, and the selftest parses every one
+/// of them — so a verb described here and misspelled, or given an argument it does not take, is
+/// a test failure rather than a sentence a language model will believe. It is also where
+/// `takesWindow` comes from, which keeps this table from claiming a target the dispatcher would
+/// refuse.
+public struct CommandDescriptor: Equatable, Sendable {
+    public let verb: String
+    public let aliases: [String]
+    /// What goes after the verb, in the shape a caller should type it, or nil for the verbs
+    /// that take nothing.
+    public let argument: String?
+    public let summary: String
+    public let sample: String
+
+    public init(verb: String, aliases: [String] = [], argument: String? = nil,
+                summary: String, sample: String) {
+        self.verb = verb
+        self.aliases = aliases
+        self.argument = argument
+        self.summary = summary
+        self.sample = sample
+    }
+
+    /// Whether `--window` means anything for this verb — asked of the command the sample parses
+    /// to, so the answer is the dispatcher's own and not a second opinion about it.
+    public var takesWindow: Bool {
+        (try? CommandParser.parse(sample))?.acceptsTarget ?? false
+    }
+
+    public var usage: String {
+        argument.map { "\(verb) \($0)" } ?? verb
+    }
+}
+
+/// One verb as JSON — `toe query commands`.
+///
+/// A projection rather than making `CommandDescriptor` itself `Codable`, because the field that
+/// matters most to a caller is the one the descriptor computes: whether `--window` works. A
+/// synthesised encoding would quietly leave it out.
+public struct CommandReport: Codable, Equatable, Sendable {
+    public var verb: String
+    public var aliases: [String]
+    public var argument: String?
+    /// Whether `dispatch --window` may point this verb at a window other than the focused one.
+    public var window: Bool
+    public var summary: String
+    public var example: String
+}
+
+public extension CommandDescriptor {
+    var report: CommandReport {
+        CommandReport(verb: verb, aliases: aliases, argument: argument,
+                      window: takesWindow, summary: summary, example: sample)
+    }
+}
+
+/// The saved layout profiles, and where they live — so a caller that wants to read or edit one
+/// by hand is not left guessing at the directory.
+public struct LayoutsReport: Codable, Equatable, Sendable {
+    public var directory: String
+    public var layouts: [String]
+
+    public init(directory: String, layouts: [String]) {
+        self.directory = directory
+        self.layouts = layouts
+    }
+}
+
+/// Every verb `CommandParser` accepts, as a table.
+///
+/// This exists because the caller on the other end of the socket cannot read the config file to
+/// find out what toe can do — and because the alternative, letting a model infer the vocabulary
+/// from Hyprland's documentation, produces confident calls to verbs toe does not have. `toe
+/// query commands` is the answer to "what can I say", and the skill document is generated from
+/// this same table, so the two cannot disagree.
+///
+/// Ordered the way `MenuModel.rank` orders the keybindings page — focus, then windows, then
+/// workspaces, then how it all looks, then toe itself — because that is the order somebody
+/// learns them in.
+public enum CommandCatalogue {
+
+    public static let entries: [CommandDescriptor] = [
+        CommandDescriptor(verb: "movefocus", aliases: ["focus"], argument: "l|r|u|d",
+                          summary: "Move the focus to the window in that direction.",
+                          sample: "movefocus l"),
+        CommandDescriptor(verb: "swapwindow", aliases: ["swap"], argument: "l|r|u|d",
+                          summary: "Trade places with the window in that direction.",
+                          sample: "swapwindow r"),
+        CommandDescriptor(verb: "movewindow", aliases: ["move"], argument: "l|r|u|d",
+                          summary: "Move the focused window that way in the tree, or to the next monitor.",
+                          sample: "movewindow r"),
+        CommandDescriptor(verb: "killactive", aliases: ["close"],
+                          summary: "Close the window.",
+                          sample: "killactive"),
+        CommandDescriptor(verb: "togglefloating", aliases: ["float"],
+                          summary: "Step the window round the floating cycle: tiled, floating, larger, tiled.",
+                          sample: "togglefloating"),
+        CommandDescriptor(verb: "togglesplit",
+                          summary: "Flip the focused window's split between side-by-side and stacked.",
+                          sample: "togglesplit"),
+        CommandDescriptor(verb: "swapsplit",
+                          summary: "Swap the two halves of the focused window's split.",
+                          sample: "swapsplit"),
+        CommandDescriptor(verb: "growactive", argument: "<dx> <dy>",
+                          summary: "Grow the window by that many points; negative shrinks it.",
+                          sample: "growactive 100 0"),
+        CommandDescriptor(verb: "resizeactive", argument: "<dx> <dy>",
+                          summary: "Move the window's split by that many points — Hyprland's verb, "
+                                 + "where growactive is toe's.",
+                          sample: "resizeactive 100 0"),
+        CommandDescriptor(verb: "workspace", argument: "1-10 | next | prev | previous",
+                          summary: "Show a workspace. `previous` is the one you were on last.",
+                          sample: "workspace 3"),
+        CommandDescriptor(verb: "movetoworkspace", argument: "1-10",
+                          summary: "Send the window to that workspace and follow it there.",
+                          sample: "movetoworkspace 3"),
+        CommandDescriptor(verb: "movetoworkspacesilent", argument: "1-10",
+                          summary: "Send the window to that workspace and stay where you are.",
+                          sample: "movetoworkspacesilent 3"),
+        CommandDescriptor(verb: "swapworkspace", argument: "left|right|<±n>",
+                          summary: "Trade this workspace's number with its neighbour's. Nothing on "
+                                 + "screen moves; the strip reorders.",
+                          sample: "swapworkspace left"),
+        CommandDescriptor(verb: "theme", argument: "<name>",
+                          summary: "Wear an Omarchy theme, fetching it first if this machine has "
+                                 + "not got it. No argument hands your own colours back.",
+                          sample: "theme tokyo-night"),
+        CommandDescriptor(verb: "removetheme", aliases: ["theme-remove"], argument: "<name>",
+                          summary: "Delete a theme's folder from ~/.config/toe/themes.",
+                          sample: "removetheme tokyo-night"),
+        CommandDescriptor(verb: "background", aliases: ["bg"], argument: "<file>",
+                          summary: "Put one of the current theme's pictures up.",
+                          sample: "background city.jpg"),
+        CommandDescriptor(verb: "nextbackground", aliases: ["bgnext", "background-next"],
+                          summary: "Step to the next picture.",
+                          sample: "nextbackground"),
+        CommandDescriptor(verb: "installskill",
+                          summary: "Write the Claude Code skill into ~/.claude/skills/toe.",
+                          sample: "installskill"),
+        CommandDescriptor(verb: "removeskill",
+                          summary: "Take that skill file away again.",
+                          sample: "removeskill"),
+        CommandDescriptor(verb: "menu", argument: "[root|keybindings|style|theme|background|setup|install|remove]",
+                          summary: "Open the quick menu, at a level.",
+                          sample: "menu theme"),
+        CommandDescriptor(verb: "reload",
+                          summary: "Re-read toe.toml and re-tile everything.",
+                          sample: "reload"),
+        CommandDescriptor(verb: "exec", aliases: ["exec-and-forget"], argument: "<shell line>",
+                          summary: "Run a shell command. Refused over the socket unless "
+                                 + "[cli] allow_exec is on.",
+                          sample: "exec open -a Safari"),
+        CommandDescriptor(verb: "quit", aliases: ["exit"],
+                          summary: "Stop toe, putting every hidden workspace's windows back first. "
+                                 + "Refused over the socket unless [cli] allow_quit is on.",
+                          sample: "quit"),
+    ]
+
+    /// The verbs a caller may not send over the socket without saying so in the config first,
+    /// and the setting that lets each through. See `CLIConfig`.
+    public static func gate(_ command: Command) -> (key: String, reason: String)? {
+        switch command {
+        case .exec:
+            return ("cli.allow_exec",
+                    "`exec` runs a shell command as you, so the socket refuses it by default — "
+                    + "set allow_exec = true under [cli] if you want it")
+        case .quit:
+            return ("cli.allow_quit",
+                    "`quit` stops toe, and a caller that stops toe cannot start it again — "
+                    + "set allow_quit = true under [cli] if you want it")
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/ToeCore/Control/ControlCLI.swift
+++ b/Sources/ToeCore/Control/ControlCLI.swift
@@ -1,0 +1,255 @@
+import Foundation
+
+/// What toe should do about the words after its own name.
+///
+/// The same binary is the agent and the thing you type at it, which is not a trick: `main.swift`
+/// has always decided by argv — `--version` and `--print-default-config` predate any of this —
+/// and a second executable would need a second code signature, a second Accessibility grant it
+/// does not want, and somewhere to be installed. One binary, two jobs, told apart by the first
+/// word.
+///
+/// So this is the doorman, and it is in ToeCore because argument parsing is arithmetic and
+/// belongs where `make test` can reach it. Nothing here opens a socket or touches a file.
+public struct CLIInvocation: Equatable {
+
+    public enum Skill: String, Equatable, Sendable {
+        case install
+        case remove
+        case status
+        /// Print the document to stdout without writing it anywhere — the way to read what a
+        /// row in the menu is about to put on your disk before you let it.
+        case print
+    }
+
+    public enum Kind: Equatable {
+        /// No verb: this invocation is the window manager, exactly as it has always been.
+        case agent
+        case help(String)
+        /// Nothing was run and something was wrong with the way it was asked. Exit 2, so a
+        /// script can tell a mistyped command from a command that reached toe and failed.
+        case error(String)
+        /// Done here, with no running toe involved: writing a file needs a file, not an agent.
+        case skill(Skill)
+        case request(ControlRequest)
+    }
+
+    public var kind: Kind
+    /// A `-` stood where command lines were expected. The client fills them from stdin — which
+    /// ToeCore cannot do and should not know how to.
+    public var readsStdin: Bool
+
+    public init(_ kind: Kind, readsStdin: Bool = false) {
+        self.kind = kind
+        self.readsStdin = readsStdin
+    }
+}
+
+public enum ControlCLI {
+
+    /// The verbs that mean "talk to the running toe" rather than "be the running toe", plus the
+    /// one that means the opposite and is here for the reason below.
+    public static let verbs = ["query", "dispatch", "focus", "layout", "skill", "help", "agent"]
+
+    /// - Parameters:
+    ///   - arguments: everything after the executable's own name.
+    ///   - isInteractive: whether this came from a shell — `isatty` on either standard input or
+    ///     standard output, decided by the caller because ToeCore has neither.
+    public static func parse(_ arguments: [String], isInteractive: Bool = false) -> CLIInvocation {
+        guard let verb = arguments.first else {
+            // A bare `toe` from a shell prints the usage rather than starting the window
+            // manager, and this matters exactly as much as `toe` being on a PATH does.
+            //
+            // Started from a shell, the agent is a child of that shell: it inherits the terminal's
+            // process group, so closing the window or pressing ^C sends it a signal and
+            // `installSignalHandlers` shuts it down — after `AppIdentity.takeOver` has already
+            // stopped the copy that was running properly. Somebody typing `toe` to see what it
+            // does would therefore replace a working window manager with one that dies when they
+            // close the tab, and nothing on screen would explain either half of that. This is not
+            // hypothetical: it is what happened the first time this was tested, and the test was
+            // `toe | head`.
+            //
+            // Which is why the question is asked of standard input *and* standard output rather
+            // than one of them. Either alone is a rule with a hole in it that a pipe or a
+            // redirect walks straight through — `toe | head` has no terminal on stdout, and
+            // `toe > log` has none either, and both were typed by somebody at a prompt. Together
+            // they say something simple enough to rely on: from a shell, `toe` never becomes the
+            // window manager. launchd and `open Toe.app` have neither, which is every way toe is
+            // meant to start, and `toe agent` is how you ask for it from a shell on purpose.
+            return CLIInvocation(isInteractive ? .help(usage) : .agent)
+        }
+
+        // A leading flag is not a verb. `open Toe.app` passes `-psn_0_1234` on some launches and
+        // the release workflow passes `--version`, and neither is somebody trying to drive toe
+        // from a shell — so anything beginning with a dash falls through to the agent and to the
+        // flag handling that has always been there.
+        guard !verb.hasPrefix("-") else { return CLIInvocation(.agent) }
+
+        // A first word that is not a flag and not a verb is a typo, and the one thing it must not
+        // do is start a second window manager. `toe quer windows` says so and stops.
+        guard verbs.contains(verb) else {
+            return CLIInvocation(.error("unknown command '\(verb)' — try `toe help`"))
+        }
+
+        let rest = Array(arguments.dropFirst())
+
+        switch verb {
+        case "help":
+            return CLIInvocation(.help(usage))
+
+        // The window manager, asked for in as many words. The only reason to type it is that a
+        // shell is where you are and the agent is what you want — a debug build, or a run you
+        // intend to watch with TOE_VERBOSE — and the bare `toe` above deliberately no longer
+        // means that from a shell, however its output is redirected.
+        case "agent":
+            return CLIInvocation(.agent)
+
+        case "query":
+            guard let what = rest.first else {
+                return CLIInvocation(.error("query needs one of: "
+                                            + ControlQuery.allCases.map(\.rawValue).joined(separator: ", ")))
+            }
+            guard ControlQuery(rawValue: what) != nil else {
+                return CLIInvocation(.error("no such query '\(what)' — try one of: "
+                                            + ControlQuery.allCases.map(\.rawValue).joined(separator: ", ")))
+            }
+            return CLIInvocation(.request(ControlRequest(op: .query, what: what)))
+
+        case "dispatch":
+            var window: String?
+            var lines: [String] = []
+            var stdin = false
+            var index = 0
+            while index < rest.count {
+                let argument = rest[index]
+                if argument == "--window" || argument == "-w" {
+                    guard index + 1 < rest.count else {
+                        return CLIInvocation(.error("--window needs a selector, such as app:Ghostty"))
+                    }
+                    window = rest[index + 1]
+                    index += 2
+                    continue
+                }
+                // `--window=app:Ghostty` as well as the two-word form: both are typed, and a
+                // caller that guesses wrong should not have to guess twice.
+                if let value = argument.dropPrefixed("--window=") {
+                    window = value
+                    index += 1
+                    continue
+                }
+                if argument == "-" { stdin = true } else { lines.append(argument) }
+                index += 1
+            }
+            guard !lines.isEmpty || stdin else {
+                return CLIInvocation(.error("dispatch needs a command line, such as "
+                                            + "`toe dispatch \"workspace 3\"` — `toe query commands` lists them"))
+            }
+            return CLIInvocation(.request(ControlRequest(op: .dispatch, commands: lines, window: window)),
+                                 readsStdin: stdin)
+
+        case "focus":
+            guard let selector = rest.first, !selector.isEmpty else {
+                return CLIInvocation(.error("focus needs a selector, such as app:Ghostty"))
+            }
+            return CLIInvocation(.request(ControlRequest(op: .focus, window: selector)))
+
+        case "layout":
+            return layout(rest)
+
+        case "skill":
+            let what = rest.first ?? "status"
+            guard let action = CLIInvocation.Skill(rawValue: what) else {
+                return CLIInvocation(.error("no such skill action '\(what)' — "
+                                            + "install, remove, status or print"))
+            }
+            return CLIInvocation(.skill(action))
+
+        default:
+            return CLIInvocation(.error("unknown command '\(verb)' — try `toe help`"))
+        }
+    }
+
+    private static func layout(_ rest: [String]) -> CLIInvocation {
+        guard let action = rest.first else {
+            return CLIInvocation(.error("layout needs one of: save, apply, list, show, delete"))
+        }
+        let name = rest.count > 1 ? rest[1] : nil
+
+        func named(_ op: ControlRequest.Op) -> CLIInvocation {
+            guard let name, !name.isEmpty else {
+                return CLIInvocation(.error("layout \(action) needs a name, such as `toe layout \(action) work`"))
+            }
+            return CLIInvocation(.request(ControlRequest(op: op, what: name)))
+        }
+
+        switch action {
+        case "save":   return named(.layoutSave)
+        case "apply":  return named(.layoutApply)
+        case "show":   return named(.layoutShow)
+        case "delete", "remove": return named(.layoutDelete)
+        case "list":   return CLIInvocation(.request(ControlRequest(op: .layoutList)))
+        default:
+            return CLIInvocation(.error("no such layout action '\(action)' — "
+                                        + "save, apply, list, show or delete"))
+        }
+    }
+
+    /// Written for a person at a terminal. The machine-readable half is `toe query commands`,
+    /// which is a table rather than prose and is what the skill document is generated from —
+    /// so this can stay short without leaving anything undocumented.
+    public static let usage = """
+    toe — a tiling window manager, and the command line that steers it.
+
+    With one of the verbs below it talks to the copy already running, over a socket in
+    ~/.local/state/toe.
+
+      toe query state             everything at once: monitors, workspaces, windows, focus
+      toe query windows           every managed window, with its workspace and frame
+      toe query workspaces        what is on each of the ten, and which are showing
+      toe query monitors          the displays and their tiling areas
+      toe query binds             the live keybindings
+      toe query commands          every verb dispatch accepts — the vocabulary
+      toe query layouts           the saved layout profiles
+      toe query skill             where the agent skill file is, and whether it is current
+
+      toe dispatch "workspace 3"                run a command
+      toe dispatch "workspace 3" "movefocus l"  run several, rendering once at the end
+      toe dispatch -                            read command lines from stdin
+      toe dispatch --window app:Safari "movetoworkspace 3"
+                                                act on a window other than the focused one
+      toe focus app:Ghostty                     bring a window forward, revealing its workspace
+
+      toe layout save work        remember where everything is, under a name
+      toe layout apply work       put the windows that are open back into that arrangement
+      toe layout list             the profiles in ~/.config/toe/layouts
+      toe layout show work        one profile, as JSON
+      toe layout delete work      forget it
+
+      toe skill install           write the Claude Code skill into ~/.claude/skills/toe
+      toe skill remove            take it away again
+      toe skill status            where it is and whether it matches this copy of toe
+      toe skill print             the document, to stdout, without writing anything
+
+      toe agent                   run the window manager here, in this shell
+
+    With no arguments and no terminal — from launchd, or `open Toe.app` — toe *is* the window
+    manager. Run from a shell with no arguments it prints this instead, because a window manager
+    started from a shell dies with that shell. `toe agent` does it anyway.
+
+    Window selectors:  id:4213  app:Ghostty  bundle:com.apple.Safari  title:release  workspace:3
+    A bare word tries the application first, then the title.
+
+    Replies are JSON on stdout: {"ok":true,"result":…}. A refusal exits 1 with a sentence on
+    stderr; a mistyped command exits 2 without reaching toe at all.
+
+    exec and quit are refused over the socket unless [cli] allow_exec / allow_quit say otherwise.
+    """
+}
+
+private extension String {
+    /// `--window=app:Ghostty` → `app:Ghostty`, or nil when the prefix is not there.
+    func dropPrefixed(_ prefix: String) -> String? {
+        guard hasPrefix(prefix) else { return nil }
+        let value = String(dropFirst(prefix.count))
+        return value.isEmpty ? nil : value
+    }
+}

--- a/Sources/ToeCore/Control/ControlProtocol.swift
+++ b/Sources/ToeCore/Control/ControlProtocol.swift
@@ -1,0 +1,287 @@
+import Foundation
+
+/// The wire between the `toe` you type and the `toe` that is running.
+///
+/// One line of JSON in, one line of JSON out, over a Unix socket — Hyprland's `hyprctl`
+/// arrangement, and for its reasons. The alternative on macOS is a Mach service, which needs a
+/// `MachServices` key in a launchd plist; toe is frequently started by `open Toe.app`, which
+/// never goes through launchd at all, so that channel would exist for some launches and not
+/// others. A socket in the state directory works however toe was started.
+///
+/// The request half is shaped as a struct with an `op` rather than as an enum with associated
+/// values, so that the JSON on the wire reads the way a person would write it by hand —
+/// `{"op":"query","what":"windows"}` — and so a field added later is absent rather than
+/// breaking a client that predates it. The response half is the part a language model reads,
+/// and it is the half that is shaped for a reader.
+public struct ControlRequest: Codable, Equatable, Sendable {
+
+    /// Bumped when the meaning of a field changes rather than when one is added. The server
+    /// refuses a request from a future protocol rather than guessing at it — one binary is
+    /// both halves, so a mismatch means the app was replaced under a shell that still has the
+    /// old one on its PATH, and saying so beats acting on half-understood JSON.
+    public static let currentVersion = 1
+
+    public enum Op: String, Codable, Sendable {
+        case query
+        case dispatch
+        case focus
+        case layoutSave
+        case layoutApply
+        case layoutList
+        case layoutShow
+        case layoutDelete
+    }
+
+    public var version: Int
+    public var op: Op
+    /// What to report, for `query`; the profile's name, for the `layout` operations.
+    public var what: String?
+    /// The command lines for `dispatch`, in the order they should run. More than one is
+    /// deliberate: a batch renders once at the end, which is the difference between a layout
+    /// arriving and a layout being assembled in front of you.
+    public var commands: [String]?
+    /// A window selector — the window `focus` acts on, or the one `dispatch` acts on instead
+    /// of whichever window happens to hold the focus.
+    public var window: String?
+
+    public init(op: Op, what: String? = nil, commands: [String]? = nil, window: String? = nil) {
+        self.version = Self.currentVersion
+        self.op = op
+        self.what = what
+        self.commands = commands
+        self.window = window
+    }
+}
+
+/// What `query` can be asked for.
+public enum ControlQuery: String, Codable, CaseIterable, Sendable {
+    case state
+    case windows
+    case workspaces
+    case monitors
+    case binds
+    case commands
+    case layouts
+    case skill
+}
+
+// MARK: - What a query answers with
+
+/// One window, as everything outside toe sees it.
+///
+/// The frame is the layout's, not Accessibility's. Asking the system where each window is
+/// would be one synchronous round trip per window on the main thread — `isManageable` alone is
+/// six per candidate — and it would answer for a window on a hidden workspace with the stash
+/// corner, which is where toe parked it rather than where it belongs. The frame toe intends is
+/// the true answer to "where is this window", and it costs nothing.
+public struct WindowReport: Codable, Equatable, Sendable {
+    public var id: WindowID
+    /// The application's own name — "Ghostty", "Safari". What a person, or a model, calls it.
+    public var app: String
+    /// The bundle identifier, which is what `[[float]]` rules match on and the stabler of the
+    /// two names. Absent for the occasional process that has none.
+    public var bundle: String?
+    public var title: String?
+    public var workspace: Int?
+    public var monitor: UInt32?
+    /// Where the layout puts it, or nil while its workspace is hidden — see the note above.
+    public var frame: Box?
+    public var floating: Bool
+    public var focused: Bool
+    /// On a workspace that is not currently showing. Not a macOS Space: the window is parked
+    /// off-screen and is still in Cmd-Tab, which is a thing worth knowing before concluding
+    /// that a command did nothing.
+    public var hidden: Bool
+
+    public init(id: WindowID, app: String, bundle: String? = nil, title: String? = nil,
+                workspace: Int? = nil, monitor: UInt32? = nil, frame: Box? = nil,
+                floating: Bool = false, focused: Bool = false, hidden: Bool = false) {
+        self.id = id
+        self.app = app
+        self.bundle = bundle
+        self.title = title
+        self.workspace = workspace
+        self.monitor = monitor
+        self.frame = frame
+        self.floating = floating
+        self.focused = focused
+        self.hidden = hidden
+    }
+}
+
+public struct WorkspaceReport: Codable, Equatable, Sendable {
+    public var index: Int
+    public var monitor: UInt32
+    public var visible: Bool
+    public var focused: Bool
+    /// Tiles first, in the order they sit in the tree from left to right, then the detached
+    /// windows. That order is the one a layout profile replays, so it is the order this reports.
+    public var windows: [WindowID]
+
+    public init(index: Int, monitor: UInt32, visible: Bool, focused: Bool, windows: [WindowID]) {
+        self.index = index
+        self.monitor = monitor
+        self.visible = visible
+        self.focused = focused
+        self.windows = windows
+    }
+}
+
+public struct MonitorReport: Codable, Equatable, Sendable {
+    public var id: UInt32
+    /// The durable key the session file uses, which survives a replug where the id does not.
+    public var key: String?
+    public var name: String?
+    public var frame: Box
+    /// The tiling area: the frame with the menu bar, the Dock and anything else that reserves
+    /// space already taken out.
+    public var usable: Box
+    public var workspace: Int?
+    public var focused: Bool
+
+    public init(id: UInt32, key: String? = nil, name: String? = nil, frame: Box, usable: Box,
+                workspace: Int? = nil, focused: Bool = false) {
+        self.id = id
+        self.key = key
+        self.name = name
+        self.frame = frame
+        self.usable = usable
+        self.workspace = workspace
+        self.focused = focused
+    }
+}
+
+/// Everything at once — the shape a model should ask for first, because the three lists only
+/// mean anything against each other.
+public struct StateReport: Codable, Equatable, Sendable {
+    public var version: String?
+    public var focusedWindow: WindowID?
+    public var focusedWorkspace: Int
+    public var focusedMonitor: UInt32
+    public var monitors: [MonitorReport]
+    public var workspaces: [WorkspaceReport]
+    public var windows: [WindowReport]
+
+    public init(version: String? = nil, focusedWindow: WindowID? = nil, focusedWorkspace: Int,
+                focusedMonitor: UInt32, monitors: [MonitorReport],
+                workspaces: [WorkspaceReport], windows: [WindowReport]) {
+        self.version = version
+        self.focusedWindow = focusedWindow
+        self.focusedWorkspace = focusedWorkspace
+        self.focusedMonitor = focusedMonitor
+        self.monitors = monitors
+        self.workspaces = workspaces
+        self.windows = windows
+    }
+}
+
+/// One live binding. The key and what it does, in the words the keybindings page uses.
+///
+/// No command string. Spelling a `Command` back out would be a fifth exhaustive switch over it
+/// — `CommandParser`, `Coordinator.dispatch`, `CommandLabel` and `MenuModel.rank` are the four
+/// — and the vocabulary a caller actually needs is `query commands`, which is a table rather
+/// than a transcription and cannot drift out of step without a test noticing.
+public struct BindReport: Codable, Equatable, Sendable {
+    public var keys: String
+    public var does: String
+
+    public init(keys: String, does: String) {
+        self.keys = keys
+        self.does = does
+    }
+}
+
+/// What ran, and what it did. `dispatch`'s answer.
+public struct DispatchReport: Codable, Equatable, Sendable {
+    /// The command lines, as they were parsed and accepted.
+    public var ran: [String]
+    /// The window they acted on, when `--window` named one.
+    public var window: WindowID?
+
+    public init(ran: [String], window: WindowID? = nil) {
+        self.ran = ran
+        self.window = window
+    }
+}
+
+/// Where the skill file is and whether what is there is what this copy of toe would write.
+public struct SkillReport: Codable, Equatable, Sendable {
+    public var path: String
+    public var installed: Bool
+    /// Installed, but written by a different copy of toe — most often the development build,
+    /// since the document names the binary that wrote it.
+    public var stale: Bool
+
+    public init(path: String, installed: Bool, stale: Bool) {
+        self.path = path
+        self.installed = installed
+        self.stale = stale
+    }
+}
+
+// MARK: - The envelope
+
+/// A reply that worked. `ok` is a constant so that a reader — a person at a terminal or a model
+/// reading stdout — can tell the two apart without knowing which query it was.
+public struct ControlSuccess<Result: Encodable>: Encodable {
+    public let ok = true
+    public let result: Result
+
+    public init(_ result: Result) { self.result = result }
+}
+
+/// A refusal, with the sentence the caller should be shown.
+///
+/// Its own type rather than `String` because a `Result` wants an `Error`, and rather than an
+/// enum of cases because there is nothing to switch on: every one of these ends up printed on
+/// somebody's terminal or read by a model, and the useful distinction between them is the words.
+public struct Refusal: Error, Equatable, Sendable, CustomStringConvertible {
+    public let description: String
+    public init(_ description: String) { self.description = description }
+}
+
+public struct ControlFailure: Codable, Equatable, Sendable {
+    public let ok: Bool
+    public let error: String
+
+    public init(_ error: String) {
+        self.ok = false
+        self.error = error
+    }
+}
+
+public enum ControlCoding {
+
+    /// Pretty-printed and sorted.
+    ///
+    /// Sorted because the alternative is not "declaration order" but *no* order: Foundation
+    /// encodes through an unordered dictionary, so without this the fields of a window come out
+    /// in whatever sequence the hashing produced that run. Declaration order would read better —
+    /// `id`, `app`, `title` is how a person reads a window — but it is not on offer, and a
+    /// profile on disk that reorders itself between two writes, or a reply a script cannot diff
+    /// against yesterday's, is a worse thing to be than alphabetical.
+    public static func encoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    public static func decoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+
+    /// The whole reply as one line, newline-terminated. Newline-framed rather than
+    /// length-prefixed because the far end is as likely to be `nc` as it is to be toe.
+    public static func line<T: Encodable>(_ value: T) -> Data {
+        let encoder = encoder()
+        // Pretty printing puts newlines *inside* the payload, so the framing newline cannot be
+        // a delimiter for the response the way it is for the request. It does not need to be:
+        // the server closes its side when it is done, and the client reads to end of file.
+        var data = (try? encoder.encode(value)) ?? Data(#"{"ok":false,"error":"could not encode the reply"}"#.utf8)
+        data.append(0x0a)
+        return data
+    }
+}

--- a/Sources/ToeCore/Control/LayoutProfile.swift
+++ b/Sources/ToeCore/Control/LayoutProfile.swift
@@ -1,0 +1,216 @@
+import Foundation
+
+/// A named arrangement of windows, saved and put back by name.
+///
+/// This is the session snapshot's idea with the one thing that makes a session snapshot exact
+/// taken out. `SessionSnapshot` is keyed on `CGWindowID`, which the window server keeps stable
+/// for the life of a window — so a restart puts every window back with no matching at all, and
+/// a reboot invalidates the whole file. A profile has to survive exactly what that cannot: the
+/// applications being quit and started again, on another day, with different window ids. So it
+/// names windows the way a person would — by application, and by a fragment of the title when
+/// the application has more than one window that matters.
+///
+/// What it therefore records is *placement*: which workspace each window belongs on, in what
+/// order, and whether it floats. Not the split ratios. A dwindle tree is built by inserting
+/// windows one after another, so replaying the order rebuilds the same shape as long as nobody
+/// has since flipped a split by hand — and the alternative, storing ratios against selectors,
+/// would put back a geometry for a set of windows that may not all have turned up. Placement is
+/// the part that is true whether or not every application in the profile is running.
+public struct LayoutProfile: Codable, Equatable, Sendable {
+
+    /// Bumped when the shape below changes incompatibly; an older or newer file is refused
+    /// with a sentence rather than half-read.
+    public static let currentVersion = 1
+
+    public var version: Int
+    public var name: String
+    public var savedAt: Date
+    public var workspaces: [ProfileWorkspace]
+
+    public init(name: String, savedAt: Date = Date(), workspaces: [ProfileWorkspace] = []) {
+        self.version = Self.currentVersion
+        self.name = name
+        self.savedAt = savedAt
+        self.workspaces = workspaces
+    }
+}
+
+public struct ProfileWorkspace: Codable, Equatable, Sendable {
+    public var index: Int
+    /// In the order they should be put back: tiles first, left to right through the tree, then
+    /// the detached windows. Replaying that order is what reproduces the shape.
+    public var windows: [ProfileWindow]
+
+    public init(index: Int, windows: [ProfileWindow]) {
+        self.index = index
+        self.windows = windows
+    }
+}
+
+/// One window, named the way it will still be nameable tomorrow.
+public struct ProfileWindow: Codable, Equatable, Sendable {
+    /// The bundle identifier where there is one — the stable name, and the one `[[float]]`
+    /// rules already match on.
+    public var bundle: String?
+    /// The application's own name, kept as well as the bundle rather than instead of it: it is
+    /// what a person reads when they open the file, and it is the fallback for the handful of
+    /// processes that have no bundle identifier at all.
+    public var app: String
+    /// A fragment of the title, and only when the profile needs it to tell two windows of the
+    /// same application apart. Written for the *second* window of an application and after,
+    /// never for the first — a title is the least durable thing about a window (a browser's is
+    /// whatever page it is on), so it earns its place only where nothing else distinguishes.
+    public var title: String?
+    public var floating: Bool
+
+    public init(bundle: String? = nil, app: String, title: String? = nil, floating: Bool) {
+        self.bundle = bundle
+        self.app = app
+        self.title = title
+        self.floating = floating
+    }
+
+    /// Whether a live window could be this one. Bundle identifier if the profile has one,
+    /// otherwise the application's name; the title fragment narrows it when it is there.
+    public func matches(_ window: WindowReport) -> Bool {
+        if let bundle {
+            guard window.bundle?.compare(bundle, options: .caseInsensitive) == .orderedSame
+            else { return false }
+        } else {
+            guard window.app.compare(app, options: .caseInsensitive) == .orderedSame
+            else { return false }
+        }
+        guard let title else { return true }
+        return window.title?.range(of: title, options: .caseInsensitive) != nil
+    }
+}
+
+/// One window's move, as the app layer should carry it out.
+public struct ProfileMove: Equatable, Sendable {
+    public var window: WindowID
+    public var workspace: Int
+    public var floating: Bool
+
+    public init(window: WindowID, workspace: Int, floating: Bool) {
+        self.window = window
+        self.workspace = workspace
+        self.floating = floating
+    }
+}
+
+/// What applying a profile would do, worked out before anything moves.
+public struct ProfilePlan: Equatable, Sendable {
+    /// In the order they must be carried out: a workspace's windows are inserted one after
+    /// another, and the order is the shape.
+    public var moves: [ProfileMove]
+    /// Windows the profile names that are not open. Reported rather than swallowed — a profile
+    /// half-applied because an application was not running looks identical to a profile that
+    /// did not work, and the difference is the whole of what the caller needs to know.
+    public var missing: [ProfileWindow]
+    /// Open windows the profile says nothing about. Left exactly where they are: a profile is
+    /// an arrangement of the windows it names, not a claim about the whole screen, and moving
+    /// somebody's unrelated windows out of the way would be the kind of tidying nobody asked
+    /// for.
+    public var untouched: [WindowID]
+
+    public init(moves: [ProfileMove] = [], missing: [ProfileWindow] = [], untouched: [WindowID] = []) {
+        self.moves = moves
+        self.missing = missing
+        self.untouched = untouched
+    }
+}
+
+public extension LayoutProfile {
+
+    /// Reads a profile off the current state.
+    ///
+    /// `windows` must be in the order `WorkspaceReport.windows` gives — tiles in tree order,
+    /// then floats — because that order is the whole of what a profile knows about shape.
+    static func capture(name: String, from state: StateReport) -> LayoutProfile {
+        var profile = LayoutProfile(name: name)
+        let byID = Dictionary(state.windows.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+
+        for workspace in state.workspaces.sorted(by: { $0.index < $1.index }) {
+            var seen: [String: Int] = [:]
+            var rows: [ProfileWindow] = []
+            for id in workspace.windows {
+                guard let window = byID[id] else { continue }
+                // The title only from the second window of an application onwards — see
+                // `ProfileWindow.title`. The first one of a kind is named by its application,
+                // which is both what the user means and the name that will still be true when
+                // they come back to it.
+                let key = window.bundle ?? window.app
+                let count = (seen[key] ?? 0) + 1
+                seen[key] = count
+                rows.append(ProfileWindow(bundle: window.bundle,
+                                          app: window.app,
+                                          title: count > 1 ? window.title : nil,
+                                          floating: window.floating))
+            }
+            guard !rows.isEmpty else { continue }
+            profile.workspaces.append(ProfileWorkspace(index: workspace.index, windows: rows))
+        }
+        return profile
+    }
+
+    /// Matches the profile against what is open now.
+    ///
+    /// A live window is claimed at most once and in the order the profile lists them, so two
+    /// terminals in a profile take the two terminals that are open, and a profile asking for
+    /// three when two are running places two and reports the third as missing rather than
+    /// placing one of them twice.
+    ///
+    /// Windows already on the workspace the profile wants them on still produce a move. The app
+    /// layer drops those — it is a `moveWindow` to where the window already is — and the plan is
+    /// easier to read as the arrangement it asks for than as a diff against the arrangement
+    /// that happens to be there.
+    func plan(against windows: [WindowReport]) -> ProfilePlan {
+        var plan = ProfilePlan()
+        var available = windows.sorted { $0.id < $1.id }
+        var claimed: Set<WindowID> = []
+
+        for workspace in workspaces {
+            for wanted in workspace.windows {
+                guard let hit = available.first(where: { !claimed.contains($0.id) && wanted.matches($0) })
+                else {
+                    plan.missing.append(wanted)
+                    continue
+                }
+                claimed.insert(hit.id)
+                plan.moves.append(ProfileMove(window: hit.id,
+                                              workspace: workspace.index,
+                                              floating: wanted.floating))
+            }
+        }
+
+        available.removeAll { claimed.contains($0.id) }
+        plan.untouched = available.map(\.id)
+        return plan
+    }
+}
+
+/// What `layout apply` answers with.
+public struct LayoutApplyReport: Codable, Equatable, Sendable {
+    public var profile: String
+    public var moved: [WindowID]
+    /// The windows the profile named that are not open, as the profile spells them — enough for
+    /// a caller to decide to launch them and try again.
+    public var missing: [String]
+    public var untouched: [WindowID]
+
+    public init(profile: String, moved: [WindowID], missing: [String], untouched: [WindowID]) {
+        self.profile = profile
+        self.moved = moved
+        self.missing = missing
+        self.untouched = untouched
+    }
+
+    public init(profile: String, plan: ProfilePlan, moved: [WindowID]) {
+        self.profile = profile
+        self.moved = moved
+        self.missing = plan.missing.map { window in
+            window.title.map { "\(window.app) — \($0)" } ?? window.app
+        }
+        self.untouched = plan.untouched
+    }
+}

--- a/Sources/ToeCore/Control/SkillDocument.swift
+++ b/Sources/ToeCore/Control/SkillDocument.swift
@@ -1,0 +1,165 @@
+import Foundation
+
+/// The Claude Code skill file, generated rather than kept.
+///
+/// A skill is one Markdown file with a little YAML on top, dropped in `~/.claude/skills/toe/`,
+/// which an agent reads when a request looks like it is about windows. The obvious way to ship
+/// one is to commit it and copy it out of the bundle — and that is exactly how the file and the
+/// program drift apart: the day a verb is added, the skill still lists the old set, and a model
+/// reading it calls something that does not exist with complete confidence.
+///
+/// So the half that can go stale is not written by hand. The verb table below is
+/// `CommandCatalogue.entries`, which is the same table `toe query commands` answers with and
+/// whose every sample the selftest parses. The rest is prose about things a model cannot
+/// discover by asking — that a workspace is not a Space, that a fullscreen window suspends half
+/// the verbs, that a window somebody is dragging is not toe's to write to. Those are the notes
+/// that took a version each to learn, and they are the reason this file is worth having at all.
+public enum SkillDocument {
+
+    public static let directoryName = "toe"
+    public static let fileName = "SKILL.md"
+
+    /// - Parameter binary: the absolute path to the toe that wrote this. Baked in rather than
+    ///   left as a bare `toe`, because nothing puts toe on a PATH: it lives inside an
+    ///   application bundle, and an agent that has to guess where is an agent that gives up.
+    ///   It also makes the document honest about *which* copy wrote it — the development build
+    ///   names itself, so a skill written by `make run` does not quietly point at
+    ///   /Applications.
+    public static func text(binary: String, version: String? = nil) -> String {
+        let stamp = version.map { " \($0)" } ?? ""
+        return frontmatter + "\n" + body(binary: binary, stamp: stamp) + "\n" + verbs + "\n" + closing(binary: binary)
+    }
+
+    private static let frontmatter = #"""
+    ---
+    name: toe
+    description: >-
+      Inspect and rearrange the windows on this Mac through toe, the tiling window manager —
+      list windows, workspaces and displays; move windows between workspaces; focus, close,
+      float and resize them; and save or restore named layouts. Use whenever the user asks to
+      arrange, tidy, move, focus, split or set up windows, workspaces or their screen layout on
+      macOS, or asks what is open.
+    ---
+    """#
+
+    private static func body(binary: String, stamp: String) -> String {
+        #"""
+
+        # Driving toe\#(stamp)
+
+        toe is a tiling window manager running as a background agent. It is a port of Hyprland's
+        dwindle layout, so its verbs are Hyprland's verbs and a config copied from Omarchy mostly
+        works. You talk to the running copy through its own binary:
+
+            \#(binary) query state
+
+        Every reply is JSON on stdout — `{"ok":true,"result":…}` — or exit 1 with a sentence on
+        stderr. Exit 2 means the command line itself was wrong and nothing reached toe.
+
+        If that path does not exist, toe has been moved or is not installed; do not guess at
+        another one. If a call reports that toe is not running, say so rather than starting it —
+        starting a window manager rearranges the user's screen and is theirs to ask for.
+
+        ## Read before you write
+
+        Start with `query state`. It returns the displays, the ten workspaces, every managed
+        window with its id, application, title, workspace and frame, and what currently holds the
+        focus. Almost every mistake in this domain is acting on a stale idea of what is open, and
+        one query costs nothing.
+
+        Windows are identified by `id`, a `CGWindowID` the window server keeps stable for the life
+        of the window. Do not remember one across a restart of the application that owns it.
+
+        ## Acting
+
+            \#(binary) dispatch "workspace 3"
+            \#(binary) dispatch "movetoworkspace 2" "workspace 2"
+            \#(binary) dispatch --window app:Safari "movetoworkspace 3"
+            \#(binary) focus app:Ghostty
+
+        Several command lines in one `dispatch` are applied as a batch and drawn once at the end.
+        Prefer that to a sequence of separate calls: the difference on screen is an arrangement
+        appearing against an arrangement being assembled in front of the user.
+
+        `--window` names a window other than the one holding the focus, and only the verbs marked
+        below accept it. The directional verbs deliberately do not — `movefocus l` means "left of
+        where the focus is", and pointing it somewhere else would be a different command with the
+        same name. To act directionally elsewhere, `focus` there first.
+
+        ### Selectors
+
+            id:4213                 exactly that window — the only form that is not a guess
+            app:Ghostty             application name, or its bundle identifier
+            bundle:com.apple.Safari the bundle identifier alone
+            title:release           a substring of the title, case-insensitive
+            workspace:3             everything on that workspace
+            Ghostty                 no prefix: application first, then title
+
+        Prefer `app:`. A selector that matches more than one window is refused, and the refusal
+        lists the candidates with their ids — use one of those rather than guessing.
+
+        """#
+    }
+
+    /// The table, from `CommandCatalogue`. Generated so that a verb added to the parser and the
+    /// catalogue reaches the skill file without anybody remembering to come here.
+    private static var verbs: String {
+        var out = "## The verbs\n\nEvery one of these is a line for `dispatch`. "
+            + "`\u{2022}` marks the ones `--window` accepts.\n\n"
+        for entry in CommandCatalogue.entries {
+            let mark = entry.takesWindow ? "\u{2022} " : "  "
+            out += "- \(mark)`\(entry.usage)` — \(entry.summary)"
+            if !entry.aliases.isEmpty {
+                out += " Also: \(entry.aliases.map { "`\($0)`" }.joined(separator: ", "))."
+            }
+            out += "\n"
+        }
+        out += "\n`toe query commands` is this same table as JSON, and is the authority if the two"
+             + " ever disagree.\n"
+        return out
+    }
+
+    private static func closing(binary: String) -> String {
+        #"""
+
+        ## Layouts
+
+            \#(binary) layout save work
+            \#(binary) layout apply work
+
+        A profile records which workspace each window belongs on, in what order, and whether it
+        floats — named by application rather than by window id, so it survives quitting and
+        restarting those applications. It does not record split ratios. Applying one moves only
+        the windows it names; anything else is left where it is, and windows the profile names
+        that are not open come back in `missing` rather than being silently skipped.
+
+        ## Things that will surprise you
+
+        - **A toe workspace is not a macOS Space.** There is no public API for putting a window on
+          another Space, so a hidden workspace's windows are parked far off-screen. They are still
+          in Cmd-Tab and Mission Control, and a window reported as `hidden` is one of those. It has
+          not been closed.
+        - **A native-fullscreen window suspends half the verbs.** While one holds the focus,
+          anything that moves the focus, a window or a workspace is refused — it would act on the
+          workspace behind a screen the user cannot see. Check `query state` if a dispatch appears
+          to have done nothing.
+        - **Floating windows are the user's.** toe writes a floating window's frame once and never
+          re-asserts it, on purpose. Do not repeatedly place one.
+        - **Never write to a window being dragged.** toe already refuses; a burst of commands
+          while somebody has hold of a window is still a fight worth not starting.
+        - **`exec` and `quit` are refused over this socket** unless the config's `[cli]` section
+          allows them. That is deliberate: `exec` would make this a shell. If the user wants a
+          program launched, use the ordinary way of launching programs.
+        - **Some applications push back.** Chromium, Electron and JetBrains windows re-apply their
+          own geometry, and toe re-asserts a frame three times before leaving them alone. A window
+          that will not sit in its tile has a minimum size larger than the tile.
+
+        ## Working with the user
+
+        Rearranging somebody's screen is visible and interrupting. Say what you are about to move
+        before moving it, prefer one batch to a stream of small changes, and if the user wants to
+        be able to get back — `layout save` first, and tell them the name.
+
+        """#
+    }
+}

--- a/Sources/ToeCore/Control/WindowSelector.swift
+++ b/Sources/ToeCore/Control/WindowSelector.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+/// How something outside toe names a window it can see but cannot point at.
+///
+/// Every command toe has acts on the focused window, because every command toe has arrives on a
+/// key and the key was pressed by somebody looking at the screen. A caller on the other end of a
+/// socket is not looking at the screen: it has just read a list of windows and wants the third
+/// one. So a selector is the missing half of the CLI, and it is deliberately the *only* new way
+/// of naming a window — the commands themselves are unchanged.
+///
+/// The forms, in the order they are tried:
+///
+///     id:4213            exactly that window, and the only form that is not a guess
+///     app:ghostty        the application's name or its bundle identifier, case-insensitive
+///     bundle:com.apple   the bundle identifier alone
+///     title:release      a case-insensitive substring of the title
+///     workspace:3        every window on that workspace, which only `--window` narrows further
+///     ghostty            no prefix: the application, then the title
+///
+/// A bare word tries the application first because that is what a caller means nine times in
+/// ten, and because titles change under you — a browser's title is whatever page it is on, and
+/// a selector that resolved yesterday resolves to nothing today. `app:` is the stable one and
+/// the one the skill file tells a model to prefer.
+public struct WindowSelector: Equatable, Sendable {
+
+    public enum Field: String, Equatable, Sendable {
+        case id
+        case app
+        case bundle
+        case title
+        case workspace
+        /// No prefix: application, then title.
+        case any
+    }
+
+    public let field: Field
+    public let value: String
+
+    public init(field: Field, value: String) {
+        self.field = field
+        self.value = value
+    }
+
+    /// Parses `app:Ghostty`. Never fails: an unknown prefix is not a prefix, it is part of the
+    /// text being searched for — `Downloads:2024` is a window title before it is a mistake, and
+    /// a selector that refused it would be wrong more often than it was helpful.
+    public static func parse(_ raw: String) -> WindowSelector {
+        let text = raw.trimmingCharacters(in: .whitespaces)
+        guard let colon = text.firstIndex(of: ":") else {
+            return WindowSelector(field: .any, value: text)
+        }
+        let head = String(text[text.startIndex..<colon]).lowercased()
+        let tail = String(text[text.index(after: colon)...]).trimmingCharacters(in: .whitespaces)
+        guard let field = Field(rawValue: head), field != .any, !tail.isEmpty else {
+            return WindowSelector(field: .any, value: text)
+        }
+        return WindowSelector(field: field, value: tail)
+    }
+
+    public func matches(_ window: WindowReport) -> Bool {
+        switch field {
+        case .id:
+            // Exact, and by number: `id:0421` is not window 421, it is a typo.
+            return UInt32(value).map { $0 == window.id } ?? false
+        case .app:
+            return contains(window.app) || equals(window.bundle)
+        case .bundle:
+            // Whole, like the bundle branch of `app:` above, and for the same reason — see
+            // `equals`. This is the precise form of the two; somebody reaching for it is naming
+            // one application exactly, not searching.
+            return equals(window.bundle)
+        case .title:
+            return contains(window.title)
+        case .workspace:
+            return Int(value).map { $0 == window.workspace } ?? false
+        case .any:
+            return contains(window.app) || equals(window.bundle) || contains(window.title)
+        }
+    }
+
+    private func contains(_ subject: String?) -> Bool {
+        guard let subject else { return false }
+        return subject.range(of: value, options: [.caseInsensitive, .diacriticInsensitive]) != nil
+    }
+
+    /// Bundle identifiers are matched whole rather than by substring. `app:com.apple.Safari`
+    /// naming Safari is right; `app:com` naming every Apple application at once is not, and a
+    /// substring rule would do exactly that to the shortest and most tempting selectors. The
+    /// substring rule is kept for the two fields where a fragment is what anybody means — an
+    /// application's own name, and a window title.
+    private func equals(_ subject: String?) -> Bool {
+        guard let subject else { return false }
+        return subject.compare(value, options: .caseInsensitive) == .orderedSame
+    }
+}
+
+/// What resolving a selector against the live windows produced.
+public enum SelectorResolution: Equatable {
+    case one(WindowReport)
+    /// More than one window answers to it. The caller is told which, rather than being given
+    /// the first: acting on an arbitrary one of two terminals is the kind of help nobody asked
+    /// for, and the list is exactly what a caller needs to write a narrower selector.
+    case many([WindowReport])
+    case none
+}
+
+public extension WindowSelector {
+
+    /// Resolves against a window list, preferring exactness.
+    ///
+    /// The order matters more than it looks. A bare `Safari` matches an application named
+    /// Safari and also every window whose title mentions it, and a caller that typed `Safari`
+    /// meant the application — so a match on the application name wins outright, and the title
+    /// matches are only consulted when nothing matched by application. Without that rule the
+    /// most obvious selector anyone will ever type is ambiguous the moment a browser has a tab
+    /// open about Safari.
+    static func resolve(_ raw: String, in windows: [WindowReport]) -> SelectorResolution {
+        let selector = parse(raw)
+        let hits = windows.filter(selector.matches).sorted { $0.id < $1.id }
+        guard selector.field == .any, hits.count > 1 else { return outcome(hits) }
+
+        let byApp = hits.filter {
+            WindowSelector(field: .app, value: selector.value).matches($0)
+        }
+        return outcome(byApp.isEmpty ? hits : byApp)
+    }
+
+    private static func outcome(_ hits: [WindowReport]) -> SelectorResolution {
+        switch hits.count {
+        case 0:  return .none
+        case 1:  return .one(hits[0])
+        default: return .many(hits)
+        }
+    }
+
+    /// The sentence the caller gets back when a selector did not land on one window. Naming the
+    /// candidates rather than the count, because the next thing the caller does is write a
+    /// narrower selector and the ids are what it needs to do that.
+    static func explain(_ resolution: SelectorResolution, selector raw: String) -> String? {
+        switch resolution {
+        case .one:
+            return nil
+        case .none:
+            return "no window matches '\(raw)' — `toe query windows` lists what there is"
+        case .many(let hits):
+            let named = hits.prefix(8).map { window in
+                "id:\(window.id) \(window.app)" + (window.title.map { " — \($0)" } ?? "")
+            }
+            let more = hits.count > 8 ? ", and \(hits.count - 8) more" : ""
+            return "'\(raw)' matches \(hits.count) windows (\(named.joined(separator: "; "))\(more))"
+                 + " — narrow it with id: or title:"
+        }
+    }
+}

--- a/Sources/ToeCore/Dispatch/Command.swift
+++ b/Sources/ToeCore/Dispatch/Command.swift
@@ -54,6 +54,13 @@ public enum Command: Equatable {
     case background(String)
     /// `omarchy-theme-bg-next`.
     case nextBackground
+    /// Writes the Claude Code skill into `~/.claude/skills/toe`, so an agent knows what the
+    /// `toe` command line can do without being told each time. toe's own verb: it has no
+    /// Omarchy counterpart, because a shell on Linux needs no help finding `hyprctl`.
+    case installSkill
+    /// Takes that file away again — the Remove level's mirror of the row above, and the same
+    /// bounded kind of destructive as `removeTheme`: one path toe wrote, and no other.
+    case removeSkill
 }
 
 public extension Command {
@@ -128,6 +135,28 @@ public extension Command {
         }
     }
 
+    /// Whether `--window` means anything for this verb.
+    ///
+    /// Every command toe has acts on the focused window, because every one of them arrives on a
+    /// key pressed by somebody looking at the screen. A caller on the socket is not, so it may
+    /// name a window instead — but only for the verbs whose meaning survives the substitution.
+    ///
+    /// These four do, and they are exactly the ones the layout can already carry out on a window
+    /// by id rather than by focus. The directional verbs deliberately do not: `movefocus l` is
+    /// "the window left of *here*", and here is where the focus is — pointed at somebody else's
+    /// window it would mean walking a tree from a place the user is not standing, which is a
+    /// different command wearing the same name. `workspace` and the theme verbs take no window at
+    /// all. A caller that wants a directional verb somewhere else moves the focus there first,
+    /// which is a thing it can say and a thing the user can see happening.
+    var acceptsTarget: Bool {
+        switch self {
+        case .killActive, .toggleFloating, .moveToWorkspace, .growActive, .resizeActive:
+            return true
+        default:
+            return false
+        }
+    }
+
     /// Whether the quick menu stays up after running this.
     ///
     /// Every row used to dismiss the panel, which is right for almost all of them: `exec` brings
@@ -156,6 +185,11 @@ public extension Command {
         // Removing one is the same argument from the other side: the row leaves the list under
         // the cursor, and that disappearance is the whole of what toe says about it.
         case .theme, .removeTheme: return true
+        // The same argument again, and it is the reason the Install level exists: the row is
+        // the only thing that reports what happened. Installing the skill writes one file and
+        // says nothing about it, so the row turning into a ticked, dimmed one under the cursor
+        // *is* the confirmation — and closing the menu would take it away before it was read.
+        case .installSkill, .removeSkill: return true
         default:                   return false
         }
     }
@@ -245,6 +279,11 @@ public enum CommandParser {
             return .background(argument)
         case "nextbackground", "bgnext", "background-next":
             return .nextBackground
+
+        // Spelled like `removetheme` beside it, and for the same reason: a binding's value is a
+        // verb and its argument, so the noun goes in the verb rather than after it.
+        case "installskill":                return .installSkill
+        case "removeskill":                 return .removeSkill
 
         // Spelled the way `omarchy-menu` and `omarchy-menu keybindings` are invoked, so a
         // binding can be read across from an Omarchy config without translating it.

--- a/Sources/ToeCore/Dispatch/CommandLabel.swift
+++ b/Sources/ToeCore/Dispatch/CommandLabel.swift
@@ -4,9 +4,12 @@ import Foundation
 ///
 /// The keybindings page shows `SUPER + W  →  Close window`, and the right-hand half is this. It
 /// is one of three exhaustive `switch`es over `Command` in the tree — `Coordinator.dispatch` and
-/// `MenuModel.rank` are the others — so a new command needs four edits rather than two: the verb
-/// in `CommandParser`, the arm in `dispatch`, a label here, and a rank on the keybindings page.
-/// The compiler catches a missing label; nothing but a reader catches a bad one.
+/// `MenuModel.rank` are the others — so a new command needs five edits rather than two: the verb
+/// in `CommandParser`, the arm in `dispatch`, a label here, a rank on the keybindings page, and a
+/// row in `CommandCatalogue`, which is what `toe query commands` and the generated skill file
+/// answer with. The compiler catches the first four; the fifth is caught by the selftest only in
+/// the direction that matters — every catalogued verb must parse — so a verb added to the parser
+/// and left out of the table is a verb the command line will run and never mention.
 public enum CommandLabel {
 
     public static func describe(_ command: Command) -> String {
@@ -50,6 +53,11 @@ public enum CommandLabel {
         case .removeTheme(let slug): return "Remove the theme \(Slug.title(slug))"
         case .background(let file):  return "Background: \(ellipsised(file))"
         case .nextBackground:        return "Next background"
+        // Named for what it is for rather than for what it writes. Somebody reading this row in
+        // the keybindings list has not got the path in their head, and "the Claude Code skill"
+        // is the thing they went looking for.
+        case .installSkill:          return "Install the Claude Code skill"
+        case .removeSkill:           return "Remove the Claude Code skill"
         }
     }
 

--- a/Sources/ToeCore/Layout/WorkspaceManager.swift
+++ b/Sources/ToeCore/Layout/WorkspaceManager.swift
@@ -623,11 +623,26 @@ public final class WorkspaceManager {
 
     /// `movetoworkspace <n>` / `movetoworkspacesilent <n>`.
     public func moveFocusedWindow(toWorkspace index: Int, follow: Bool) {
+        guard let id = focusedWindow else { return }
+        moveWindow(id, toWorkspace: index, follow: follow)
+    }
+
+    /// The same move, for a window that was named rather than focused.
+    ///
+    /// This is the generalisation `toe dispatch --window` needs, and it is the only one of its
+    /// kind: every other verb either already takes an id — `toggleFloating`, `growWindow`,
+    /// `resizeWindow` — or means something different when it is pointed away from the focus, and
+    /// those are refused rather than generalised. See `Command.acceptsTarget`.
+    ///
+    /// `follow` still means what it meant: the workspace comes forward and the window keeps the
+    /// focus. Sent for a window that is not the focused one, following it is usually not what the
+    /// caller wants, which is why `movetoworkspacesilent` exists and why a layout profile uses it.
+    @discardableResult
+    public func moveWindow(_ id: WindowID, toWorkspace index: Int, follow: Bool) -> Bool {
         guard (1...Self.workspaceCount).contains(index),
-              let id = focusedWindow,
               let currentIndex = workspaceIndex(of: id),
               currentIndex != index
-        else { return }
+        else { return false }
 
         let wasFloating = isFloating(id)
         workspaces[currentIndex]?.layout.remove(id)
@@ -645,6 +660,39 @@ public final class WorkspaceManager {
             switchTo(workspace: index)
             noteFocus(id)
         }
+        return true
+    }
+
+    /// Puts a window into or out of the tree, without walking the cycle to get there.
+    ///
+    /// `toggleFloating` is a cycle — tiled, floating, floating larger, tiled — because it is on a
+    /// key and a key that can only go one way round is how you ask for a size you cannot get
+    /// back from. A caller restoring a saved arrangement is not pressing a key: it knows the
+    /// state it wants and has to arrive at it in one step, since "press until it looks right" is
+    /// not something a program can see well enough to do.
+    ///
+    /// The floating half is deliberately the cycle's first stage rather than whichever one the
+    /// window last had. A profile records *that* a window floats, not how big it was — the size a
+    /// float lands at is centred on the monitor it is going to, and a remembered size from a
+    /// display that may not be plugged in is a worse answer than the one toe would give a window
+    /// leaving the tree today.
+    @discardableResult
+    public func setFloating(_ id: WindowID, _ floating: Bool) -> Bool {
+        guard let index = workspaceIndex(of: id), isFloating(id) != floating else { return false }
+        let ws = workspace(index)
+        guard floating else {
+            ws.floating.remove(id)
+            floatingStage.removeValue(forKey: id)
+            ws.layout.insert(id, anchor: anchor(on: ws, excluding: id), focalPoint: focalPoint(on: ws))
+            return true
+        }
+        ws.layout.remove(id)
+        ws.floating.insert(id)
+        floatingStage[id] = 1
+        if let m = monitor(id: ws.monitorID) {
+            floatingFrames[id] = centredFloatingBox(on: m, stage: 1)
+        }
+        return true
     }
 
     /// Focus the most recently used window on the workspace `focusedMonitorID` is now showing.

--- a/Sources/ToeCore/Menu/MenuModel.swift
+++ b/Sources/ToeCore/Menu/MenuModel.swift
@@ -49,6 +49,8 @@ public struct MenuItem: Equatable {
         case gear, book, keyboard, pencil, power, toggleOn, toggleOff
         case paintbrush, droplet, image
         case download, trash, info, globe
+        /// The command line, and the one row that is about it — see `MenuModel.agentSkill`.
+        case terminal
     }
 
     public indirect enum Action: Equatable {
@@ -138,6 +140,12 @@ public enum LoginItemState: Equatable, Sendable {
 
 /// What the Style, Install and Remove levels need to draw themselves.
 ///
+/// Style is in the name because for a long time that was all of it. The Install and Remove levels
+/// hold one row that is not about colour — the agent skill — and it is carried here rather than
+/// as a second parameter for the reason the rest of this is one value: it is threaded from the
+/// Coordinator through `QuickMenu` to `MenuModel` unchanged, and a second thing to thread is a
+/// second thing to forget to thread.
+///
 /// A value rather than four parameters, because it is threaded from the Coordinator through
 /// `QuickMenu` to here unchanged, and because it is rebuilt every time the menu opens — that is
 /// what makes a theme folder you created a moment ago appear without a reload.
@@ -164,11 +172,15 @@ public struct StyleMenu: Equatable {
     /// The theme being fetched right now, if one is. Its row fills as the pictures arrive, which
     /// is the whole of what toe says about a download since the menu bar stopped saying it.
     public var downloading: ThemeDownload?
+    /// Where the Claude Code skill file is and whether what is there is what this copy of toe
+    /// would write. nil where nobody has asked — the selftest, and every construction of this
+    /// value that is not the menu opening — and the row is then left out rather than guessing.
+    public var skill: SkillReport?
 
     public init(themes: [ThemeRef] = [], available: [RemoteTheme] = [], fetching: Bool = false,
                 current: String? = nil,
                 backgrounds: [String] = [], currentBackground: String? = nil,
-                downloading: ThemeDownload? = nil) {
+                downloading: ThemeDownload? = nil, skill: SkillReport? = nil) {
         self.themes = themes
         self.available = available
         self.fetching = fetching
@@ -176,6 +188,7 @@ public struct StyleMenu: Equatable {
         self.backgrounds = backgrounds
         self.currentBackground = currentBackground
         self.downloading = downloading
+        self.skill = skill
     }
 }
 
@@ -361,18 +374,49 @@ public enum MenuModel {
         return rows
     }
 
-    /// Omarchy's `Install` level. Upstream it holds sixteen submenus; toe can fetch one kind of
-    /// thing, so it holds `Style › Theme` and the two levels above it exist to put that row
-    /// where an Omarchy user's hands expect to find it.
+    /// Omarchy's `Install` level. Upstream it holds sixteen submenus; toe can put two kinds of
+    /// thing on your machine, so it holds `Style › Theme` — the two levels above it exist to put
+    /// that row where an Omarchy user's hands expect to find it — and the agent skill.
     ///
-    /// Empty — and so absent from the root — until the catalogue has been fetched once. A
-    /// machine that has never had a network has nothing to install and says so by not offering.
+    /// The theme half is absent until the catalogue has been fetched once: a machine that has
+    /// never had a network has no themes to offer and says so by not offering. The skill needs
+    /// nothing fetched, so the level itself is no longer conditional — which is a change from
+    /// when this could come out empty, and the reason the guard below stays: the *rule* is that a
+    /// row leading into an empty level is worse than no row, not that this particular level
+    /// happens to have something in it today.
     public static func install(_ style: StyleMenu) -> [MenuItem] {
-        let rows = installableThemes(style)
-        guard !rows.isEmpty else { return [] }
-        return [MenuItem(title: "Style", icon: .paintbrush, action: .submenu([
-            MenuItem(title: "Theme", icon: .droplet, action: .submenu(rows)),
-        ]))]
+        var rows: [MenuItem] = []
+        let themes = installableThemes(style)
+        if !themes.isEmpty {
+            rows.append(MenuItem(title: "Style", icon: .paintbrush, action: .submenu([
+                MenuItem(title: "Theme", icon: .droplet, action: .submenu(themes)),
+            ])))
+        }
+        if let skill = agentSkill(style) { rows.append(skill) }
+        return rows
+    }
+
+    /// The row that writes `~/.claude/skills/toe/SKILL.md`.
+    ///
+    /// toe's own row, with no Omarchy counterpart — Omarchy's Install level installs software,
+    /// and this installs a page of documentation into another program's directory. It is here
+    /// rather than under Setup because Setup is switches and the config file, and this is a thing
+    /// that is either on your disk or not, which is exactly what Install and Remove are for.
+    ///
+    /// Omarchy's `disabled` guard does the work: once the file is there the row stays listed,
+    /// goes dim and takes a tick, so the level reads as a catalogue of what toe can put on the
+    /// machine rather than a list that empties as you use it. The one thing that is not simply
+    /// present or absent is a file written by the *other* copy of toe — the document names the
+    /// binary that wrote it, so the development build and the installed one write different text
+    /// — and that is offered rather than ticked, with the second column saying which it is.
+    public static func agentSkill(_ style: StyleMenu) -> MenuItem? {
+        guard let skill = style.skill else { return nil }
+        let current = skill.installed && !skill.stale
+        return MenuItem(title: "Claude Code skill",
+                        icon: .terminal,
+                        value: current ? checkmark : (skill.stale ? "update" : nil),
+                        isDisabled: current,
+                        action: .run(.installSkill))
     }
 
     /// Everything Omarchy publishes: what you have, dimmed, and what you do not, priced.
@@ -416,9 +460,20 @@ public enum MenuModel {
     /// already gone*; removing the theme you are wearing is allowed, and hands your own colours
     /// back on the way out.
     public static func remove(_ style: StyleMenu) -> [MenuItem] {
-        guard !style.themes.isEmpty else { return [] }
-        return [MenuItem(title: "Theme", icon: .droplet, action: .submenu(
-            style.themes.map { MenuItem(title: $0.name, action: .run(.removeTheme($0.slug))) }))]
+        var rows: [MenuItem] = []
+        if !style.themes.isEmpty {
+            rows.append(MenuItem(title: "Theme", icon: .droplet, action: .submenu(
+                style.themes.map { MenuItem(title: $0.name, action: .run(.removeTheme($0.slug))) })))
+        }
+        // Only when there is something to remove, which is upstream's `when` and the mirror of
+        // the Install row: no tick and no dimming here, because in a list called Remove a tick
+        // would read as *this one is already gone*. A stale file is still a file and is still
+        // listed — you can take away a skill written by the other copy of toe.
+        if style.skill?.installed == true {
+            rows.append(MenuItem(title: "Claude Code skill", icon: .terminal,
+                                 action: .run(.removeSkill)))
+        }
+        return rows
     }
 
     /// The current theme's pictures, and the row that steps through them.
@@ -549,6 +604,9 @@ public enum MenuModel {
         case .killActive, .toggleFloating, .toggleSplit, .swapSplit, .resizeActive, .growActive: return 7
         case .theme, .removeTheme, .background, .nextBackground: return 8
         case .menu:             return 9
+        // With `reload` and `quit` rather than with the theme rows: this is a thing done to
+        // toe's own installation, not to how the screen looks.
+        case .installSkill, .removeSkill: return 10
         case .reload, .quit:    return 10
         case .exec:             return 11
         }

--- a/Sources/toe-selftest/main.swift
+++ b/Sources/toe-selftest/main.swift
@@ -4092,4 +4092,298 @@ h.test("a disabled row is listed, ticked, and cannot be reached") { t in
     t.equal(landed.activate(), MenuOutcome.none, "pressing it does nothing, leaving the menu up")
 }
 
+// MARK: - The command line
+
+/// A window as `toe query windows` would report it.
+func win(_ id: WindowID, _ app: String, bundle: String? = nil, title: String? = nil,
+         workspace: Int? = 1, floating: Bool = false) -> WindowReport {
+    WindowReport(id: id, app: app, bundle: bundle, title: title, workspace: workspace,
+                 frame: box(0, 0, 100, 100), floating: floating)
+}
+
+h.test("the CLI tells a verb from a flag from a typo") { t in
+    t.equal(ControlCLI.parse([]).kind, .agent,
+            "no arguments and no terminal — launchd, or `open Toe.app` — is the window manager")
+
+    // Once `toe` is on a PATH, a bare `toe` typed to see what it does would otherwise take the
+    // machine from the copy running properly and hand it to a process that dies with the shell.
+    t.equal(ControlCLI.parse([], isInteractive: true).kind, .help(ControlCLI.usage),
+            "typed at a terminal it prints the usage instead")
+    t.equal(ControlCLI.parse(["agent"], isInteractive: true).kind, .agent,
+            "and `toe agent` is how you say it out loud from a terminal anyway")
+    t.equal(ControlCLI.parse(["query", "state"], isInteractive: true).kind,
+            .request(ControlRequest(op: .query, what: "state")),
+            "a terminal changes nothing about a verb")
+    t.equal(ControlCLI.parse(["--version"]).kind, .agent,
+            "a flag falls through to the flag handling that has always been there")
+    t.equal(ControlCLI.parse(["-psn_0_12345"]).kind, .agent,
+            "and so does the argument some launches of `open Toe.app` carry")
+
+    // The one that matters: a mistyped verb must never start a second window manager on top of
+    // the running one.
+    guard case .error(let message) = ControlCLI.parse(["quer", "windows"]).kind else {
+        return t.expect(false, "a word that is not a verb is an error, not an agent")
+    }
+    t.expect(message.contains("quer"), "and the error says which word it did not know")
+
+    t.equal(ControlCLI.parse(["query", "windows"]).kind,
+            .request(ControlRequest(op: .query, what: "windows")), "query windows")
+    guard case .error = ControlCLI.parse(["query", "everything"]).kind else {
+        return t.expect(false, "an unknown query names the ones there are")
+    }
+    guard case .error = ControlCLI.parse(["query"]).kind else {
+        return t.expect(false, "and query with nothing after it does too")
+    }
+}
+
+h.test("dispatch takes several lines, a window and stdin") { t in
+    t.equal(ControlCLI.parse(["dispatch", "workspace 3"]).kind,
+            .request(ControlRequest(op: .dispatch, commands: ["workspace 3"])), "one line")
+    t.equal(ControlCLI.parse(["dispatch", "workspace 3", "movefocus l"]).kind,
+            .request(ControlRequest(op: .dispatch, commands: ["workspace 3", "movefocus l"])),
+            "several, which is what makes them one render")
+
+    let both = ControlCLI.parse(["dispatch", "--window", "app:Safari", "movetoworkspace 3"])
+    t.equal(both.kind, .request(ControlRequest(op: .dispatch, commands: ["movetoworkspace 3"],
+                                               window: "app:Safari")), "--window and its selector")
+    t.equal(ControlCLI.parse(["dispatch", "--window=app:Safari", "movetoworkspace 3"]).kind,
+            both.kind, "the joined-up spelling is the same request")
+
+    let piped = ControlCLI.parse(["dispatch", "-"])
+    t.expect(piped.readsStdin, "a bare - means the lines are on stdin")
+    guard case .request = piped.kind else { return t.expect(false, "and it is still a dispatch") }
+
+    guard case .error = ControlCLI.parse(["dispatch"]).kind else {
+        return t.expect(false, "dispatch with nothing to dispatch is a usage error")
+    }
+    guard case .error = ControlCLI.parse(["dispatch", "--window"]).kind else {
+        return t.expect(false, "and --window with no selector after it is too")
+    }
+}
+
+h.test("layout and skill route to their own operations") { t in
+    t.equal(ControlCLI.parse(["layout", "save", "work"]).kind,
+            .request(ControlRequest(op: .layoutSave, what: "work")), "layout save work")
+    t.equal(ControlCLI.parse(["layout", "list"]).kind,
+            .request(ControlRequest(op: .layoutList)), "layout list needs no name")
+    guard case .error = ControlCLI.parse(["layout", "apply"]).kind else {
+        return t.expect(false, "layout apply without a name says so rather than applying nothing")
+    }
+    t.equal(ControlCLI.parse(["skill", "install"]).kind, .skill(.install), "skill install")
+    t.equal(ControlCLI.parse(["skill"]).kind, .skill(.status),
+            "bare `skill` reports rather than writing anything")
+    guard case .help = ControlCLI.parse(["help"]).kind else {
+        return t.expect(false, "help prints the usage")
+    }
+}
+
+h.test("a selector names a window without pointing at it") { t in
+    let windows = [
+        win(11, "Ghostty", bundle: "com.mitchellh.ghostty", title: "toe — zsh"),
+        win(12, "Ghostty", bundle: "com.mitchellh.ghostty", title: "notes — nvim"),
+        win(13, "Safari", bundle: "com.apple.Safari", title: "Ghostty on GitHub", workspace: 2),
+    ]
+
+    t.equal(WindowSelector.resolve("id:13", in: windows), .one(windows[2]), "an id is exact")
+    t.equal(WindowSelector.resolve("id:99", in: windows), .none, "and an id nothing has finds nothing")
+    t.equal(WindowSelector.resolve("bundle:com.apple.Safari", in: windows), .one(windows[2]),
+            "a bundle identifier is matched whole")
+    t.equal(WindowSelector.resolve("bundle:com.apple", in: windows), .none,
+            "and not by substring, or `app:com` would name every Apple application at once")
+    t.equal(WindowSelector.resolve("title:notes", in: windows), .one(windows[1]), "a title fragment")
+    t.equal(WindowSelector.resolve("workspace:2", in: windows), .one(windows[2]), "a whole workspace")
+
+    // The rule that makes the most obvious selector anyone will type mean what they meant: a
+    // bare word matches the application *and* the Safari window whose title mentions it, and
+    // the application wins outright rather than the two being called ambiguous.
+    t.equal(WindowSelector.resolve("Safari", in: windows), .one(windows[2]),
+            "a bare word prefers the application to a title that mentions it")
+    guard case .many(let hits) = WindowSelector.resolve("Ghostty", in: windows) else {
+        return t.expect(false, "two windows of one application are ambiguous, not a guess")
+    }
+    t.equal(hits.map(\.id), [11, 12], "and both are named, in id order")
+
+    let explained = WindowSelector.explain(WindowSelector.resolve("Ghostty", in: windows),
+                                           selector: "Ghostty") ?? ""
+    t.expect(explained.contains("id:11") && explained.contains("id:12"),
+             "the refusal carries the ids, which is what a narrower selector needs")
+    t.expect(WindowSelector.explain(.one(windows[0]), selector: "id:11") == nil,
+             "a selector that landed has nothing to explain")
+
+    // Not a prefix toe knows is not a prefix at all: a window title with a colon in it is a
+    // title before it is a mistake.
+    t.equal(WindowSelector.parse("Downloads:2024").field, .any, "an unknown prefix is just text")
+    t.equal(WindowSelector.parse("Downloads:2024").value, "Downloads:2024", "kept whole")
+}
+
+h.test("every catalogued verb is a verb toe actually has") { t in
+    for entry in CommandCatalogue.entries {
+        t.expect(entry.sample.hasPrefix(entry.verb), "\(entry.verb): the sample uses the verb")
+        t.expect((try? CommandParser.parse(entry.sample)) != nil,
+                 "\(entry.verb): `\(entry.sample)` parses")
+        for alias in entry.aliases {
+            let aliased = entry.sample.replacingOccurrences(of: entry.verb, with: alias)
+            t.expect((try? CommandParser.parse(aliased)) != nil,
+                     "\(entry.verb): the alias `\(alias)` parses too")
+        }
+    }
+
+    let verbs = Set(CommandCatalogue.entries.map(\.verb))
+    t.expect(verbs.contains("installskill"), "the skill verbs are in the table")
+    t.expect(verbs.contains("movetoworkspace"), "and so is the one an agent reaches for first")
+
+    // The table's `--window` column is asked of the command rather than written down beside it,
+    // so it cannot claim a target the dispatcher would refuse.
+    func takesWindow(_ verb: String) -> Bool {
+        CommandCatalogue.entries.first { $0.verb == verb }?.takesWindow ?? false
+    }
+    t.expect(takesWindow("movetoworkspace"), "movetoworkspace can be pointed at a window")
+    t.expect(takesWindow("killactive"), "and so can killactive")
+    t.expect(!takesWindow("movefocus"),
+             "movefocus cannot: it means 'from where the focus is'")
+    t.expect(!takesWindow("workspace"), "and a workspace verb has no window to take")
+}
+
+h.test("[cli] keeps exec and quit off the socket until you say otherwise") { t in
+    let config = try Config.parse("")
+    t.expect(config.cli.enabled, "the socket is on by default")
+    t.expect(!config.cli.allowExec, "and exec is not")
+    t.expect(config.cli.refusal(for: .exec("rm -rf /")) != nil, "so exec is refused")
+    t.expect(config.cli.refusal(for: .quit) != nil, "and so is quit")
+    t.expect(config.cli.refusal(for: .workspace(.index(3))) == nil,
+             "while everything that only moves windows goes straight through")
+
+    let opened = try Config.parse("[cli]\nenabled = false\nallow_exec = true\n")
+    t.expect(!opened.cli.enabled, "enabled = false is read")
+    t.expect(opened.cli.refusal(for: .exec("ls")) == nil, "and allow_exec lets exec through")
+    t.expect(opened.cli.refusal(for: .quit) != nil, "one gate does not open the other")
+
+    let wrong = try Config.parse("[cli]\nenabled = \"yes\"\n")
+    t.expect(wrong.cli.enabled, "a mistyped boolean keeps the default")
+    t.expect(wrong.warnings.contains { $0.contains("cli.enabled") },
+             "and says so, rather than looking like toe ignored the file")
+
+    // The default config is the file every new install gets, and it documents this section.
+    let shipped = try Config.parse(Config.defaultTOML)
+    t.expect(shipped.cli.enabled && !shipped.cli.allowExec && !shipped.cli.allowQuit,
+             "the shipped default opens the socket and gates the two verbs")
+}
+
+h.test("a window can be moved and floated without being the focused one") { t in
+    let wm = WorkspaceManager()
+    wm.setMonitors([Monitor(id: 1, frame: AREA, usable: AREA)])
+    wm.addWindow(1); wm.addWindow(2)
+    wm.noteFocus(1)
+
+    t.expect(wm.moveWindow(2, toWorkspace: 4, follow: false), "window 2 moved without holding focus")
+    t.equal(wm.workspaceIndex(of: 2), 4, "it is on workspace 4")
+    t.equal(wm.focusedWorkspaceIndex, 1, "and nobody went with it")
+    t.equal(wm.focusedWindow, 1, "the focus never moved")
+    t.expect(!wm.moveWindow(2, toWorkspace: 4, follow: false), "moving it where it already is does nothing")
+    t.expect(!wm.moveWindow(99, toWorkspace: 2, follow: false), "and a window toe does not know does nothing")
+
+    // `setFloating` arrives at a state in one step where `togglefloating` walks a cycle to it —
+    // a caller restoring a saved arrangement cannot press until it looks right.
+    t.expect(wm.setFloating(1, true), "window 1 floats")
+    t.expect(wm.isFloating(1), "and says so")
+    t.expect(!wm.setFloating(1, true), "asking again changes nothing")
+    t.expect(wm.setFloating(1, false), "and it tiles again in one step")
+    t.expect(!wm.isFloating(1), "rather than at the second size the cycle would have given it")
+}
+
+h.test("a layout profile names windows in a way that survives quitting them") { t in
+    let state = StateReport(
+        focusedWindow: 11, focusedWorkspace: 1, focusedMonitor: 1,
+        monitors: [MonitorReport(id: 1, frame: AREA, usable: AREA, workspace: 1, focused: true)],
+        workspaces: [WorkspaceReport(index: 1, monitor: 1, visible: true, focused: true,
+                                     windows: [11, 12]),
+                     WorkspaceReport(index: 2, monitor: 1, visible: false, focused: false,
+                                     windows: [13])],
+        windows: [win(11, "Ghostty", bundle: "com.mitchellh.ghostty", title: "toe — zsh"),
+                  win(12, "Ghostty", bundle: "com.mitchellh.ghostty", title: "notes — nvim"),
+                  win(13, "Safari", bundle: "com.apple.Safari", title: "GitHub", workspace: 2,
+                      floating: true)])
+
+    let profile = LayoutProfile.capture(name: "work", from: state)
+    t.equal(profile.workspaces.map(\.index), [1, 2], "both workspaces are recorded, in order")
+    t.equal(profile.workspaces[0].windows.map(\.app), ["Ghostty", "Ghostty"], "in tree order")
+    t.expect(profile.workspaces[0].windows[0].title == nil,
+             "the first window of an application is named by the application alone")
+    t.equal(profile.workspaces[0].windows[1].title, "notes — nvim",
+             "and only the second earns a title, which is the least durable thing about a window")
+    t.expect(profile.workspaces[1].windows[0].floating, "the float is recorded as one")
+
+    // Applied against the same windows, it asks for exactly the arrangement it was taken from.
+    let same = profile.plan(against: state.windows)
+    t.equal(same.moves.map(\.window), [11, 12, 13], "every window is placed")
+    t.equal(same.moves.map(\.workspace), [1, 1, 2], "back where it came from")
+    t.expect(same.missing.isEmpty && same.untouched.isEmpty, "nothing missing, nothing left over")
+
+    // One terminal running where the profile wants two: it places the one and reports the other
+    // rather than putting the same window in two places.
+    let fewer = [win(21, "Ghostty", bundle: "com.mitchellh.ghostty", title: "something else"),
+                 win(22, "Mail", bundle: "com.apple.mail", title: "Inbox")]
+    let short = profile.plan(against: fewer)
+    t.equal(short.moves.map(\.window), [21], "the one terminal is claimed once")
+    t.equal(short.missing.count, 2, "the second terminal and Safari are reported missing")
+    t.equal(short.untouched, [22], "and a window the profile says nothing about is left alone")
+}
+
+h.test("the skill row is Install's, with Omarchy's already-have-it guard") { t in
+    let none = StyleMenu()
+    t.expect(MenuModel.agentSkill(none) == nil,
+             "with nothing known about the file there is no row rather than a guess")
+    t.expect(MenuModel.remove(none).isEmpty, "and nothing to remove")
+
+    let missing = StyleMenu(skill: SkillReport(path: "/x/SKILL.md", installed: false, stale: false))
+    let offer = MenuModel.install(missing)
+    t.equal(offer.map(\.title), ["Claude Code skill"],
+            "with no catalogue fetched the level is the skill row alone")
+    t.expect(offer[0].value == nil && !offer[0].isDisabled, "offered plainly")
+    t.equal(offer[0].action, .run(.installSkill), "and it installs")
+    t.expect(MenuModel.remove(missing).isEmpty, "Remove says nothing about a file that is not there")
+
+    let installed = StyleMenu(skill: SkillReport(path: "/x/SKILL.md", installed: true, stale: false))
+    let have = MenuModel.install(installed)
+    t.equal(have[0].value, MenuModel.checkmark, "installed takes the tick")
+    t.expect(have[0].isDisabled, "and Omarchy's disabled guard, so it is listed but not choosable")
+    t.equal(MenuModel.remove(installed).map(\.title), ["Claude Code skill"],
+            "while Remove now offers it")
+    t.expect(MenuModel.remove(installed)[0].value == nil,
+             "with no tick: in a list called Remove that would read as 'already gone'")
+
+    // The document names the binary that wrote it, so the two copies of toe write different
+    // text. A file from the other one is offered again rather than ticked.
+    let stale = StyleMenu(skill: SkillReport(path: "/x/SKILL.md", installed: true, stale: true))
+    let update = MenuModel.install(stale)
+    t.equal(update[0].value, "update", "a stale file says what pressing it would do")
+    t.expect(!update[0].isDisabled, "and can be pressed")
+    t.equal(MenuModel.remove(stale).map(\.title), ["Claude Code skill"],
+            "a stale file is still a file, and still removable")
+
+    // The row keeps the menu open, for the reason a theme row does: the row changing under the
+    // cursor is the whole of what toe says about having done it.
+    t.expect(Command.installSkill.keepsMenuOpen && Command.removeSkill.keepsMenuOpen,
+             "both leave the menu up to show the row change")
+}
+
+h.test("the skill document is generated from the verb table") { t in
+    let text = SkillDocument.text(binary: "/Applications/Toe.app/Contents/MacOS/toe", version: "1.2.3")
+    t.expect(text.hasPrefix("---\nname: toe\n"), "it starts with the frontmatter a skill needs")
+    t.expect(text.contains("/Applications/Toe.app/Contents/MacOS/toe query state"),
+             "and names the binary that wrote it, since nothing puts toe on a PATH")
+
+    // The half that would otherwise go stale: every verb toe has appears because the table is
+    // walked, not because somebody remembered to add it here.
+    for entry in CommandCatalogue.entries {
+        t.expect(text.contains("`\(entry.usage)`"), "the document lists \(entry.verb)")
+    }
+
+    // The half that cannot be derived, and the reason the document is worth having.
+    for note in ["not a macOS Space", "fullscreen", "Floating windows are the user's",
+                 "app:Ghostty", "layout save"] {
+        t.expect(text.contains(note), "it still says the thing about \(note)")
+    }
+}
+
 exit(h.report())

--- a/Sources/toe/AppIdentity.swift
+++ b/Sources/toe/AppIdentity.swift
@@ -25,6 +25,23 @@ enum AppIdentity {
     /// eventually debug the wrong one of.
     static var isDevelopment: Bool { Bundle.main.bundleIdentifier == development }
 
+    /// What this copy was stamped with, or nil for a binary run straight out of `.build`, which
+    /// has no `Info.plist` to have been stamped.
+    static var version: String? {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    }
+
+    /// Where this binary is, absolutely.
+    ///
+    /// The skill document names it, because nothing puts toe on a PATH — it lives inside an
+    /// application bundle, and an agent that has to guess at the path is an agent that gives up.
+    /// `argv[0]` is the fallback for the case `Bundle` cannot answer, which is a binary invoked
+    /// through a symlink from somewhere odd; it is the path the caller actually used, which is
+    /// the next best thing to the real one.
+    static var binaryPath: String {
+        Bundle.main.executableURL?.resolvingSymlinksInPath().path ?? CommandLine.arguments[0]
+    }
+
     /// Asks every other copy of toe to quit, and waits for it to be gone.
     ///
     /// `SIGTERM`, not `NSRunningApplication.terminate()`: that sends a quit Apple Event, which

--- a/Sources/toe/Control/ControlClient.swift
+++ b/Sources/toe/Control/ControlClient.swift
@@ -1,0 +1,200 @@
+import Darwin
+import Foundation
+import ToeCore
+
+/// The `toe` you type: connect, say one thing, print what comes back, exit.
+///
+/// This runs before `NSApplication` exists and never creates one. It is the same binary as the
+/// window manager and shares its code, but not its life: no Accessibility, no hotkeys, no menu
+/// bar, no `Coordinator` — a few milliseconds and a file descriptor.
+///
+/// Blocking calls throughout, which is the opposite of `ControlSocket` and right for the same
+/// reason it is wrong there. Nothing else is happening in this process; there is no run loop to
+/// starve and no window to leave un-drawn. The one thing guarded is the wait, so a wedged agent
+/// cannot leave a shell hanging.
+enum ControlClient {
+
+    /// How long to wait for a reply. Generous, because a reply can be behind a synchronous
+    /// Accessibility write for every window on a workspace, and short enough that a toe which is
+    /// never going to answer says so while somebody is still watching.
+    private static let replyTimeout: TimeInterval = 10
+
+    /// - Returns: the process's exit status. 0 worked, 1 reached toe and was refused, 2 never
+    ///   got that far — the distinction a script needs to tell a typo from a "no".
+    static func run(_ invocation: CLIInvocation) -> Int32 {
+        switch invocation.kind {
+        case .agent:
+            return 0   // never reached: main.swift only calls this for the other cases
+
+        case .help(let text):
+            print(text)
+            return 0
+
+        case .error(let message):
+            complain(message)
+            return 2
+
+        case .skill(let action):
+            return skill(action)
+
+        case .request(var request):
+            if invocation.readsStdin {
+                request.commands = (request.commands ?? []) + linesFromStandardInput()
+                guard !(request.commands ?? []).isEmpty else {
+                    complain("nothing on stdin to dispatch")
+                    return 2
+                }
+            }
+            return send(request)
+        }
+    }
+
+    // MARK: - The skill file
+
+    /// Done here rather than sent to the agent. Writing a file needs a file system, not a window
+    /// manager — so `toe skill install` works on a machine where toe has never been started, and
+    /// the day the socket is switched off in the config this is still the way in.
+    private static func skill(_ action: CLIInvocation.Skill) -> Int32 {
+        switch action {
+        case .print:
+            print(SkillStore.text)
+            return 0
+
+        case .status:
+            return emit(SkillStore.state())
+
+        case .install:
+            switch SkillStore.install() {
+            case .success(let report):
+                return emit(report)
+            case .failure(let refusal):
+                complain(refusal.description)
+                return 1
+            }
+
+        case .remove:
+            switch SkillStore.remove() {
+            case .success(let report):
+                return emit(report)
+            case .failure(let refusal):
+                complain(refusal.description)
+                return 1
+            }
+        }
+    }
+
+    private static func emit<T: Encodable>(_ value: T) -> Int32 {
+        FileHandle.standardOutput.write(ControlCoding.line(ControlSuccess(value)))
+        return 0
+    }
+
+    // MARK: - The socket
+
+    private static func send(_ request: ControlRequest) -> Int32 {
+        guard let payload = try? JSONEncoder().encode(request) else {
+            complain("could not encode that request")
+            return 2
+        }
+
+        let path = ControlSocket.url.path
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            complain("could not open a socket: \(errorText())")
+            return 2
+        }
+        defer { close(fd) }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        _ = withUnsafeMutablePointer(to: &address.sun_path) { field in
+            field.withMemoryRebound(to: CChar.self, capacity: 104) { strncpy($0, path, 103) }
+        }
+        let size = socklen_t(MemoryLayout<sockaddr_un>.size)
+        let connected = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { connect(fd, $0, size) }
+        }
+        guard connected == 0 else {
+            // The two ways this fails are the two ways toe can be absent, and they deserve the
+            // same sentence: no socket file at all (never started, or shut down cleanly), and a
+            // socket file nothing is listening on (killed). Neither is worth explaining to
+            // somebody who only wanted to move a window.
+            complain(errno == ENOENT || errno == ECONNREFUSED
+                     ? "toe is not running"
+                     : "could not reach toe at \(path): \(errorText())")
+            return 1
+        }
+
+        // The deadline is the socket's own, so a toe that accepts the connection and then wedges
+        // cannot hold a shell open indefinitely.
+        var deadline = timeval(tv_sec: Int(replyTimeout), tv_usec: 0)
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &deadline, socklen_t(MemoryLayout<timeval>.size))
+        setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &deadline, socklen_t(MemoryLayout<timeval>.size))
+        var on: Int32 = 1
+        setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &on, socklen_t(MemoryLayout<Int32>.size))
+
+        var line = payload
+        line.append(0x0a)
+        var sent = 0
+        while sent < line.count {
+            let written = line.withUnsafeBytes {
+                write(fd, $0.baseAddress!.advanced(by: sent), line.count - sent)
+            }
+            guard written > 0 else {
+                complain("toe closed the connection before hearing the request")
+                return 1
+            }
+            sent += written
+        }
+        // Says "that is all of it". The reply is framed by end of file rather than by a newline,
+        // because it is pretty-printed and full of them.
+        shutdown(fd, SHUT_WR)
+
+        var reply = Data()
+        var buffer = [UInt8](repeating: 0, count: 8192)
+        while true {
+            let read = buffer.withUnsafeMutableBytes { Darwin.read(fd, $0.baseAddress, 8192) }
+            if read > 0 { reply.append(contentsOf: buffer[0..<read]); continue }
+            if read == 0 { break }
+            if errno == EINTR { continue }
+            complain(errno == EAGAIN || errno == EWOULDBLOCK
+                     ? "toe did not answer within \(Int(replyTimeout))s"
+                     : "lost the connection to toe: \(errorText())")
+            return 1
+        }
+
+        guard !reply.isEmpty else {
+            complain("toe answered with nothing")
+            return 1
+        }
+
+        // A refusal is a sentence on stderr and a non-zero exit, not JSON on stdout: a shell
+        // pipeline should see an empty stdout when nothing worked, and a person should see the
+        // reason without reading JSON. Everything that *did* work goes to stdout whole, exactly
+        // as toe wrote it — pretty-printed, in declaration order, ready to be piped into `jq`.
+        if let failure = try? ControlCoding.decoder().decode(ControlFailure.self, from: reply),
+           !failure.ok {
+            complain(failure.error)
+            return 1
+        }
+        FileHandle.standardOutput.write(reply)
+        return 0
+    }
+
+    // MARK: - Odds and ends
+
+    /// One command line per line, blank ones dropped and `#` comments ignored — so a file of
+    /// commands can be kept, annotated, and piped in.
+    private static func linesFromStandardInput() -> [String] {
+        let data = FileHandle.standardInput.readDataToEndOfFile()
+        return String(decoding: data, as: UTF8.self)
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty && !$0.hasPrefix("#") }
+    }
+
+    private static func complain(_ message: String) {
+        FileHandle.standardError.write(Data("toe: \(message)\n".utf8))
+    }
+
+    private static func errorText() -> String { String(cString: strerror(errno)) }
+}

--- a/Sources/toe/Control/ControlSocket.swift
+++ b/Sources/toe/Control/ControlSocket.swift
@@ -1,0 +1,338 @@
+import Darwin
+import Foundation
+import ToeCore
+
+/// The listening half of `toe query` and `toe dispatch`.
+///
+/// A Unix domain socket at `~/.local/state/toe/toe.sock`, beside the four journals and the
+/// session file, because it is the same kind of thing: state that belongs to this machine's one
+/// running toe. The alternative on macOS is a Mach service, which has to be declared in a
+/// launchd plist — and toe is as often started by `open Toe.app`, which never goes near launchd,
+/// so that channel would exist for some launches and not for others. A socket works however toe
+/// was started, and `nc` can talk to it, which has been worth a great deal while building this.
+///
+/// **Everything here runs on the main thread, deliberately and dangerously.** A request ends in
+/// `Coordinator.dispatch`, which writes window frames over Accessibility, and Accessibility is
+/// main-thread-only. Handing the socket a background queue would only move the hop somewhere
+/// less obvious. The price is that a client which connects and then says nothing is holding the
+/// compositor's hand, so nothing here may ever block:
+///
+///   * every descriptor is non-blocking, and a partial write is finished by a write source
+///     rather than by spinning;
+///   * a request is capped at 64 KiB, and a connection that has not produced a whole one within
+///     two seconds is closed unread;
+///   * `SO_NOSIGPIPE` is set on every accepted descriptor, because the default answer to writing
+///     down a socket the client has already closed is to kill the process.
+///
+/// The connection is closed after one reply. That is what lets the reply be pretty-printed JSON
+/// with newlines in it: the request is newline-framed, the response is framed by end of file.
+final class ControlSocket {
+
+    static let url = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".local/state/toe/toe.sock")
+
+    /// Answers a request with the bytes to send back. Called on the main thread.
+    var onRequest: ((ControlRequest) -> Data)?
+
+    private var listener: Int32 = -1
+    private var source: DispatchSourceRead?
+    private var connections: [ObjectIdentifier: Connection] = [:]
+
+    /// How long a connection has to produce a whole request.
+    private static let requestDeadline: TimeInterval = 2
+    /// A request is a line of JSON naming a verb. Anything past this is not one.
+    private static let requestLimit = 64 << 10
+
+    var isRunning: Bool { source != nil }
+
+    // MARK: - Lifecycle
+
+    @discardableResult
+    func start() -> String? {
+        guard source == nil else { return nil }
+
+        let path = Self.url.path
+        // `sun_path` is 104 bytes on Darwin, which the state directory is nowhere near — but the
+        // check is here rather than assumed, because the failure it prevents is a silent bind to
+        // a truncated path.
+        guard path.utf8.count < 104 else {
+            return "the socket path is too long for a Unix socket: \(path)"
+        }
+
+        do {
+            try FileManager.default.createDirectory(at: Self.url.deletingLastPathComponent(),
+                                                    withIntermediateDirectories: true,
+                                                    attributes: [.posixPermissions: 0o700])
+        } catch {
+            return "could not make \(Self.url.deletingLastPathComponent().path): \(error.localizedDescription)"
+        }
+
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return "could not open a socket: \(errorText())" }
+
+        // A socket file left behind by a copy that was killed rather than quit. Removing it
+        // unconditionally is safe for the reason `AppIdentity.takeOver` is: exactly one toe runs
+        // at a time, and it has already waited for the other one to be gone.
+        unlink(path)
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        _ = withUnsafeMutablePointer(to: &address.sun_path) { field in
+            field.withMemoryRebound(to: CChar.self, capacity: 104) { destination in
+                strncpy(destination, path, 103)
+            }
+        }
+        let size = socklen_t(MemoryLayout<sockaddr_un>.size)
+        let bound = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { bind(fd, $0, size) }
+        }
+        guard bound == 0 else {
+            let message = "could not bind \(path): \(errorText())"
+            close(fd)
+            return message
+        }
+
+        // After the bind, which is when the file exists. The directory is already 0700, so this
+        // is belt and braces — but the socket is the one thing in there that is an *entry point*
+        // rather than a record, and it should say so in its own mode.
+        chmod(path, 0o600)
+
+        guard listen(fd, 8) == 0 else {
+            let message = "could not listen on \(path): \(errorText())"
+            close(fd)
+            unlink(path)
+            return message
+        }
+        setNonBlocking(fd)
+
+        let source = DispatchSource.makeReadSource(fileDescriptor: fd, queue: .main)
+        source.setEventHandler { [weak self] in self?.acceptWaiting() }
+        // The descriptor is closed here and nowhere else: cancelling a source is asynchronous,
+        // and a descriptor closed before the source has finished with it can be handed to
+        // something else in between.
+        source.setCancelHandler { close(fd) }
+        source.resume()
+
+        self.listener = fd
+        self.source = source
+        Log.info("cli: listening on \(path)")
+        return nil
+    }
+
+    func stop() {
+        guard let source else { return }
+        for connection in connections.values { connection.close() }
+        connections.removeAll()
+        source.cancel()
+        self.source = nil
+        listener = -1
+        unlink(Self.url.path)
+    }
+
+    // MARK: - Accepting
+
+    private func acceptWaiting() {
+        // Until EAGAIN: a read source fires once for any number of pending connections, and
+        // accepting one per firing would leave the rest waiting on the next client.
+        while true {
+            let fd = accept(listener, nil, nil)
+            guard fd >= 0 else { return }
+
+            // Same user only. The socket is already 0600 inside a 0700 directory, so this is not
+            // load-bearing — it is the check that stays true if either of those ever slips.
+            var uid = uid_t(), gid = gid_t()
+            guard getpeereid(fd, &uid, &gid) == 0, uid == getuid() else {
+                Log.error("cli: refused a connection from uid \(uid)")
+                close(fd)
+                continue
+            }
+
+            setNonBlocking(fd)
+            // Without this, replying down a socket whose client has already gone away kills toe.
+            var on: Int32 = 1
+            setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &on, socklen_t(MemoryLayout<Int32>.size))
+
+            let connection = Connection(fd: fd,
+                                        limit: Self.requestLimit,
+                                        onRequest: { [weak self] data in self?.answer(data) ?? Data() },
+                                        onFinish: { [weak self] connection in
+                                            self?.connections.removeValue(forKey: ObjectIdentifier(connection))
+                                        })
+            connections[ObjectIdentifier(connection)] = connection
+            connection.start(deadline: Self.requestDeadline)
+        }
+    }
+
+    /// One request's worth of bytes in, one reply's worth out. Every failure below is answered
+    /// rather than dropped: a client that gets nothing back cannot tell a refusal from a toe
+    /// that has wedged, and the whole point of a control socket is that the far end can find out
+    /// what happened.
+    private func answer(_ data: Data) -> Data {
+        guard let request = try? ControlCoding.decoder().decode(ControlRequest.self, from: data) else {
+            return ControlCoding.line(ControlFailure("that is not a request toe understands"))
+        }
+        guard request.version <= ControlRequest.currentVersion else {
+            return ControlCoding.line(ControlFailure(
+                "this request speaks protocol \(request.version) and toe speaks "
+                + "\(ControlRequest.currentVersion) — the `toe` on your PATH is newer than the "
+                + "one that is running"))
+        }
+        guard let onRequest else {
+            return ControlCoding.line(ControlFailure("toe is not ready for commands yet"))
+        }
+        return onRequest(request)
+    }
+
+    private func setNonBlocking(_ fd: Int32) {
+        let flags = fcntl(fd, F_GETFL, 0)
+        _ = fcntl(fd, F_SETFL, flags | O_NONBLOCK)
+    }
+
+    private func errorText() -> String { String(cString: strerror(errno)) }
+}
+
+// MARK: - One client
+
+/// Reads one newline-framed request, writes one reply, closes.
+///
+/// A class with its own sources rather than a synchronous read and write, because both halves
+/// run on the main thread: a 200 KiB reply to `query state` on a busy machine can fill the send
+/// buffer, and the honest way to finish it is a write source that resumes when there is room.
+private final class Connection {
+
+    private let fd: Int32
+    private let limit: Int
+    private let onRequest: (Data) -> Data
+    private let onFinish: (Connection) -> Void
+
+    private var reader: DispatchSourceRead?
+    private var writer: DispatchSourceWrite?
+    private var inbox = Data()
+    private var outbox = Data()
+    private var timeout: DispatchWorkItem?
+    private var isClosed = false
+
+    init(fd: Int32, limit: Int, onRequest: @escaping (Data) -> Data,
+         onFinish: @escaping (Connection) -> Void) {
+        self.fd = fd
+        self.limit = limit
+        self.onRequest = onRequest
+        self.onFinish = onFinish
+    }
+
+    func start(deadline: TimeInterval) {
+        let reader = DispatchSource.makeReadSource(fileDescriptor: fd, queue: .main)
+        reader.setEventHandler { [weak self] in self?.readWaiting() }
+        reader.resume()
+        self.reader = reader
+
+        // A client that opens a connection and says nothing would otherwise sit here forever
+        // holding a descriptor and a place in the accept queue.
+        let work = DispatchWorkItem { [weak self] in
+            guard let self, !self.isClosed else { return }
+            Log.error("cli: a connection sent nothing within \(Int(deadline))s — closing it")
+            self.close()
+        }
+        timeout = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + deadline, execute: work)
+    }
+
+    private func readWaiting() {
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let read = buffer.withUnsafeMutableBytes { Darwin.read(fd, $0.baseAddress, 4096) }
+            if read > 0 {
+                inbox.append(contentsOf: buffer[0..<read])
+                guard inbox.count <= limit else {
+                    reply(ControlCoding.line(ControlFailure("that request is too long")))
+                    return
+                }
+                if let newline = inbox.firstIndex(of: 0x0a) {
+                    answer(inbox[inbox.startIndex..<newline])
+                    return
+                }
+                continue
+            }
+            if read == 0 {
+                // End of file with no newline: a client that wrote its request and shut its
+                // writing half without a terminator, which is what a plain `printf | nc` does.
+                // Answering it is friendlier than insisting on the framing.
+                if inbox.isEmpty { close() } else { answer(inbox[...]) }
+                return
+            }
+            if errno == EAGAIN || errno == EWOULDBLOCK { return }
+            if errno == EINTR { continue }
+            close()
+            return
+        }
+    }
+
+    private func answer(_ request: Data.SubSequence) {
+        timeout?.cancel()
+        timeout = nil
+        reader?.cancel()
+        reader = nil
+        reply(onRequest(Data(request)))
+    }
+
+    private func reply(_ data: Data) {
+        outbox = data
+        flush()
+    }
+
+    private func flush() {
+        while !outbox.isEmpty {
+            let written = outbox.withUnsafeBytes { Darwin.write(fd, $0.baseAddress, outbox.count) }
+            if written > 0 {
+                outbox.removeFirst(written)
+                continue
+            }
+            if written < 0, errno == EINTR { continue }
+            if written < 0, errno == EAGAIN || errno == EWOULDBLOCK {
+                waitForRoom()
+                return
+            }
+            // The client has gone. Nothing to report to and nothing to do about it.
+            close()
+            return
+        }
+        close()
+    }
+
+    private func waitForRoom() {
+        guard writer == nil else { return }
+        let writer = DispatchSource.makeWriteSource(fileDescriptor: fd, queue: .main)
+        writer.setEventHandler { [weak self] in
+            guard let self else { return }
+            self.writer?.cancel()
+            self.writer = nil
+            self.flush()
+        }
+        writer.resume()
+        self.writer = writer
+    }
+
+    func close() {
+        guard !isClosed else { return }
+        isClosed = true
+        timeout?.cancel()
+        timeout = nil
+        // The descriptor is closed by whichever source still holds it, for the reason the
+        // listener's is: cancellation is asynchronous. With neither source left it is closed
+        // here.
+        if let reader {
+            reader.setCancelHandler { [fd] in Darwin.close(fd) }
+            reader.cancel()
+            self.reader = nil
+            self.writer?.cancel()
+            self.writer = nil
+        } else if let writer {
+            writer.setCancelHandler { [fd] in Darwin.close(fd) }
+            writer.cancel()
+            self.writer = nil
+        } else {
+            Darwin.close(fd)
+        }
+        onFinish(self)
+    }
+}

--- a/Sources/toe/Control/LayoutStore.swift
+++ b/Sources/toe/Control/LayoutStore.swift
@@ -1,0 +1,93 @@
+import Foundation
+import ToeCore
+
+/// Reads and writes `~/.config/toe/layouts` — the named arrangements `toe layout save` keeps.
+///
+/// Under `.config` rather than `.local/state`, which is the opposite of where the session
+/// snapshot lives, and deliberately. A session snapshot is toe's own bookkeeping: nobody names
+/// it, nobody edits it, and it is worthless after a reboot. A profile is something the user
+/// asked for by name, will want to keep, and may well want to hand-edit or put in a dotfiles
+/// repository — that is the config directory's job, next to the themes.
+///
+/// The disk half of the split ToeCore keeps everywhere else: `LayoutProfile` is the shape and
+/// the matching, this is the directory walking, exactly as `ThemeStore` is to `Theme`.
+enum LayoutStore {
+
+    static let directory = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".config/toe/layouts")
+
+    /// A profile is a line or two per window. Anything past this is not one, and it is read
+    /// before it is trusted — `SessionStore`'s reasoning, one directory over.
+    private static let sizeLimit = 1 << 20
+
+    /// The profiles there are, by name, sorted so a listing reads the same way twice running.
+    static func names() -> [String] {
+        let files = (try? FileManager.default.contentsOfDirectory(
+            at: directory, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])) ?? []
+        return files
+            .filter { $0.pathExtension == "json" }
+            .map { $0.deletingPathExtension().lastPathComponent }
+            .filter { Slug.make($0) == $0 }
+            .sorted()
+    }
+
+    static func load(_ name: String) -> Result<LayoutProfile, Refusal> {
+        guard let url = url(for: name) else { return .failure(Refusal(badName(name))) }
+        guard let data = try? Data(contentsOf: url) else {
+            let known = names()
+            let suffix = known.isEmpty ? " — nothing has been saved yet"
+                                       : " — there is \(known.joined(separator: ", "))"
+            return .failure(Refusal("no layout called '\(name)'\(suffix)"))
+        }
+        guard data.count <= sizeLimit else {
+            return .failure(Refusal("'\(name)' is implausibly large for a layout; refusing to read it"))
+        }
+        guard let profile = try? ControlCoding.decoder().decode(LayoutProfile.self, from: data) else {
+            return .failure(Refusal("'\(name)' is not a layout toe can read"))
+        }
+        guard profile.version == LayoutProfile.currentVersion else {
+            return .failure(Refusal("'\(name)' was written by a different version of toe"))
+        }
+        return .success(profile)
+    }
+
+    static func save(_ profile: LayoutProfile) -> Result<URL, Refusal> {
+        guard let url = url(for: profile.name) else { return .failure(Refusal(badName(profile.name))) }
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true,
+                                                    attributes: [.posixPermissions: 0o700])
+            try ControlCoding.encoder().encode(profile).write(to: url, options: .atomic)
+            return .success(url)
+        } catch {
+            return .failure(Refusal("could not write \(url.path): \(error.localizedDescription)"))
+        }
+    }
+
+    static func delete(_ name: String) -> Result<Void, Refusal> {
+        guard let url = url(for: name) else { return .failure(Refusal(badName(name))) }
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return .failure(Refusal("no layout called '\(name)'"))
+        }
+        do {
+            try FileManager.default.removeItem(at: url)
+            return .success(())
+        } catch {
+            return .failure(Refusal("could not remove \(url.path): \(error.localizedDescription)"))
+        }
+    }
+
+    /// Through the slug, and refusing anything the slug changes — the same guard `removeTheme`
+    /// puts between a name and a path join. This name arrives over a socket and is joined onto a
+    /// directory that is about to be written to and deleted from, so a `/` or a `..` in it must
+    /// not become part of the path. Rejecting rather than silently slugifying: a caller that
+    /// asked for `../../x` should be told no, not handed a file called something else.
+    private static func url(for name: String) -> URL? {
+        guard !name.isEmpty, Slug.make(name) == name else { return nil }
+        return directory.appendingPathComponent(name).appendingPathExtension("json")
+    }
+
+    private static func badName(_ name: String) -> String {
+        "'\(name)' is not a usable layout name — lower case, digits and hyphens, "
+        + "so it can be a file name (try '\(Slug.make(name))')"
+    }
+}

--- a/Sources/toe/Control/SkillStore.swift
+++ b/Sources/toe/Control/SkillStore.swift
@@ -1,0 +1,77 @@
+import Foundation
+import ToeCore
+
+/// Puts the generated skill document where Claude Code looks for one, and takes it away again.
+///
+/// `~/.claude/skills/toe/SKILL.md` is another program's directory, so this writes exactly one
+/// file into exactly one folder of its own and never touches anything beside it. Removing takes
+/// the same file and then the folder *only if it is empty*, so anything a user has added next to
+/// it — a reference file, a script the skill calls — survives toe changing its mind.
+///
+/// The document is generated, not shipped: see `SkillDocument` for why a committed copy would
+/// be lying about the verb list within a release or two. That has a consequence worth knowing
+/// here — the text names the binary that wrote it, so the copy `make run` builds writes a
+/// document pointing at `build/ToeDev.app`, and installing from one copy leaves the other
+/// reporting `stale`. That is the honest answer rather than an annoyance: the file really does
+/// point at the other binary.
+enum SkillStore {
+
+    static let directory = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".claude/skills")
+        .appendingPathComponent(SkillDocument.directoryName)
+
+    static var file: URL { directory.appendingPathComponent(SkillDocument.fileName) }
+
+    /// What this copy of toe would write.
+    static var text: String {
+        SkillDocument.text(binary: AppIdentity.binaryPath, version: AppIdentity.version)
+    }
+
+    static func state() -> SkillReport {
+        let onDisk = try? String(contentsOf: file, encoding: .utf8)
+        return SkillReport(path: file.path,
+                           installed: onDisk != nil,
+                           // Compared whole rather than by a version stamp: the document is
+                           // generated from the verb table, so "the same" is a question about
+                           // its entire contents, and any stamp fine enough to answer it would
+                           // be the contents again.
+                           stale: onDisk != nil && onDisk != text)
+    }
+
+    @discardableResult
+    static func install() -> Result<SkillReport, Refusal> {
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            try text.write(to: file, atomically: true, encoding: .utf8)
+            Log.info("skill: wrote \(file.path)")
+            return .success(state())
+        } catch {
+            let message = "could not write \(file.path): \(error.localizedDescription)"
+            Log.error("skill: \(message)")
+            return .failure(Refusal(message))
+        }
+    }
+
+    @discardableResult
+    static func remove() -> Result<SkillReport, Refusal> {
+        guard FileManager.default.fileExists(atPath: file.path) else {
+            return .failure(Refusal("nothing to remove — \(file.path) is not there"))
+        }
+        do {
+            try FileManager.default.removeItem(at: file)
+            // Only when it is empty, and only ours: `~/.claude/skills/toe` is toe's folder, but
+            // somebody may have put something in it, and a removal that took their file with it
+            // would be a surprise nobody could have anticipated from a menu row called Remove.
+            if let left = try? FileManager.default.contentsOfDirectory(atPath: directory.path),
+               left.isEmpty {
+                try? FileManager.default.removeItem(at: directory)
+            }
+            Log.info("skill: removed \(file.path)")
+            return .success(state())
+        } catch {
+            let message = "could not remove \(file.path): \(error.localizedDescription)"
+            Log.error("skill: \(message)")
+            return .failure(Refusal(message))
+        }
+    }
+}

--- a/Sources/toe/Control/StateReporter.swift
+++ b/Sources/toe/Control/StateReporter.swift
@@ -1,0 +1,89 @@
+import AppKit
+import ToeCore
+
+/// Turns what toe knows into what `toe query` answers with.
+///
+/// A free function over the pieces rather than a method on `Coordinator`, so that the assembly
+/// — which is nearly all of it — is separable from the hub that owns the state. It reads and
+/// writes nothing: `render()` is asked for the frames, exactly as `apply` asks for them, and
+/// every other field is already in memory.
+///
+/// **No Accessibility calls, on purpose.** The obvious way to report where a window is would be
+/// to ask the system, and that is a synchronous round trip per window on the main thread —
+/// twenty windows is twenty chances to block the compositor for the messaging timeout, in answer
+/// to a question nobody urgent asked. It would also be wrong: a window on a hidden workspace is
+/// parked in the stash corner, and the stash corner is where toe put it rather than where it
+/// belongs. The frame the layout intends is the true answer to "where is this window", and it is
+/// free.
+enum StateReporter {
+
+    static func report(_ workspaces: WorkspaceManager,
+                       tracked: [WindowID: ManagedWindow],
+                       monitorKey: (UInt32) -> String?,
+                       version: String?) -> StateReport {
+        let plan = workspaces.render()
+        let focused = workspaces.focusedWindow
+
+        var windows: [WindowReport] = []
+        for id in tracked.keys.sorted() {
+            guard let window = tracked[id] else { continue }
+            let index = workspaces.workspaceIndex(of: id)
+            windows.append(WindowReport(
+                id: id,
+                app: name(of: window),
+                bundle: window.bundleID,
+                title: window.title,
+                workspace: index,
+                monitor: index.flatMap { workspaces.workspaces[$0]?.monitorID },
+                frame: plan.frames[id] ?? plan.floating[id],
+                floating: workspaces.isFloating(id),
+                focused: id == focused,
+                hidden: plan.stashed.contains(id)))
+        }
+
+        let visible = workspaces.visibleWorkspaceIndices
+        var rows: [WorkspaceReport] = []
+        for index in workspaces.workspaces.keys.sorted() {
+            guard let ws = workspaces.workspaces[index] else { continue }
+            rows.append(WorkspaceReport(
+                index: index,
+                monitor: ws.monitorID,
+                visible: visible.contains(index),
+                focused: index == workspaces.focusedWorkspaceIndex,
+                // Tiles in tree order, then the detached windows. This is the order a layout
+                // profile replays, and replaying it is what reproduces the shape — so it is the
+                // order reported, rather than anything sorted for tidiness.
+                windows: ws.layout.windowIDs + ws.floating.sorted()))
+        }
+
+        let screens = Dictionary(NSScreen.screens.map { ($0.displayID, $0.localizedName) },
+                                 uniquingKeysWith: { first, _ in first })
+        let monitors = workspaces.monitors.map { monitor in
+            MonitorReport(id: monitor.id,
+                          key: monitorKey(monitor.id),
+                          name: screens[monitor.id],
+                          frame: monitor.frame,
+                          usable: monitor.usable,
+                          workspace: workspaces.activeWorkspace[monitor.id],
+                          focused: monitor.id == workspaces.focusedMonitorID)
+        }
+
+        return StateReport(version: version,
+                           focusedWindow: focused,
+                           focusedWorkspace: workspaces.focusedWorkspaceIndex,
+                           focusedMonitor: workspaces.focusedMonitorID,
+                           monitors: monitors,
+                           workspaces: rows,
+                           windows: windows)
+    }
+
+    /// What a person calls the application. The bundle identifier is reported beside it and is
+    /// the stabler name, but nobody asks for "the com.mitchellh.ghostty window".
+    private static func name(of window: ManagedWindow) -> String {
+        if let running = NSRunningApplication(processIdentifier: window.pid),
+           let name = running.localizedName, !name.isEmpty {
+            return name
+        }
+        return window.bundleID ?? "pid \(window.pid)"
+    }
+}

--- a/Sources/toe/Coordinator.swift
+++ b/Sources/toe/Coordinator.swift
@@ -19,6 +19,10 @@ final class Coordinator: WindowTrackerDelegate {
     private let hideBlocker = HideBlocker()
     private let status = StatusItem()
     private let quickMenu = QuickMenu()
+    /// The `toe` you type, on the other end of a socket. See `ControlSocket` — it is
+    /// opened by `applyCLISetting` rather than here, so that `[cli] enabled = false` is a
+    /// socket that is never created and a reload can open or close it.
+    private let control = ControlSocket()
     private var watcher: ConfigWatcher?
     /// Watches `~/.config/toe/themes`, so a theme folder appearing or going away is noticed
     /// without waiting for anything else to happen. Optional and re-checked on every reload,
@@ -88,6 +92,19 @@ final class Coordinator: WindowTrackerDelegate {
     /// than fought with forever.
     private var corrections: [WindowID: Int] = [:]
     private var focusApplied: WindowID?
+    /// How deep inside a batch we are. While this is above zero every `apply` is recorded rather
+    /// than carried out, and the whole batch is drawn once when it unwinds.
+    ///
+    /// This exists for the command line and for nothing else. Every arm of `dispatch` ends in its
+    /// own `apply`, which is right for a keypress — one press, one change, drawn immediately —
+    /// and wrong for the ten commands that put a saved layout back: ten renders means every
+    /// window written up to ten times, and an arrangement that assembles itself on screen instead
+    /// of arriving. Only synchronous runs of commands are ever wrapped, so nothing arriving from
+    /// a callback can find itself inside somebody else's batch.
+    private var batchDepth = 0
+    /// Whether anything in the batch asked for the focus to be re-applied. Sticky, because one
+    /// command in ten wanting it is the batch wanting it.
+    private var batchRefocus = false
     /// Windows toe raised itself, and when — see `isEchoOfOwnRaise`.
     private var selfRaised: [WindowID: TimeInterval] = [:]
     /// How long a focus notification can still be the echo of one of those raises.
@@ -348,6 +365,7 @@ final class Coordinator: WindowTrackerDelegate {
         applyAnimationSetting()
         applyMiscSettings()
         applySessionSetting()
+        applyCLISetting()
         refreshStatus()
         apply(refocus: false)
         Log.info("managing \(tracker.windows.count) window(s) across \(workspaces.monitors.count) monitor(s)")
@@ -478,6 +496,7 @@ final class Coordinator: WindowTrackerDelegate {
         applyAnimationSetting()
         applyMiscSettings()
         applySessionSetting()
+        applyCLISetting()
 
         refreshStatus()
         // The theme may have changed under an open menu — most often because a download just
@@ -661,7 +680,12 @@ final class Coordinator: WindowTrackerDelegate {
                          fetching: available.isFetching,
                          current: current,
                          backgrounds: backgrounds, currentBackground: currentBackground,
-                         downloading: downloading)
+                         downloading: downloading,
+                         // Read every time rather than remembered, and on the redraw as well as
+                         // on the open: it is one small file, the row it draws is the whole of
+                         // what toe says about installing it, and a file somebody deleted by
+                         // hand should stop being ticked without a reload.
+                         skill: SkillStore.state())
     }
 
     /// Takes a theme off the disk, and off your border if you were wearing it.
@@ -1570,6 +1594,14 @@ final class Coordinator: WindowTrackerDelegate {
     // MARK: - Applying the layout
 
     private func apply(refocus: Bool) {
+        // Held, not dropped: see `batchDepth`. Before the slide check below because a batch has
+        // not happened yet — cancelling a slide on behalf of a render that is still to come would
+        // be acting on a decision nobody has made.
+        guard batchDepth == 0 else {
+            batchRefocus = batchRefocus || refocus
+            return
+        }
+
         // A slide waiting for its picture has switched the model and not yet the screen. A render
         // arriving now from anywhere else — a window appearing, a config reload — puts the new
         // layout on screen before the picture of the old one is taken, and the picture would then
@@ -1827,6 +1859,11 @@ final class Coordinator: WindowTrackerDelegate {
         // WindowServer, so it is taken down deliberately rather than left to process death.
         dockSwipes.stop()
         hideBlocker.stop()
+        // Before the four journals below, and for the same family of reason: the socket file is
+        // state that outlives the process. A copy that is killed rather than quit leaves one
+        // behind, which the next `start` unlinks — but a copy that goes away properly should not
+        // leave a door that opens onto nothing.
+        control.stop()
         // The four that would otherwise outlive toe: the window server keeps a symbolic hotkey
         // switched off until something switches it back on, and the reveal-desktop, edge-tiling
         // and Dock auto-hide preferences are written to the user's settings.
@@ -1918,6 +1955,40 @@ final class Coordinator: WindowTrackerDelegate {
         sessionSave?.cancel()
         sessionSave = nil
         SessionStore.clear()
+    }
+
+    // MARK: - The control socket
+
+    /// Opens or closes the socket `toe query` and `toe dispatch` talk to.
+    ///
+    /// Called from the same fan-out as the other `apply*` settings, and unlike them *not* gated
+    /// on `isManaging`: the socket needs no Accessibility grant, and a machine sitting at the
+    /// permission prompt is exactly where somebody wants to ask toe what it thinks is going on.
+    /// The commands that arrive before the grant do nothing, which is what those commands do on
+    /// a key as well.
+    private func applyCLISetting() {
+        guard config.cli.enabled else {
+            if control.isRunning { Log.info("cli: [cli] enabled = false — closing the socket") }
+            control.stop()
+            runtimeWarnings.removeValue(forKey: "cli")
+            return
+        }
+        guard !control.isRunning else { return }
+        control.onRequest = { [weak self] request in
+            guard let self else {
+                return ControlCoding.line(ControlFailure("toe is going away"))
+            }
+            return self.handle(request)
+        }
+        if let problem = control.start() {
+            // Keyed under `cli` rather than appended to `setupWarnings`, so that a reload
+            // replaces this message instead of stacking another copy of it — and so that the
+            // dock-swipe check, which starts that list afresh, cannot take it away.
+            runtimeWarnings["cli"] = "the toe command line is unavailable: \(problem)"
+            Log.error("cli: \(problem)")
+        } else {
+            runtimeWarnings.removeValue(forKey: "cli")
+        }
     }
 
     /// A durable name for each live display, asked again every time rather than cached:
@@ -2075,6 +2146,296 @@ final class Coordinator: WindowTrackerDelegate {
                 return
             }
             setBackground(next)
+
+        case .installSkill:
+            writeSkill(SkillStore.install())
+
+        case .removeSkill:
+            writeSkill(SkillStore.remove())
         }
     }
+
+    /// Both skill rows, which differ only in which way they went.
+    ///
+    /// A failure is a `runtimeWarnings` entry rather than a thrown anything: this is reached from
+    /// a menu row and from a keybinding, and neither has a way of showing an error except the one
+    /// toe already has. Keyed, so a later success takes the message down — the same contract
+    /// `download` has with a failed fetch.
+    private func writeSkill(_ outcome: Result<SkillReport, Refusal>) {
+        switch outcome {
+        case .success:
+            runtimeWarnings.removeValue(forKey: "skill")
+        case .failure(let refusal):
+            runtimeWarnings["skill"] = refusal.description
+        }
+        refreshStatus()
+        // The Install and Remove levels are built from whether the file is there, so the row the
+        // user just pressed becomes a ticked, dimmed one under their cursor. That change *is* the
+        // confirmation — see `Command.keepsMenuOpen`.
+        refreshMenu()
+    }
+}
+
+// MARK: - Answering the command line
+
+/// The socket's side of `Coordinator`.
+///
+/// In this file rather than beside `ControlSocket`, because everything here reaches into state
+/// the coordinator keeps to itself — the tracker, the layout, the config — and Swift's `private`
+/// is file-scoped. Splitting it out would mean opening those up to the whole module in order to
+/// tidy a file, which is the wrong trade in a type whose invariants are the reason it is one type.
+///
+/// Every path is main-thread, synchronous, and answers something. A request that cannot be
+/// carried out comes back as a sentence rather than as silence: the caller is a script or a
+/// language model, and "nothing happened" is the one reply neither can do anything with.
+extension Coordinator {
+
+    func handle(_ request: ControlRequest) -> Data {
+        switch request.op {
+        case .query:        return query(request.what)
+        case .dispatch:     return runBatch(request)
+        case .focus:        return focus(selector: request.window)
+        case .layoutSave:   return saveLayout(request.what)
+        case .layoutApply:  return applyLayout(request.what)
+        case .layoutList:   return ok(layoutsReport())
+        case .layoutShow:   return showLayout(request.what)
+        case .layoutDelete: return deleteLayout(request.what)
+        }
+    }
+
+    // MARK: Reading
+
+    private func query(_ what: String?) -> Data {
+        guard let what, let kind = ControlQuery(rawValue: what) else {
+            return no("query needs one of: "
+                      + ControlQuery.allCases.map(\.rawValue).joined(separator: ", "))
+        }
+        switch kind {
+        case .state:      return ok(state())
+        case .windows:    return ok(state().windows)
+        case .workspaces: return ok(state().workspaces)
+        case .monitors:   return ok(state().monitors)
+        case .binds:
+            return ok(config.bindings.map {
+                BindReport(keys: ShortcutFormatter.describe($0, superKey: config.superKey),
+                           does: CommandLabel.describe($0.command))
+            })
+        case .commands:   return ok(CommandCatalogue.entries.map(\.report))
+        case .layouts:    return ok(layoutsReport())
+        case .skill:      return ok(SkillStore.state())
+        }
+    }
+
+    private func state() -> StateReport {
+        let keys = monitorKeys()
+        return StateReporter.report(workspaces,
+                                    tracked: tracker.windows,
+                                    monitorKey: { keys[$0] },
+                                    version: AppIdentity.version)
+    }
+
+    private func layoutsReport() -> LayoutsReport {
+        LayoutsReport(directory: LayoutStore.directory.path, layouts: LayoutStore.names())
+    }
+
+    // MARK: Acting
+
+    /// One or more command lines, parsed and checked before any of them runs.
+    ///
+    /// Everything that can be refused is refused up front — a verb that does not exist, a verb
+    /// the config has not allowed over the socket, a `--window` that names two windows or none, a
+    /// verb that cannot be pointed at a window at all. A batch that fails halfway leaves a layout
+    /// nobody asked for and no way to say which half happened, so the whole of it is checked
+    /// while nothing has moved.
+    private func runBatch(_ request: ControlRequest) -> Data {
+        let lines = (request.commands ?? []).filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+        guard !lines.isEmpty else {
+            return no("nothing to dispatch — `toe query commands` lists the verbs")
+        }
+
+        var commands: [Command] = []
+        for line in lines {
+            do {
+                let command = try CommandParser.parse(line)
+                if let refusal = config.cli.refusal(for: command) { return no(refusal) }
+                commands.append(command)
+            } catch {
+                return no("'\(line)': \(error) — `toe query commands` lists the verbs")
+            }
+        }
+
+        // Said rather than logged. On a key this is a press that does nothing and a line in the
+        // log; over the socket the caller cannot see the screen, and "the command was accepted
+        // and ignored" is indistinguishable from "toe is broken" unless somebody says which.
+        if commands.contains(where: \.suspendedByFullscreen), AX.frontmostFullscreenFrame != nil {
+            return no("a fullscreen window has the focus, so toe is refusing anything that would "
+                      + "move the focus, a window or a workspace behind it — leave fullscreen, or "
+                      + "act on another display")
+        }
+
+        var target: WindowID?
+        if let selector = request.window {
+            let resolution = WindowSelector.resolve(selector, in: state().windows)
+            guard case .one(let window) = resolution else {
+                return no(WindowSelector.explain(resolution, selector: selector) ?? "no such window")
+            }
+            if let refused = commands.first(where: { !$0.acceptsTarget }) {
+                return no("`\(CommandLabel.describe(refused))` cannot be pointed at another window "
+                          + "— it means \"from where the focus is\". Focus that window first, or "
+                          + "drop --window. `toe query commands` marks the verbs that take one")
+            }
+            target = window.id
+        }
+
+        batch {
+            for command in commands {
+                if let target { dispatch(command, on: target) } else { dispatch(command) }
+            }
+        }
+        return ok(DispatchReport(ran: lines, window: target))
+    }
+
+    /// Runs a run of commands as one change to the screen. See `batchDepth`.
+    private func batch(_ body: () -> Void) {
+        batchDepth += 1
+        body()
+        batchDepth -= 1
+        guard batchDepth == 0 else { return }
+        let refocus = batchRefocus
+        batchRefocus = false
+        apply(refocus: refocus)
+    }
+
+    /// A command aimed at a window that is not the focused one.
+    ///
+    /// Only the verbs `Command.acceptsTarget` admits reach this, and the caller has already been
+    /// told about the ones that do not. Each arm is its focused counterpart in `dispatch` with
+    /// the id handed in rather than looked up — deliberately duplicated rather than folded
+    /// together, because the two differ in the one place it matters and the difference is easier
+    /// to see written out than hidden behind an optional parameter.
+    private func dispatch(_ command: Command, on id: WindowID) {
+        switch command {
+        case .killActive:
+            guard let window = tracker.window(id) else { return }
+            WindowMover.close(window)
+
+        case .toggleFloating:
+            workspaces.toggleFloating(id)
+            desired.removeValue(forKey: id)
+            corrections.removeValue(forKey: id)
+            apply(refocus: false)
+            // Deliberately *not* raised, where the focused version raises. That raise is there
+            // because you have just floated the window you are looking at and a float belongs
+            // above the tiles; doing it to somebody else's window would take the focus off the
+            // one they are working in, which is a bigger surprise than a float sitting low.
+
+        case .moveToWorkspace(let index, let follow):
+            if workspaces.moveWindow(id, toWorkspace: index, follow: follow) {
+                apply(refocus: follow)
+            }
+
+        case .growActive(let dx, let dy):
+            if workspaces.growWindow(id, dx: dx, dy: dy) { apply(refocus: false) }
+
+        case .resizeActive(let dx, let dy):
+            if workspaces.resizeWindow(id, dx: dx, dy: dy) { apply(refocus: false) }
+
+        default:
+            break
+        }
+    }
+
+    private func focus(selector: String?) -> Data {
+        guard let selector, !selector.isEmpty else {
+            return no("focus needs a selector, such as app:Ghostty")
+        }
+        let resolution = WindowSelector.resolve(selector, in: state().windows)
+        guard case .one(let window) = resolution else {
+            return no(WindowSelector.explain(resolution, selector: selector) ?? "no such window")
+        }
+        // The window's workspace is brought to it rather than the window being dragged out of
+        // its workspace — `revealWindow`'s contract, and the same answer a click on a Dock icon
+        // gets. Which of the two happened decides how much work follows: a whole workspace
+        // arriving has to be written out, a window already on screen only needs the focus.
+        if workspaces.revealWindow(window.id) {
+            apply(refocus: true)
+        } else {
+            focus(window.id)
+        }
+        return ok(DispatchReport(ran: ["focus"], window: window.id))
+    }
+
+    // MARK: Layouts
+
+    private func saveLayout(_ name: String?) -> Data {
+        guard let name, !name.isEmpty else { return no("layout save needs a name") }
+        let profile = LayoutProfile.capture(name: name, from: state())
+        switch LayoutStore.save(profile) {
+        case .success:            return ok(profile)
+        case .failure(let why):   return no(why.description)
+        }
+    }
+
+    private func showLayout(_ name: String?) -> Data {
+        guard let name, !name.isEmpty else { return no("layout show needs a name") }
+        switch LayoutStore.load(name) {
+        case .success(let profile): return ok(profile)
+        case .failure(let why):     return no(why.description)
+        }
+    }
+
+    private func deleteLayout(_ name: String?) -> Data {
+        guard let name, !name.isEmpty else { return no("layout delete needs a name") }
+        switch LayoutStore.delete(name) {
+        // What is left rather than an acknowledgement of what went: the caller's next question
+        // after deleting one is which ones there still are.
+        case .success:          return ok(layoutsReport())
+        case .failure(let why): return no(why.description)
+        }
+    }
+
+    /// Puts a saved arrangement back, as one change to the screen.
+    ///
+    /// The plan is worked out against what is open before anything moves, so a profile naming
+    /// applications that are not running places the ones that are and reports the rest — rather
+    /// than half-applying and leaving the caller to work out where it stopped.
+    private func applyLayout(_ name: String?) -> Data {
+        guard let name, !name.isEmpty else { return no("layout apply needs a name") }
+        let profile: LayoutProfile
+        switch LayoutStore.load(name) {
+        case .success(let loaded): profile = loaded
+        case .failure(let why):    return no(why.description)
+        }
+
+        let plan = profile.plan(against: state().windows)
+        var moved: [WindowID] = []
+        batch {
+            for move in plan.moves {
+                // `follow: false` throughout: applying a layout is not a request to be taken to
+                // any particular workspace, and following each move in turn would walk the user
+                // through every workspace the profile mentions before landing on the last one.
+                var changed = workspaces.moveWindow(move.window, toWorkspace: move.workspace,
+                                                    follow: false)
+                // After the move, so the float is centred on the monitor it has arrived at
+                // rather than the one it left.
+                changed = workspaces.setFloating(move.window, move.floating) || changed
+                guard changed else { continue }
+                // A window that has changed tree or floating state has no valid remembered frame;
+                // clearing both is what makes `apply` write it afresh rather than deciding it is
+                // already where it belongs.
+                desired.removeValue(forKey: move.window)
+                corrections.removeValue(forKey: move.window)
+                moved.append(move.window)
+            }
+        }
+        Log.info("layout '\(name)': moved \(moved.count) window(s), "
+                 + "\(plan.missing.count) not open, \(plan.untouched.count) left alone")
+        return ok(LayoutApplyReport(profile: name, plan: plan, moved: moved))
+    }
+
+    // MARK: The envelope
+
+    private func ok<T: Encodable>(_ value: T) -> Data { ControlCoding.line(ControlSuccess(value)) }
+
+    private func no(_ message: String) -> Data { ControlCoding.line(ControlFailure(message)) }
 }

--- a/Sources/toe/UI/MenuFont.swift
+++ b/Sources/toe/UI/MenuFont.swift
@@ -110,6 +110,7 @@ enum MenuFont {
         case .trash:     return "\u{F014}"   // nf-fa-trash_o
         case .info:      return "\u{F05A}"   // nf-fa-info_circle
         case .globe:     return "\u{F0AC}"   // nf-fa-globe
+        case .terminal:  return "\u{F120}"   // nf-fa-terminal
         }
     }
 
@@ -131,6 +132,7 @@ enum MenuFont {
         case .trash:     return "trash"
         case .info:      return "info.circle"
         case .globe:     return "globe"
+        case .terminal:  return "terminal"
         }
     }
 }

--- a/Sources/toe/main.swift
+++ b/Sources/toe/main.swift
@@ -24,6 +24,30 @@ if CommandLine.arguments.contains("--version") {
     exit(0)
 }
 
+// The command line. `toe query state`, `toe dispatch "workspace 3"` and the rest talk to the copy
+// already running, over the socket in ~/.local/state/toe — see `ControlSocket` for why a socket
+// and not a Mach service.
+//
+// Before `NSApplication.shared`, deliberately and not merely for speed: touching it connects to
+// the window server and makes this process an application as far as macOS is concerned, which is
+// not what a shell command should be. A verb here is a few milliseconds, one file descriptor and
+// no Accessibility at all.
+//
+// Anything that is not one of these verbs falls through and starts the window manager, exactly as
+// it always has — including the flags above and the `-psn_…` argument some launches of
+// `open Toe.app` carry. A first word that is neither a flag nor a verb stops with a usage error
+// rather than starting a second window manager on top of the running one.
+//
+// `isInteractive` is what tells a bare `toe` typed at a prompt from the launchd and `open
+// Toe.app` invocations that carry no arguments either — see `ControlCLI.parse`. Either descriptor
+// being a terminal is enough, because a pipe or a redirect takes the other one away and the thing
+// being asked is who typed this, not where its output goes.
+let invocation = ControlCLI.parse(Array(CommandLine.arguments.dropFirst()),
+                                  isInteractive: isatty(STDIN_FILENO) == 1 || isatty(STDOUT_FILENO) == 1)
+if case .agent = invocation.kind {} else {
+    exit(ControlClient.run(invocation))
+}
+
 let app = NSApplication.shared
 app.setActivationPolicy(.accessory)
 // `toe --print-corner-radius` reports what macOS rounds windows to, so the border can be

--- a/toe.example.toml
+++ b/toe.example.toml
@@ -172,6 +172,40 @@ prevent_hiding = true
 # choice you made rather than a window arrangement toe worked out for you.
 restore_session = true
 
+[cli]
+# `toe` is a command line as well as a window manager. Run with a verb it talks to the copy already
+# running, over a socket at ~/.local/state/toe/toe.sock — 0600, in a 0700 directory, and refused to
+# any user but you:
+#
+#   toe query state                          what is open, where, and on which workspace
+#   toe query commands                       every verb dispatch accepts
+#   toe dispatch "workspace 3"               run one
+#   toe dispatch "movetoworkspace 2" "workspace 2"    run several, drawn once at the end
+#   toe dispatch --window app:Safari "movetoworkspace 3"
+#   toe layout save work / toe layout apply work      remember an arrangement, and put it back
+#   toe help                                 all of it
+#
+# The binary is inside the app bundle, so it is /Applications/Toe.app/Contents/MacOS/toe unless you
+# have put a symlink to it on your PATH.
+#
+# This exists so that something else can drive toe — a script, or a language model with a terminal.
+# `toe skill install` writes a page for Claude Code into ~/.claude/skills/toe describing all of the
+# above, generated from toe's own verb table so it cannot go stale; SUPER+SPACE > Install has the
+# same row, and Remove takes it away again.
+enabled = true
+
+# Two verbs are refused over that socket regardless, unless these say otherwise. They stay bound to
+# keys either way, where a person pressed them.
+#
+# `exec` runs a shell line, so a socket that carried it would hand a shell to every script and every
+# agent that learned to talk to toe — not by anyone's decision, but because window management
+# happens to have one verb that runs programs. Turn it on if you want that; know that it is what you
+# are turning on.
+allow_exec = false
+# `quit` stops toe, and a caller that stops toe cannot start it again — leaving a machine that has
+# stopped tiling for reasons nothing on screen explains.
+allow_quit = false
+
 [bar]
 # waybar's persistent-workspaces: the fewest slots the bar ever has, so a fresh session still
 # shows 1-5, the empty ones dimmed. It is a floor and not a claim on the first five: once five


### PR DESCRIPTION
toe has had one way in: a key. This adds a second — `toe <verb>`, the same binary told apart by argv, talking to the running copy over a Unix socket at `~/.local/state/toe/toe.sock`. Anything that is not a verb falls through and starts the window manager exactly as before.

`CommandParser` was already the whole vocabulary, so nothing new is invented: `toe dispatch "workspace 3"` is the key press spelled out loud.

## What is new

- **Reading.** `toe query state|windows|workspaces|monitors|binds|commands|layouts|skill`, assembled from the render plan rather than from Accessibility — a round trip per window on the main thread is a real cost for a question nobody urgent asked, and it would answer for a hidden window with the stash corner rather than its tile.
- **Naming a window that is not focused.** `--window app:Safari`, and only for the verbs whose meaning survives being aimed away from the focus (`Command.acceptsTarget`). The directional ones mean "from where the focus is" and are refused with that sentence.
- **Batching.** `Coordinator.batch` holds `apply` for a run of commands, because every arm of `dispatch` ends in its own and ten of those is an arrangement assembling itself on screen.
- **Layout profiles.** `toe layout save work` / `apply work`. The session snapshot's idea with the part that makes it exact taken out: named by application rather than `CGWindowID`, so a profile survives quitting and restarting the applications in it. Placement only — the tree is replayed by order.
- **The Claude Code skill.** Generated, not committed: its verb table is `CommandCatalogue`, which is also what `query commands` answers with and whose every sample the selftest parses. `Install › Claude Code skill` in the quick menu, ticked by Omarchy's `disabled` guard once it is there, mirrored under `Remove`; `toe skill install` does it with no agent running.
- **`toe` on the PATH.** The cask gains a `binary` stanza; `make install-cli` does the same from source.

## Two deliberate refusals

`exec` and `quit` do not travel over the socket unless `[cli] allow_exec` / `allow_quit` say so. `exec` runs a shell line, and a control socket that carried it would hand a shell to everything that learned to talk to toe — not by anyone's decision, but because window management happens to have one verb that runs programs. The socket is 0600 in your own home directory, so this is not a privilege boundary; it is a blast radius.

## The one behaviour change

A bare `toe` used to start the window manager. Once `toe` is on a PATH, that means a child of your shell: closing the tab signals it and it shuts down, after `takeOver` has already stopped the copy running properly. So with a terminal on standard input **or** standard output it now prints the usage, and `toe agent` is how you ask for the manager from a shell on purpose. Either descriptor alone leaves a hole that `toe | head` walks through, which is how this was found.

## Notes for review

- The socket runs on the main thread, because a request ends in Accessibility writes. Nothing in `ControlSocket` may block: non-blocking descriptors, a 64 KiB request cap, a two-second deadline, a write source for partial writes, `SO_NOSIGPIPE` on every accepted descriptor.
- `ToeCore/Control` is pure and in the selftest; `toe/Control` is the socket, the client and the live-state assembly.
- A new `Command` case now needs five edits rather than four — the fifth is `CommandCatalogue`, and the selftest catches it in the direction that matters.

## Tested

`make test` — 1529 assertions. Exercised live against a running agent: state query, targeted silent move, profile round trip, both gates, unknown verb, `--window` on a directional verb, ambiguous selector listing its candidates, the batch, the stdin form, `focus`, `layout delete`, and the usage path under a pty. Menu rows confirmed on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRHpsH8pnxUNYibc1m5TcJ